### PR TITLE
feat: add max beds and house client id

### DIFF
--- a/source/house.cpp
+++ b/source/house.cpp
@@ -84,6 +84,8 @@ House::House(Map& map) :
 	rent(0),
 	townid(0),
 	guildhall(false),
+	clientid(0),
+	beds(0),
 	map(&map),
 	exit(0,0,0)
 {

--- a/source/house.h
+++ b/source/house.h
@@ -39,6 +39,8 @@ public:
 
 	uint32_t id;
 	int rent;
+	int clientid;
+	int beds;
 	//HouseDoorList doorList;
 	std::string name;
 	uint32_t townid;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1181,7 +1181,7 @@ bool IOMapOTBM::loadHouses(Map& map, pugi::xml_document& doc)
 		}
 
 		if((attribute = houseNode.attribute("clientid"))) {
-			house->clientid = pugi::cast<int32_t>(attribute.value());
+			house->clientid = attribute.as_uint();
 		}
 
 		if((attribute = houseNode.attribute("beds"))) {

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1185,7 +1185,7 @@ bool IOMapOTBM::loadHouses(Map& map, pugi::xml_document& doc)
 		}
 
 		if((attribute = houseNode.attribute("beds"))) {
-			house->beds = pugi::cast<int32_t>(attribute.value());
+			house->beds = attribute.as_uint();
 		}
 	}
 	return true;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -224,7 +224,7 @@ void Item::serializeItemAttributes_OTBM(const IOMap& maphandle, NodeFileWriteHan
 
 void Item::serializeItemCompact_OTBM(const IOMap& maphandle, NodeFileWriteHandle& stream) const
 {
-	stream.addU16(id);
+	stream.addU16(g_items[id].clientID);
 
 	/* This is impossible
 	const ItemType& iType = g_items[id];
@@ -238,7 +238,7 @@ void Item::serializeItemCompact_OTBM(const IOMap& maphandle, NodeFileWriteHandle
 bool Item::serializeItemNode_OTBM(const IOMap& maphandle, NodeFileWriteHandle& file) const
 {
 	file.addNode(OTBM_ITEM);
-	file.addU16(id);
+	file.addU16(g_items[id].clientID);
 	if(maphandle.version.otbm == MAP_OTBM_1) {
 		const ItemType& iType = g_items[id];
 		if(iType.stackable || iType.isSplash() || iType.isFluidContainer()) {
@@ -370,7 +370,7 @@ bool Container::unserializeItemNode_OTBM(const IOMap& maphandle, BinaryNode* nod
 bool Container::serializeItemNode_OTBM(const IOMap& maphandle, NodeFileWriteHandle& file) const
 {
 	file.addNode(OTBM_ITEM);
-	file.addU16(id);
+	file.addU16(g_items[id].clientID);
 	if(maphandle.version.otbm == MAP_OTBM_1) {
 		// In the ludicrous event that an item is a container AND stackable, we have to do this. :p
 		const ItemType& iType = g_items[id];
@@ -1179,6 +1179,14 @@ bool IOMapOTBM::loadHouses(Map& map, pugi::xml_document& doc)
 			warning("House %d has no town! House was removed.", house->id);
 			map.houses.removeHouse(house);
 		}
+
+		if((attribute = houseNode.attribute("clientid"))) {
+			house->clientid = pugi::cast<int32_t>(attribute.value());
+		}
+
+		if((attribute = houseNode.attribute("beds"))) {
+			house->beds = pugi::cast<int32_t>(attribute.value());
+		}
 	}
 	return true;
 }
@@ -1761,6 +1769,8 @@ bool IOMapOTBM::saveHouses(Map& map, pugi::xml_document& doc)
 
 		houseNode.append_attribute("townid") = house->townid;
 		houseNode.append_attribute("size") = static_cast<int32_t>(house->size());
+		houseNode.append_attribute("clientid") = house->clientid;
+		houseNode.append_attribute("beds") = house->beds;
 	}
 	return true;
 }

--- a/source/palette_house.cpp
+++ b/source/palette_house.cpp
@@ -466,6 +466,8 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	house_name = wxstr(house->name);
 	house_id = i2ws(house->id);
 	house_rent = i2ws(house->rent);
+	house_clientid = i2ws(house->clientid);
+	house_beds = i2ws(house->beds);
 
 	// House options
 	tmpsizer = newd wxStaticBoxSizer(wxHORIZONTAL, this, "Name");
@@ -480,6 +482,16 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	id_field = newd wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(70,20), 0, wxTextValidator(wxFILTER_NUMERIC, &house_id));
 	id_field->Enable(false);
 	tmpsizer->Add(id_field);
+	sizer->Add(tmpsizer, wxSizerFlags().Border(wxALL, 20));
+
+	tmpsizer = newd wxStaticBoxSizer(wxHORIZONTAL, this, "Client ID");
+	clientid_field = newd wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(160,20), 0, wxTextValidator(wxFILTER_NUMERIC, &house_clientid));
+	tmpsizer->Add(clientid_field);
+	sizer->Add(tmpsizer, wxSizerFlags().Border(wxALL, 20));
+
+	tmpsizer = newd wxStaticBoxSizer(wxHORIZONTAL, this, "Max beds");
+	beds_field = newd wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(160,20), 0, wxTextValidator(wxFILTER_NUMERIC, &house_beds));
+	tmpsizer->Add(beds_field);
 	sizer->Add(tmpsizer, wxSizerFlags().Border(wxALL, 20));
 
 	// House options
@@ -509,6 +521,12 @@ void EditHouseDialog::OnClickOK(wxCommandEvent& WXUNUSED(event))
 		long new_house_rent;
 		house_rent.ToLong(&new_house_rent);
 
+		long new_house_clientid;
+		house_clientid.ToLong(&new_house_clientid);
+
+		long new_house_beds;
+		house_beds.ToLong(&new_house_beds);
+
 		if(new_house_rent < 0) {
 			g_gui.PopupDialog(this, "Error", "House rent cannot be less than 0.", wxOK);
 			return;
@@ -536,6 +554,8 @@ void EditHouseDialog::OnClickOK(wxCommandEvent& WXUNUSED(event))
 		// Transfer to house
 		what_house->name = nstr(house_name);
 		what_house->rent = new_house_rent;
+		what_house->clientid = new_house_clientid;
+		what_house->beds = new_house_beds;
 		what_house->guildhall = guildhall_field->GetValue();
 
 		EndModal(1);

--- a/source/palette_house.h
+++ b/source/palette_house.h
@@ -101,11 +101,13 @@ protected:
 	Map* map;
 	House* what_house;
 
-	wxString house_name, house_id, house_rent;
+	wxString house_name, house_id, house_rent, house_clientid, house_beds;
 
 	wxTextCtrl* name_field;
 	wxTextCtrl* id_field;
 	wxTextCtrl* rent_field;
+	wxTextCtrl* clientid_field;
+	wxTextCtrl* beds_field;
 	wxCheckBox* guildhall_field;
 
 	DECLARE_EVENT_TABLE();


### PR DESCRIPTION
# What's added:
- [x] Convert `server_id` to `client_id` (supported canary map)

**New options in house's window :**
- [x] `Client ID`
- [x] `Max beds`

![image](https://user-images.githubusercontent.com/67392692/133334920-accdfb6d-e877-45e4-a1f6-caa44528b0c5.png)
