### PR TITLE
fix: exception handling for reading and creating JSON objects

### DIFF
--- a/source/client_version.cpp
+++ b/source/client_version.cpp
@@ -133,10 +133,9 @@ void ClientVersion::loadVersions()
 			version->setClientPath(wxstr(ver_obj.at("path").get<std::string>()));
 		}
 	}
-	catch (std::runtime_error&)
+	catch ([[maybe_unused]]const json::exception& e)
 	{
 		// pass
-		;
 	}
 }
 
@@ -329,18 +328,23 @@ void ClientVersion::loadVersionExtensions(pugi::xml_node versionNode)
 
 void ClientVersion::saveVersions()
 {
-	json vers_obj;
+	try {
+		json vers_obj;
 
-	for(auto& [id, version] : client_versions) {
-		json ver_obj;
-		ver_obj["id"] = version->getName();
-		ver_obj["path"] = version->getClientPath().GetFullPath().ToStdString();
-		vers_obj.push_back(ver_obj);
+		for(auto& [id, version] : client_versions) {
+			json ver_obj;
+			ver_obj["id"] = version->getName();
+			ver_obj["path"] = version->getClientPath().GetFullPath().ToStdString();
+			vers_obj.push_back(ver_obj);
+		}
+
+		std::ostringstream out;
+		out << vers_obj;
+		g_settings.setString(Config::ASSETS_DATA_DIRS, out.str());
 	}
-
-	std::ostringstream out;
-	out << vers_obj;
-	g_settings.setString(Config::ASSETS_DATA_DIRS, out.str());
+	catch ([[maybe_unused]]const json::exception& e) {
+		// pass
+	}
 }
 
 // Client version class

--- a/vcproj/Project/RME.vcxproj
+++ b/vcproj/Project/RME.vcxproj
@@ -109,6 +109,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Rpcrt4.lib;WS2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -119,7 +120,7 @@
       <MapExports>true</MapExports>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
-      <IgnoreSpecificDefaultLibraries>wxscintillad.lib</IgnoreSpecificDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>wxscintillad.lib;freeglutd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -135,6 +136,7 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <PrecompiledHeaderFile>main.h</PrecompiledHeaderFile>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>comctl32.lib;Rpcrt4.lib;WS2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -144,7 +146,7 @@
       <MapFileName>$(TargetName).map</MapFileName>
       <MapExports>true</MapExports>
       <SubSystem>Windows</SubSystem>
-      <IgnoreSpecificDefaultLibraries>wxscintillad.lib</IgnoreSpecificDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>wxscintillad.lib;freeglutd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
This adds exception handling to the code that reads and creates JSON objects in the program. The code now uses try-catch blocks to catch exceptions that may be thrown during the process of reading and writing JSON objects, to avoid unhandled failures that may interrupt the program's execution. With these changes, the program can now handle errors in a more robust way and offer a better user experience.