### PR TITLE
build: update vcpkg commit id, enable vcpkg manifest and fix sonarcloud gha

### DIFF
--- a/.github/workflows/analysis-sonarcloud.yml
+++ b/.github/workflows/analysis-sonarcloud.yml
@@ -9,10 +9,10 @@ on:
       - main
 
 env:
-  VCPKG_BUILD_TYPE: release
+  VCPKG_BUILD_TYPE: debug
   CMAKE_BUILD_PARALLEL_LEVEL: 2
   MAKEFLAGS: '-j 2'
-  NUMBER_OF_PROCESSORS: 2
+  VCPKG_BINARY_SOURCES: clear;default,readwrite
 
 jobs:
   sonarcloud:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can find the project for hosting your own server at [Canary](https://github.
 
 Getting Started
 =========
-* [Gitbook](https://majestyotbr.gitbook.io/opentibiabr/projects/remeres-map-editor).
+* [Gitbook](https://docs.opentibiabr.com/projects/remeres-map-editor).
 * [Wiki](https://github.com/opentibiabr/remeres-map-editor/wiki).
 
 I want to contribute

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,5 +9,5 @@
     "wxwidgets",
     "opengl"
   ],
-  "builtin-baseline":"0e67f312e831b4b897c7f492cf1e2858522c6e18"
+  "builtin-baseline":"69efe9cc2df0015f0bb2d37d55acde4a75c9a25b"
 }

--- a/vcproj/Project/RME.vcxproj
+++ b/vcproj/Project/RME.vcxproj
@@ -96,6 +96,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>$(ProjectName)_x64</TargetName>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>


### PR DESCRIPTION
Update vcpkg commit id to fix github actions builds.
Enable vcpkg manifest to install the libs automatically.
Fix sonarcloud github actions analysis.