### PR TITLE
feat: search option for items under walls/windows/doors

### DIFF
--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -39,6 +39,7 @@
             <item name="Find $Container" action="SEARCH_ON_MAP_CONTAINER" help="Find all containers on map."/>
             <item name="Find $Writeable" action="SEARCH_ON_MAP_WRITEABLE" help="Find all writeable items on map."/>
             <item name="Find $Duplicate Items" action="SEARCH_ON_MAP_DUPLICATE" help="Find all positions where there are duplicate items on the map."/>
+            <item name="Find Walls $Upon Walls" action="SEARCH_ON_MAP_WALLS_UPON_WALLS" help="Find all positions where there are walls/windows/doors on walls/windows/doors on the map."/>
         </menu>
         <separator/>
         <menu name="$Border Options">
@@ -93,6 +94,7 @@
             <item name="Find $Container" action="SEARCH_ON_SELECTION_CONTAINER" help="Find all containers on selected area."/>
             <item name="Find $Writeable" action="SEARCH_ON_SELECTION_WRITEABLE" help="Find all writeable items on selected area."/>
             <item name="Find $Duplicate Items" action="SEARCH_ON_SELECTION_DUPLICATE" help="Find all positions where there are duplicate items on selected area."/>
+            <item name="Find Walls $Upon Walls" action="SEARCH_ON_SELECTION_WALLS_UPON_WALLS" help="Find all positions where there are walls/windows/doors on walls/windows/doors on selected area."/>
         </menu>
         <separator/>
         <menu name="$Selection Mode">

--- a/source/item.h
+++ b/source/item.h
@@ -306,6 +306,9 @@ public:
 	bool hasElevation() const {
 		return getItemType().hasElevation;
 	}
+	bool isBlockMissiles() const {
+		return getItemType().blockMissiles;
+	}
 
 	// Wall alignment (vertical, horizontal, pole, corner)
 	BorderType getWallAlignment() const;

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2312,7 +2312,7 @@ namespace SearchDuplicatedItems {
 	struct condition {
 		std::unordered_set<Tile*> foundTiles;
 
-		void operator()(Map& map, Tile* tile, Item* item, long long done) {
+		void operator()(Map &map, Tile* tile, Item* item, long long done) {
 			if (done % 0x8000 == 0) {
 				g_gui.SetLoadDone((unsigned int)(100 * done / map.getTileCount()));
 			}
@@ -2343,7 +2343,7 @@ namespace SearchDuplicatedItems {
 	};
 }
 
-void MainMenuBar::SearchDuplicatedItems(bool onSelection/* = false*/) {
+void MainMenuBar::SearchDuplicatedItems(bool onSelection /* = false*/) {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}
@@ -2357,7 +2357,7 @@ void MainMenuBar::SearchDuplicatedItems(bool onSelection/* = false*/) {
 	SearchDuplicatedItems::condition finder;
 
 	foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, onSelection);
-	std::unordered_set<Tile*>& foundTiles = finder.foundTiles;
+	std::unordered_set<Tile*> &foundTiles = finder.foundTiles;
 
 	g_gui.DestroyLoadBar();
 
@@ -2377,7 +2377,7 @@ void MainMenuBar::SearchDuplicatedItems(bool onSelection/* = false*/) {
 
 namespace RemoveDuplicatesItems {
 	struct condition {
-		bool operator()(Map& map, Tile* tile, Item* item, long long removed, long long done) {
+		bool operator()(Map &map, Tile* tile, Item* item, long long removed, long long done) {
 			if (done % 0x8000 == 0) {
 				g_gui.SetLoadDone((unsigned int)(100 * done / map.getTileCount()));
 			}
@@ -2415,14 +2415,14 @@ namespace RemoveDuplicatesItems {
 	};
 }
 
-void MainMenuBar::RemoveDuplicatesItems(bool onSelection/* = false*/) {
+void MainMenuBar::RemoveDuplicatesItems(bool onSelection /* = false*/) {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}
 
 	int ok = g_gui.PopupDialog("Remove Duplicate Items", "Do you want to remove all duplicates items from the map?", wxYES | wxNO);
 
-	if(ok == wxID_YES) {
+	if (ok == wxID_YES) {
 		g_gui.GetCurrentEditor()->getSelection().clear();
 		g_gui.GetCurrentEditor()->clearActions();
 
@@ -2451,7 +2451,7 @@ namespace SearchWallsUponWalls {
 	struct condition {
 		std::unordered_set<Tile*> foundTiles;
 
-		void operator()(Map& map, Tile* tile, Item* item, long long done) {
+		void operator()(Map &map, Tile* tile, Item* item, long long done) {
 			if (done % 0x8000 == 0) {
 				g_gui.SetLoadDone(static_cast<unsigned int>(100 * done / map.getTileCount()));
 			}
@@ -2468,7 +2468,6 @@ namespace SearchWallsUponWalls {
 				return;
 			}
 
-			
 			if (item->isWall() || item->isDoor()) {
 				std::unordered_set<int> itemIDs;
 				for (Item* itemInTile : tile->items) {
@@ -2492,7 +2491,7 @@ namespace SearchWallsUponWalls {
 	};
 }
 
-void MainMenuBar::SearchWallsUponWalls(bool onSelection/* = false*/) {
+void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}
@@ -2507,7 +2506,7 @@ void MainMenuBar::SearchWallsUponWalls(bool onSelection/* = false*/) {
 
 	foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, onSelection);
 
-	std::unordered_set<Tile*>& foundTiles = finder.foundTiles;
+	std::unordered_set<Tile*> &foundTiles = finder.foundTiles;
 
 	g_gui.DestroyLoadBar();
 

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2285,27 +2285,27 @@ void MainMenuBar::SearchItems(bool unique, bool action, bool container, bool wri
 	}
 }
 
-void MainMenuBar::OnSearchForDuplicateItemsOnMap(wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForDuplicateItemsOnMap(const wxCommandEvent &WXUNUSED(event)) {
 	SearchDuplicatedItems(false);
 }
 
-void MainMenuBar::OnSearchForDuplicateItemsOnSelection(wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForDuplicateItemsOnSelection(const wxCommandEvent &WXUNUSED(event)) {
 	SearchDuplicatedItems(true);
 }
 
-void MainMenuBar::OnRemoveForDuplicateItemsOnMap(wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnRemoveForDuplicateItemsOnMap(const wxCommandEvent &WXUNUSED(event)) {
 	RemoveDuplicatesItems(false);
 }
 
-void MainMenuBar::OnRemoveForDuplicateItemsOnSelection(wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnRemoveForDuplicateItemsOnSelection(const wxCommandEvent &WXUNUSED(event)) {
 	RemoveDuplicatesItems(true);
 }
 
-void MainMenuBar::OnSearchForWallsUponWallsOnMap(wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForWallsUponWallsOnMap(const wxCommandEvent &WXUNUSED(event)) {
 	SearchWallsUponWalls(false);
 }
 
-void MainMenuBar::OnSearchForWallsUponWallsOnSelection(wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForWallsUponWallsOnSelection(const wxCommandEvent &WXUNUSED(event)) {
 	SearchWallsUponWalls(true);
 }
 

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2285,27 +2285,27 @@ void MainMenuBar::SearchItems(bool unique, bool action, bool container, bool wri
 	}
 }
 
-void MainMenuBar::OnSearchForDuplicateItemsOnMap(const wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForDuplicateItemsOnMap(wxCommandEvent &WXUNUSED(event)) {
 	SearchDuplicatedItems(false);
 }
 
-void MainMenuBar::OnSearchForDuplicateItemsOnSelection(const wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForDuplicateItemsOnSelection(wxCommandEvent &WXUNUSED(event)) {
 	SearchDuplicatedItems(true);
 }
 
-void MainMenuBar::OnRemoveForDuplicateItemsOnMap(const wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnRemoveForDuplicateItemsOnMap(wxCommandEvent &WXUNUSED(event)) {
 	RemoveDuplicatesItems(false);
 }
 
-void MainMenuBar::OnRemoveForDuplicateItemsOnSelection(const wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnRemoveForDuplicateItemsOnSelection(wxCommandEvent &WXUNUSED(event)) {
 	RemoveDuplicatesItems(true);
 }
 
-void MainMenuBar::OnSearchForWallsUponWallsOnMap(const wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForWallsUponWallsOnMap(wxCommandEvent &WXUNUSED(event)) {
 	SearchWallsUponWalls(false);
 }
 
-void MainMenuBar::OnSearchForWallsUponWallsOnSelection(const wxCommandEvent &WXUNUSED(event)) {
+void MainMenuBar::OnSearchForWallsUponWallsOnSelection(wxCommandEvent &WXUNUSED(event)) {
 	SearchWallsUponWalls(true);
 }
 
@@ -2493,7 +2493,7 @@ namespace SearchWallsUponWalls {
 	};
 }
 
-void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) const {
+void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2468,6 +2468,7 @@ namespace SearchWallsUponWalls {
 				return;
 			}
 
+			
 			if (item->isWall() || item->isDoor()) {
 				std::unordered_set<int> itemIDs;
 				for (Item* itemInTile : tile->items) {

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2452,7 +2452,7 @@ namespace SearchWallsUponWalls {
 	struct condition {
 		std::unordered_set<Tile*> foundTiles;
 
-		void operator()(Map &map, Tile* tile, Item* item, long long done) {
+		void operator()(const Map &map, Tile* tile, const Item* item, long long done) {
 			if (done % 0x8000 == 0) {
 				g_gui.SetLoadDone(static_cast<unsigned int>(100 * done / map.getTileCount()));
 			}
@@ -2469,25 +2469,26 @@ namespace SearchWallsUponWalls {
 				return;
 			}
 
-			if (item->isWall() || item->isDoor()) {
-				std::unordered_set<int> itemIDs;
-				for (Item* itemInTile : tile->items) {
-					if (itemInTile) {
-						if (itemInTile->isWall() || itemInTile->isDoor()) {
-							if (item->getID() != itemInTile->getID()) {
-								itemIDs.insert(itemInTile->getID());
-							}
-						}
-					}
-				}
-
-				size_t itemIDsSize = itemIDs.size();
-				if (itemIDsSize > 0) {
-					foundTiles.insert(tile);
-				}
-
-				itemIDs.clear();
+			if (!item->isWall() && !item->isDoor()) {
+				return;
 			}
+
+			std::unordered_set<int> itemIDs;
+			for (Item* const itemInTile : tile->items) {
+				if (!itemInTile || (!itemInTile->isWall() && !itemInTile->isDoor())) {
+					continue;
+				}
+
+				if (item->getID() != itemInTile->getID()) {
+					itemIDs.insert(itemInTile->getID());
+				}
+			}
+
+			if (itemIDs.size() > 0) {
+				foundTiles.insert(tile);
+			}
+
+			itemIDs.clear();
 		}
 	};
 }
@@ -2507,7 +2508,7 @@ void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) {
 
 	foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, onSelection);
 
-	std::unordered_set<Tile*> &foundTiles = finder.foundTiles;
+	std::unordered_set<Tile*> const &foundTiles = finder.foundTiles;
 
 	g_gui.DestroyLoadBar();
 

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2508,7 +2508,7 @@ void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) {
 
 	foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, onSelection);
 
-	std::unordered_set<Tile*> const &foundTiles = finder.foundTiles;
+	const std::unordered_set<Tile*> &foundTiles = finder.foundTiles;
 
 	g_gui.DestroyLoadBar();
 

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -1328,7 +1328,7 @@ namespace OnMapRemoveCorpses {
 				g_gui.SetLoadDone((unsigned int)(100 * done / map.getTileCount()));
 			}
 
-			return g_materials.isInTileset(item, "Corpses") & !item->isComplex();
+			return g_materials.isInTileset(item, "Corpses") && !item->isComplex();
 		}
 	};
 }
@@ -2474,7 +2474,7 @@ namespace SearchWallsUponWalls {
 			}
 
 			std::unordered_set<int> itemIDs;
-			for (Item* const itemInTile : tile->items) {
+			for (const Item* itemInTile : tile->items) {
 				if (!itemInTile || (!itemInTile->isWall() && !itemInTile->isDoor())) {
 					continue;
 				}
@@ -2484,7 +2484,7 @@ namespace SearchWallsUponWalls {
 				}
 			}
 
-			if (itemIDs.size() > 0) {
+			if (!itemIDs.empty()) {
 				foundTiles.insert(tile);
 			}
 
@@ -2493,7 +2493,7 @@ namespace SearchWallsUponWalls {
 	};
 }
 
-void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) {
+void MainMenuBar::SearchWallsUponWalls(bool onSelection /* = false*/) const {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2279,6 +2279,7 @@ void MainMenuBar::SearchItems(bool unique, bool action, bool container, bool wri
 
 	SearchResultWindow* result = g_gui.ShowSearchWindow();
 	result->Clear();
+
 	for (std::vector<std::pair<Tile*, Item*>>::iterator iter = found.begin(); iter != found.end(); ++iter) {
 		result->AddPosition(searcher.desc(iter->second), iter->first->getPosition());
 	}

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -161,6 +161,8 @@ namespace MenuBar {
 		SEARCH_ON_SELECTION_DUPLICATE,
 		REMOVE_ON_MAP_DUPLICATE_ITEMS,
 		REMOVE_ON_SELECTION_DUPLICATE_ITEMS,
+		SEARCH_ON_MAP_WALLS_UPON_WALLS,
+		SEARCH_ON_SELECTION_WALLS_UPON_WALLS,
 	};
 }
 
@@ -302,6 +304,8 @@ public:
 	void OnSearchForDuplicateItemsOnSelection(wxCommandEvent &event);
 	void OnRemoveForDuplicateItemsOnMap(wxCommandEvent &event);
 	void OnRemoveForDuplicateItemsOnSelection(wxCommandEvent &event);
+	void OnSearchForWallsUponWallsOnMap(wxCommandEvent &event);
+	void OnSearchForWallsUponWallsOnSelection(wxCommandEvent &event);
 
 protected:
 	// Load and returns a menu item, also sets accelerator
@@ -311,6 +315,7 @@ protected:
 	void SearchItems(bool unique, bool action, bool container, bool writable, bool onSelection = false);
 	void SearchDuplicatedItems(bool onSelection = false);
 	void RemoveDuplicatesItems(bool onSelection = false);
+	void SearchWallsUponWalls(bool onSelection = false);
 protected:
 	MainFrame* frame;
 	wxMenuBar* menubar;

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -316,6 +316,7 @@ protected:
 	void SearchDuplicatedItems(bool onSelection = false);
 	void RemoveDuplicatesItems(bool onSelection = false);
 	void SearchWallsUponWalls(bool onSelection = false);
+
 protected:
 	MainFrame* frame;
 	wxMenuBar* menubar;


### PR DESCRIPTION
- Adicionado opção de buscar todas as posições onde há paredes/janelas/portas sobre paredes/janelas/portas no mapa todo e por área selecionada.

(Testado no mapa otservbr 3.0.0)
![image](https://github.com/opentibiabr/remeres-map-editor/assets/6209529/a59e302b-e6a9-42d7-829a-f43d52274b2b)

![image](https://github.com/opentibiabr/remeres-map-editor/assets/6209529/f1730062-fd82-4ef5-878b-aa99252328a5)
