### PR TITLE
fix: warning ‘wxPATH_NORM_ALL’ is deprecated

### DIFF
--- a/source/iominimap.cpp
+++ b/source/iominimap.cpp
@@ -243,7 +243,7 @@ bool IOMinimap::exportMinimap(const std::string &directory) {
 					wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
 					wxString extension_wx = wxString::FromAscii(extension.mb_str());
 					wxFileName file = wxString::Format("%s-%s-%s.%s", std::to_string(h), std::to_string(w), std::to_string(z), extension_wx);
-					file.Normalize(wxPATH_NORM_ENV_VARS | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT, directory);
+					file.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE, directory);
 					image->SaveFile(file.GetFullPath(), type);
 				}
 			}
@@ -342,7 +342,7 @@ bool IOMinimap::exportSelection(const std::string &directory, const std::string 
 			wxString extension = m_format == MinimapExportFormat::Png ? "png" : "bmp";
 			wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
 			wxFileName file = wxString::Format("%s-%d.%s", name, z, extension);
-			file.Normalize(wxPATH_NORM_ENV_VARS | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT, directory);
+			file.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE, directory);
 			image->SaveFile(file.GetFullPath(), type);
 		}
 	}

--- a/source/iominimap.cpp
+++ b/source/iominimap.cpp
@@ -243,7 +243,7 @@ bool IOMinimap::exportMinimap(const std::string &directory) {
 					wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
 					wxString extension_wx = wxString::FromAscii(extension.mb_str());
 					wxFileName file = wxString::Format("%s-%s-%s.%s", std::to_string(h), std::to_string(w), std::to_string(z), extension_wx);
-					file.Normalize(wxPATH_NORM_ALL, directory);
+					file.Normalize(wxPATH_NORM_ENV_VARS | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT, directory);
 					image->SaveFile(file.GetFullPath(), type);
 				}
 			}
@@ -342,7 +342,7 @@ bool IOMinimap::exportSelection(const std::string &directory, const std::string 
 			wxString extension = m_format == MinimapExportFormat::Png ? "png" : "bmp";
 			wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
 			wxFileName file = wxString::Format("%s-%d.%s", name, z, extension);
-			file.Normalize(wxPATH_NORM_ALL, directory);
+			file.Normalize(wxPATH_NORM_ENV_VARS | wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT, directory);
 			image->SaveFile(file.GetFullPath(), type);
 		}
 	}

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -2298,7 +2298,7 @@ namespace SearchDuplicatedItems {
 	struct condition {
 		std::unordered_set<Tile*> foundTiles;
 
-		void operator()(Map& map, Tile* tile, Item* item, long long done) {
+		void operator()(Map &map, Tile* tile, Item* item, long long done) {
 			if (done % 0x8000 == 0) {
 				g_gui.SetLoadDone((unsigned int)(100 * done / map.getTileCount()));
 			}
@@ -2329,7 +2329,7 @@ namespace SearchDuplicatedItems {
 	};
 }
 
-void MainMenuBar::SearchDuplicatedItems(bool onSelection/* = false*/) {
+void MainMenuBar::SearchDuplicatedItems(bool onSelection /* = false*/) {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}
@@ -2343,7 +2343,7 @@ void MainMenuBar::SearchDuplicatedItems(bool onSelection/* = false*/) {
 	SearchDuplicatedItems::condition finder;
 
 	foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, onSelection);
-	std::unordered_set<Tile*>& foundTiles = finder.foundTiles;
+	std::unordered_set<Tile*> &foundTiles = finder.foundTiles;
 
 	g_gui.DestroyLoadBar();
 
@@ -2363,7 +2363,7 @@ void MainMenuBar::SearchDuplicatedItems(bool onSelection/* = false*/) {
 
 namespace RemoveDuplicatesItems {
 	struct condition {
-		bool operator()(Map& map, Tile* tile, Item* item, long long removed, long long done) {
+		bool operator()(Map &map, Tile* tile, Item* item, long long removed, long long done) {
 			if (done % 0x8000 == 0) {
 				g_gui.SetLoadDone((unsigned int)(100 * done / map.getTileCount()));
 			}
@@ -2401,14 +2401,14 @@ namespace RemoveDuplicatesItems {
 	};
 }
 
-void MainMenuBar::RemoveDuplicatesItems(bool onSelection/* = false*/) {
+void MainMenuBar::RemoveDuplicatesItems(bool onSelection /* = false*/) {
 	if (!g_gui.IsEditorOpen()) {
 		return;
 	}
 
 	int ok = g_gui.PopupDialog("Remove Duplicate Items", "Do you want to remove all duplicates items from the map?", wxYES | wxNO);
 
-	if(ok == wxID_YES) {
+	if (ok == wxID_YES) {
 		g_gui.GetCurrentEditor()->getSelection().clear();
 		g_gui.GetCurrentEditor()->clearActions();
 

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -311,6 +311,7 @@ protected:
 	void SearchItems(bool unique, bool action, bool container, bool writable, bool onSelection = false);
 	void SearchDuplicatedItems(bool onSelection = false);
 	void RemoveDuplicatesItems(bool onSelection = false);
+
 protected:
 	MainFrame* frame;
 	wxMenuBar* menubar;


### PR DESCRIPTION
- A flag **wxPATH_NORM_ALL** (constante) da biblioteca **wxWidgets** é usada para realizar a normalização de caminhos de arquivos ou diretórios.

- A **normalização de caminho** é o processo de garantir que um caminho de arquivo ou diretório esteja em um formato padronizado, removendo ambiguidades, resolvendo caminhos relativos e removendo partes redundantes do caminho (dependendo de acordo com as flags usadas).

- **wxPATH_NORM_ALL** está obsoleto e deve ser evitada, pois então, ao invés de depender implicitamente dela, devemos especificar explicitamente as flags que precisamos para a normalização de caminhos para alcançar o mesmo efeito.

- Ela é normalmente substituída pelas flags wxPATH_NORM_DOT, wxPATH_NORM_TILDE, wxPATH_NORM_CASE, suprindo a normalização da flag wxPATH_NORM_ALL sem prejuízos no código.

- flags: https://docs.wxwidgets.org/3.2.4/filename_8h.html#a18dd81e40b3fad4a089077e28e5dce22

