### PR TITLE
improve: select the item on raw pallete when using CTRL+F

### DIFF
--- a/source/find_item_window.cpp
+++ b/source/find_item_window.cpp
@@ -438,6 +438,7 @@ void FindItemDialog::OnClickOK(wxCommandEvent &WXUNUSED(event)) {
 			result_brush = brush;
 			result_id = brush->asRaw()->getItemID();
 			EndModal(wxID_OK);
+			g_gui.SelectBrush(brush->asRaw(), TILESET_RAW);
 		}
 	}
 }


### PR DESCRIPTION
This will give you the possibility of selecting items in the raw palette to place them on the map, instead of just searching for existing ones.