### PR TITLE
fix: crash on place monster spawn

### DIFF
--- a/source/spawn_monster_brush.cpp
+++ b/source/spawn_monster_brush.cpp
@@ -74,12 +74,14 @@ void SpawnMonsterBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 			}
 		}
 
-		for (int i = 0; i < toSpawn; ++i) {
-			auto iter = positions.begin();
-			std::advance(iter, rand() % positions.size());
-			auto monsterBrush = monsters[rand() % monsters.size()];
-			monsterBrush->drawMonster(map, map->getTile(*iter), &time);
-			positions.erase(iter);
+		if (monsters.size() > 0) {
+			for (int i = 0; i < toSpawn; ++i) {
+				auto iter = positions.begin();
+				std::advance(iter, rand() % positions.size());
+				auto monsterBrush = monsters[rand() % monsters.size()];
+				monsterBrush->drawMonster(map, map->getTile(*iter), &time);
+				positions.erase(iter);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes the crashing when placing monsters spawn without selecting any monster.

### Before:

https://github.com/opentibiabr/remeres-map-editor/assets/32341050/c32b2814-4972-4609-90a8-4282253f291b

### Actual:

https://github.com/opentibiabr/remeres-map-editor/assets/32341050/0b009ee1-ae35-4618-8fc4-404465e467c6
