### PR TITLE
fix: reload warnings

### DIFF
--- a/source/items.cpp
+++ b/source/items.cpp
@@ -133,6 +133,7 @@ ItemType &ItemDatabase::operator[](uint16_t id) {
 void ItemDatabase::clear() {
 	for (size_t i = 0; i < items.size(); i++) {
 		items[i].reset();
+		items.set(i, nullptr);
 	}
 }
 


### PR DESCRIPTION
Fixes the warnings when reloading the RME (F5).