### PR TITLE
feat: count monsters on selection

### DIFF
--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -85,6 +85,7 @@
         <item name="Find Item on Selection" action="SEARCH_ON_SELECTION_ITEM" help="Find items on selected area."/>
         <item name="Remove Item on Selection" action="REMOVE_ON_SELECTION_ITEM" help="Remove item on selected area."/>
         <item name="Remove Monsters on Selection" action="REMOVE_ON_SELECTION_MONSTER" help="Remove monsters on selected area."/>
+		<item name="Count Monsters on Selection" action="COUNT_ON_SELECTION_MONSTER" help="Count monsters on selected area."/>
         <item name="Remove Duplicated Items on Selection" action="REMOVE_ON_SELECTION_DUPLICATED_ITEMS" help="Removes all items duplicated selected area."/>
         <separator/>
         <menu name="$Find on Selection">

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -89,6 +89,7 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 	MAKE_ACTION(REPLACE_ON_SELECTION_ITEMS, wxITEM_NORMAL, OnReplaceItemsOnSelection);
 	MAKE_ACTION(REMOVE_ON_SELECTION_ITEM, wxITEM_NORMAL, OnRemoveItemOnSelection);
 	MAKE_ACTION(REMOVE_ON_SELECTION_MONSTER, wxITEM_NORMAL, OnRemoveMonstersOnSelection);
+	MAKE_ACTION(COUNT_ON_SELECTION_MONSTER, wxITEM_NORMAL, OnCountMonstersOnSelection);
 	MAKE_ACTION(SELECT_MODE_COMPENSATE, wxITEM_RADIO, OnSelectionTypeChange);
 	MAKE_ACTION(SELECT_MODE_LOWER, wxITEM_RADIO, OnSelectionTypeChange);
 	MAKE_ACTION(SELECT_MODE_CURRENT, wxITEM_RADIO, OnSelectionTypeChange);
@@ -363,6 +364,7 @@ void MainMenuBar::Update() {
 	EnableItem(REPLACE_ON_SELECTION_ITEMS, has_selection && is_host);
 	EnableItem(REMOVE_ON_SELECTION_ITEM, has_selection && is_host);
 	EnableItem(REMOVE_ON_SELECTION_MONSTER, has_selection && is_host);
+	EnableItem(COUNT_ON_SELECTION_MONSTER, has_selection && is_host);
 
 	EnableItem(CUT, has_map);
 	EnableItem(COPY, has_map);
@@ -1226,6 +1228,26 @@ void MainMenuBar::OnRemoveMonstersOnSelection(wxCommandEvent &WXUNUSED(event)) {
 	g_gui.PopupDialog("Remove Monsters", wxString::Format("%d monsters removed.", monstersRemoved), wxOK);
 	g_gui.GetCurrentMap().doChange();
 	g_gui.RefreshView();
+}
+
+void MainMenuBar::OnCountMonstersOnSelection(wxCommandEvent &WXUNUSED(event)) {
+	if (!g_gui.IsEditorOpen()) {
+		return;
+	}
+
+	g_gui.CreateLoadBar("Counting monsters on selection...");
+	const auto result = CountMonstersOnMap(g_gui.GetCurrentMap(), true);
+	g_gui.DestroyLoadBar();
+
+	int64_t totalMonsters = result.first;
+	const std::unordered_map<std::string, int64_t> &monsterCounts = result.second;
+
+	wxString message = wxString::Format("There are %d monsters in total.\n\n", totalMonsters);
+	for (const auto &pair : monsterCounts) {
+		message += wxString::Format("%s: %d\n", pair.first, pair.second);
+	}
+
+	g_gui.PopupDialog("Count Monsters", message, wxOK);
 }
 
 void MainMenuBar::OnSelectionTypeChange(wxCommandEvent &WXUNUSED(event)) {

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -58,6 +58,7 @@ namespace MenuBar {
 		REPLACE_ON_SELECTION_ITEMS,
 		REMOVE_ON_SELECTION_ITEM,
 		REMOVE_ON_SELECTION_MONSTER,
+		COUNT_ON_SELECTION_MONSTER,
 		SELECT_MODE_COMPENSATE,
 		SELECT_MODE_CURRENT,
 		SELECT_MODE_LOWER,
@@ -257,6 +258,7 @@ public:
 	void OnReplaceItemsOnSelection(wxCommandEvent &event);
 	void OnRemoveItemOnSelection(wxCommandEvent &event);
 	void OnRemoveMonstersOnSelection(wxCommandEvent &event);
+	void OnCountMonstersOnSelection(wxCommandEvent &event);
 
 	// Map menu
 	void OnMapEditTowns(wxCommandEvent &event);

--- a/source/map.cpp
+++ b/source/map.cpp
@@ -903,3 +903,30 @@ int64_t RemoveMonstersOnMap(Map &map, bool selectedOnly) {
 	}
 	return removed;
 }
+
+std::pair<int64_t, std::unordered_map<std::string, int64_t>> CountMonstersOnMap(Map &map, bool selectedOnly) {
+	int64_t done = 0;
+	int64_t total = 0;
+	std::unordered_map<std::string, int64_t> monsterCount;
+
+	MapIterator it = map.begin();
+	MapIterator end = map.end();
+
+	while (it != end) {
+		++done;
+		Tile* tile = (*it)->get();
+		if (selectedOnly && !tile->isSelected()) {
+			++it;
+			continue;
+		}
+		if (tile->monster) {
+			++total;
+			std::string monsterName = tile->monster->getName();
+			++monsterCount[monsterName];
+		}
+
+		++it;
+	}
+
+	return std::make_pair(total, monsterCount);
+}

--- a/source/map.h
+++ b/source/map.h
@@ -322,6 +322,7 @@ inline int64_t RemoveItemOnMap(Map &map, RemoveIfType &condition, bool selectedO
 }
 
 int64_t RemoveMonstersOnMap(Map &map, bool selectedOnly);
+std::pair<int64_t, std::unordered_map<std::string, int64_t>> CountMonstersOnMap(Map &map, bool selectedOnly);
 
 template <typename RemoveIfType>
 inline int64_t RemoveItemDuplicateOnMap(Map &map, RemoveIfType &condition, bool selectedOnly) {


### PR DESCRIPTION
This will help to balance some hunts.

How to use:
- Select the area.
- In the select menu, click on "Count Monsters on Selection".
![image](https://github.com/user-attachments/assets/68a68c8f-ad4e-4d43-a58a-bf92ce14686e)
- A popup will appear with the following information:
![image](https://github.com/user-attachments/assets/580daf68-1cda-4c0c-a954-8d456b4dd9fb)

