### PR TITLE
fix: monsters search

### DIFF
--- a/source/palette_monster.h
+++ b/source/palette_monster.h
@@ -57,7 +57,9 @@ public:
 	void OnListBoxChange(wxCommandEvent &event);
 	void OnClickMonsterBrushButton(wxCommandEvent &event);
 	void OnClickSpawnMonsterBrushButton(wxCommandEvent &event);
-	void OnChangeMonsterName(wxCommandEvent &event);
+	void OnSetFocus(wxFocusEvent &event);
+	void OnKillFocus(wxFocusEvent &event);
+	void OnChangeMonsterNameSearch(wxCommandEvent &event);
 
 protected:
 	void SelectMonsterBrush();
@@ -65,6 +67,7 @@ protected:
 
 	wxChoice* tileset_choice;
 	wxTextCtrl* monster_name_text;
+	wxButton* monster_search_button;
 	SortableListBox* monster_list;
 	wxToggleButton* monster_brush_button;
 	wxToggleButton* spawn_monster_brush_button;


### PR DESCRIPTION
This PR solves the monster search triggering hotkeys and enables the monster search by name.

![image](https://github.com/user-attachments/assets/604f82b9-be91-4bbf-a9ff-78c70ea19012)

![image](https://github.com/user-attachments/assets/100acd8b-482a-445c-874b-57a8a441ad26)

