### PR TITLE
feat-fix: minimap export path and pre-defined image sizes selection

### DIFF
--- a/source/common_windows.h
+++ b/source/common_windows.h
@@ -126,6 +126,7 @@ protected:
 
 	Editor &editor;
 
+	wxChoice* imageSizeOptions;
 	wxChoice* format_options;
 	wxStaticText* error_field;
 	wxTextCtrl* directory_text_field;

--- a/source/iominimap.cpp
+++ b/source/iominimap.cpp
@@ -243,7 +243,7 @@ bool IOMinimap::exportMinimap(const std::string &directory) {
 					wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
 					wxString extension_wx = wxString::FromAscii(extension.mb_str());
 					wxFileName file = wxString::Format("%s-%s-%s.%s", std::to_string(h), std::to_string(w), std::to_string(z), extension_wx);
-					file.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE, directory);
+					file.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE, directory);
 					image->SaveFile(file.GetFullPath(), type);
 				}
 			}

--- a/source/iominimap.cpp
+++ b/source/iominimap.cpp
@@ -31,11 +31,12 @@ void MinimapBlock::updateTile(int x, int y, const MinimapTile &tile) {
 	m_tiles[getTileIndex(x, y)] = tile;
 }
 
-IOMinimap::IOMinimap(Editor* editor, MinimapExportFormat format, MinimapExportMode mode, bool updateLoadbar) :
+IOMinimap::IOMinimap(Editor* editor, MinimapExportFormat format, MinimapExportMode mode, bool updateLoadbar, int imageSize /* = 1024 */) :
 	m_editor(editor),
 	m_format(format),
 	m_mode(mode),
-	m_updateLoadbar(updateLoadbar) {
+	m_updateLoadbar(updateLoadbar),
+	m_imageSize(imageSize) {
 }
 
 bool IOMinimap::saveMinimap(const std::string &directory, const std::string &name, int floor) {
@@ -188,10 +189,9 @@ bool IOMinimap::exportMinimap(const std::string &directory) {
 		totalTiles++;
 	}
 
-	constexpr int image_size = 1024;
-	constexpr int pixels_size = image_size * image_size * rme::PixelFormatRGB;
+	int pixels_size = m_imageSize * m_imageSize * rme::PixelFormatRGB;
 	uint8_t* pixels = new uint8_t[pixels_size];
-	auto image = new wxImage(image_size, image_size, pixels, true);
+	auto image = new wxImage(m_imageSize, m_imageSize, pixels, true);
 
 	int processedTiles = 0;
 	int lastShownProgress = -1;
@@ -201,8 +201,8 @@ bool IOMinimap::exportMinimap(const std::string &directory) {
 			continue;
 		}
 
-		for (int h = 0; h < rme::MapMaxHeight; h += image_size) {
-			for (int w = 0; w < rme::MapMaxWidth; w += image_size) {
+		for (int h = 0; h < rme::MapMaxHeight; h += m_imageSize) {
+			for (int w = 0; w < rme::MapMaxWidth; w += m_imageSize) {
 				if (w < rect.x || w > rect.width || h < rect.y || h > rect.height) {
 					continue;
 				}
@@ -211,8 +211,8 @@ bool IOMinimap::exportMinimap(const std::string &directory) {
 				memset(pixels, 0, pixels_size);
 
 				int index = 0;
-				for (int y = 0; y < image_size; y++) {
-					for (int x = 0; x < image_size; x++) {
+				for (int y = 0; y < m_imageSize; y++) {
+					for (int x = 0; x < m_imageSize; x++) {
 						auto tile = map.getTile(w + x, h + y, z);
 						if (!tile || (!tile->ground && tile->items.empty())) {
 							index += rme::PixelFormatRGB;

--- a/source/iominimap.h
+++ b/source/iominimap.h
@@ -72,7 +72,7 @@ private:
 
 class IOMinimap {
 public:
-	IOMinimap(Editor* editor, MinimapExportFormat format, MinimapExportMode mode, bool updateLoadbar);
+	IOMinimap(Editor* editor, MinimapExportFormat format, MinimapExportMode mode, bool updateLoadbar, int imageSize = 1024);
 
 	bool saveMinimap(const std::string &directory, const std::string &name, int floor = -1);
 
@@ -95,6 +95,7 @@ private:
 	MinimapExportMode m_mode;
 	bool m_updateLoadbar = false;
 	int m_floor = -1;
+	int m_imageSize = 1024;
 	std::unordered_map<uint32_t, MinimapBlock> m_blocks[rme::MapLayers];
 	std::string m_error;
 };


### PR DESCRIPTION
This PR fixes the export minimap path, it was exporting to the base of the application and adds a feature to select between some pre-defined image sizes to export. Now it will be exporting to the selected folder and given image size.