### PR TITLE
fix: cmake build

### DIFF
--- a/source/selection.cpp
+++ b/source/selection.cpp
@@ -140,7 +140,6 @@ void Selection::add(const Tile* tile, SpawnNpc* spawnNpc) {
 void Selection::add(const Tile* tile, const std::vector<Monster*> &monsters) {
 	ASSERT(subsession);
 	ASSERT(tile);
-	ASSERT(monster);
 
 	// Make a copy of the tile with the monsters selected
 	for (const auto monster : monsters) {
@@ -249,7 +248,6 @@ void Selection::remove(Tile* tile, SpawnNpc* spawnNpc) {
 void Selection::remove(Tile* tile, const std::vector<Monster*> &monsters) {
 	ASSERT(subsession);
 	ASSERT(tile);
-	ASSERT(monster);
 
 	std::vector<Monster*> selectedMonsters;
 	for (const auto monster : monsters) {

--- a/vcproj/Project/RME.vcxproj
+++ b/vcproj/Project/RME.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -110,7 +110,7 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRTDBG_MAP_ALLOC;__DEBUG__;WXUSINGDLL;wxMSVC_VERSION_AUTO;__EXPERIMENTAL__;LIVE_SERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>


### PR DESCRIPTION
Removes vector assert and disables deprecated minimal rebuild option.