### PR TITLE
feat: update spawntime on selection

### DIFF
--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -87,6 +87,7 @@
         <item name="Remove Monsters on Selection" action="REMOVE_ON_SELECTION_MONSTER" help="Remove monsters on selected area."/>
 		<item name="Count Monsters on Selection" action="COUNT_ON_SELECTION_MONSTER" help="Count monsters on selected area."/>
         <item name="Remove Duplicated Items on Selection" action="REMOVE_ON_SELECTION_DUPLICATED_ITEMS" help="Removes all items duplicated selected area."/>
+        <item name="Update Monster Spawntime on Selection" action="ON_EDIT_EDIT_MONSTER_SPAWN_TIME" help="Edit the spawn time of monsters on the selected area."/>
         <separator/>
         <menu name="$Find on Selection">
             <item name="Find $Everything" action="SEARCH_ON_SELECTION_EVERYTHING" help="Find all unique/action/text/container items."/>

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -90,6 +90,7 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 	MAKE_ACTION(REMOVE_ON_SELECTION_ITEM, wxITEM_NORMAL, OnRemoveItemOnSelection);
 	MAKE_ACTION(REMOVE_ON_SELECTION_MONSTER, wxITEM_NORMAL, OnRemoveMonstersOnSelection);
 	MAKE_ACTION(COUNT_ON_SELECTION_MONSTER, wxITEM_NORMAL, OnCountMonstersOnSelection);
+	MAKE_ACTION(ON_EDIT_EDIT_MONSTER_SPAWN_TIME, wxITEM_NORMAL, OnEditMonsterSpawnTime);
 	MAKE_ACTION(SELECT_MODE_COMPENSATE, wxITEM_RADIO, OnSelectionTypeChange);
 	MAKE_ACTION(SELECT_MODE_LOWER, wxITEM_RADIO, OnSelectionTypeChange);
 	MAKE_ACTION(SELECT_MODE_CURRENT, wxITEM_RADIO, OnSelectionTypeChange);
@@ -1226,6 +1227,20 @@ void MainMenuBar::OnRemoveMonstersOnSelection(wxCommandEvent &WXUNUSED(event)) {
 	g_gui.DestroyLoadBar();
 
 	g_gui.PopupDialog("Remove Monsters", wxString::Format("%d monsters removed.", monstersRemoved), wxOK);
+	g_gui.GetCurrentMap().doChange();
+	g_gui.RefreshView();
+}
+
+void MainMenuBar::OnEditMonsterSpawnTime(wxCommandEvent &WXUNUSED(event)) {
+	if (!g_gui.IsEditorOpen()) {
+		return;
+	}
+	g_gui.GetCurrentEditor()->clearActions();
+	g_gui.CreateLoadBar("Editing monster spawn time on selection...");
+	const auto monstersUpdated = EditMonsterSpawnTime(g_gui.GetCurrentMap(), true);
+	g_gui.PopupDialog(wxString("Edit Monster Spawn Time"), wxString::Format("%d monsters updated.", monstersUpdated), wxOK);
+
+	g_gui.PopupDialog("Edit Monster Spawn Time", wxString::Format("%i monsters updated.", monstersUpdated), wxOK);
 	g_gui.GetCurrentMap().doChange();
 	g_gui.RefreshView();
 }

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -59,6 +59,7 @@ namespace MenuBar {
 		REMOVE_ON_SELECTION_ITEM,
 		REMOVE_ON_SELECTION_MONSTER,
 		COUNT_ON_SELECTION_MONSTER,
+		ON_EDIT_EDIT_MONSTER_SPAWN_TIME,
 		SELECT_MODE_COMPENSATE,
 		SELECT_MODE_CURRENT,
 		SELECT_MODE_LOWER,
@@ -258,6 +259,7 @@ public:
 	void OnReplaceItemsOnSelection(wxCommandEvent &event);
 	void OnRemoveItemOnSelection(wxCommandEvent &event);
 	void OnRemoveMonstersOnSelection(wxCommandEvent &event);
+	void OnEditMonsterSpawnTime(wxCommandEvent &event);
 	void OnCountMonstersOnSelection(wxCommandEvent &event);
 
 	// Map menu

--- a/source/map.cpp
+++ b/source/map.cpp
@@ -905,6 +905,32 @@ int64_t RemoveMonstersOnMap(Map &map, bool selectedOnly) {
 	return removed;
 }
 
+int64_t EditMonsterSpawnTime(Map &map, bool selectedOnly) {
+	int64_t done = 0;
+	int64_t updated = 0;
+	int64_t spawnMonsterTime = g_gui.GetSpawnMonsterTime();
+
+	MapIterator it = map.begin();
+	MapIterator end = map.end();
+
+	while (it != end) {
+		++done;
+		Tile* tile = (*it)->get();
+		if (selectedOnly && !tile->isSelected()) {
+			++it;
+			continue;
+		}
+
+		for (auto monster : tile->monsters) {
+			monster->setSpawnMonsterTime(spawnMonsterTime);
+			++updated;
+		}
+
+		++it;
+	}
+	return updated;
+}
+
 std::pair<int64_t, std::unordered_map<std::string, int64_t>> CountMonstersOnMap(Map &map, bool selectedOnly) {
 	int64_t done = 0;
 	int64_t total = 0;

--- a/source/map.h
+++ b/source/map.h
@@ -324,6 +324,8 @@ inline int64_t RemoveItemOnMap(Map &map, RemoveIfType &condition, bool selectedO
 int64_t RemoveMonstersOnMap(Map &map, bool selectedOnly);
 std::pair<int64_t, std::unordered_map<std::string, int64_t>> CountMonstersOnMap(Map &map, bool selectedOnly);
 
+int64_t EditMonsterSpawnTime(Map &map, bool selectedOnly);
+
 template <typename RemoveIfType>
 inline int64_t RemoveItemDuplicateOnMap(Map &map, RemoveIfType &condition, bool selectedOnly) {
 	int64_t done = 0;


### PR DESCRIPTION
# Description
This feature aims to introduce a new feature on selection top menu. You can select a area and then update the Spawntime of all monsters on that area.

This it's very useful when balancing hunts or high populated areas.

**Remember that always will be applied the spawn time that is on your monster brush. (To view this brush, you can click on the monster palette)**

- Additions:
1. New option on Select option at top menu bar
2. Update several monster spawn times in a selected area using the current value stored in spawntime at monster brush.

# How to test so far

1. Get this code, compile and run RME.
3. Select a area on the map with some monsters.
4. Click on the top menu bar "Selection" and click "Update Monster Spawntime on Selection"
5. See the monsters with the new spawntime based on the current value on spawntime field at monster brush.