### PR TITLE
feat: export minimap

### DIFF
--- a/source/common_windows.cpp
+++ b/source/common_windows.cpp
@@ -633,14 +633,30 @@ void ExportMiniMapWindow::OnClickOK(wxCommandEvent &WXUNUSED(event)) {
 	const auto imageSizeSelection = imageSizeOptions->GetSelection();
 	int imageSize = 64;
 	switch (imageSizeSelection) {
-		case 0: imageSize = 64; break;
-		case 1: imageSize = 128; break;
-		case 2: imageSize = 256; break;
-		case 3: imageSize = 512; break;
-		case 4: imageSize = 1024; break;
-		case 5: imageSize = 2048; break;
-		case 6: imageSize = 4096; break;
-		default: imageSize = 1024; break;
+		case 0:
+			imageSize = 64;
+			break;
+		case 1:
+			imageSize = 128;
+			break;
+		case 2:
+			imageSize = 256;
+			break;
+		case 3:
+			imageSize = 512;
+			break;
+		case 4:
+			imageSize = 1024;
+			break;
+		case 5:
+			imageSize = 2048;
+			break;
+		case 6:
+			imageSize = 4096;
+			break;
+		default:
+			imageSize = 1024;
+			break;
 	}
 
 	auto format = static_cast<MinimapExportFormat>(format_options->GetSelection());

--- a/source/iominimap.cpp
+++ b/source/iominimap.cpp
@@ -148,90 +148,94 @@ bool IOMinimap::saveImage(const std::string &directory, const std::string &name)
 }
 
 bool IOMinimap::exportMinimap(const std::string &directory) {
-    auto &map = m_editor->getMap();
-    if (map.size() == 0) {
-        return true;
-    }
+	auto &map = m_editor->getMap();
+	if (map.size() == 0) {
+		return true;
+	}
 
-    int min_z = m_floor == -1 ? 0 : m_floor;
-    int max_z = m_floor == -1 ? rme::MapMaxLayer : m_floor;
-    int max_x = 0, max_y = 0;
-    for (auto it = map.begin(); it != map.end(); ++it) {
-        auto tile = (*it)->get();
-        if (!tile || (!tile->ground && tile->items.empty())) {
-            continue;
-        }
-        const auto &position = tile->getPosition();
-        if (position.x > max_x) max_x = position.x;
-        if (position.y > max_y) max_y = position.y;
-    }
+	int min_z = m_floor == -1 ? 0 : m_floor;
+	int max_z = m_floor == -1 ? rme::MapMaxLayer : m_floor;
+	int max_x = 0, max_y = 0;
+	for (auto it = map.begin(); it != map.end(); ++it) {
+		auto tile = (*it)->get();
+		if (!tile || (!tile->ground && tile->items.empty())) {
+			continue;
+		}
+		const auto &position = tile->getPosition();
+		if (position.x > max_x) {
+			max_x = position.x;
+		}
+		if (position.y > max_y) {
+			max_y = position.y;
+		}
+	}
 
-    int last_x = ((max_x / m_imageSize) + 1) * m_imageSize - 1;
-    int last_y = ((max_y / m_imageSize) + 1) * m_imageSize - 1;
+	int last_x = ((max_x / m_imageSize) + 1) * m_imageSize - 1;
+	int last_y = ((max_y / m_imageSize) + 1) * m_imageSize - 1;
 
-    int pixels_size = m_imageSize * m_imageSize * rme::PixelFormatRGB;
-    uint8_t* pixels = new uint8_t[pixels_size];
-    auto image = new wxImage(m_imageSize, m_imageSize, pixels, true);
+	int pixels_size = m_imageSize * m_imageSize * rme::PixelFormatRGB;
+	uint8_t* pixels = new uint8_t[pixels_size];
+	auto image = new wxImage(m_imageSize, m_imageSize, pixels, true);
 
-    int processedTiles = 0;
-    int lastShownProgress = -1;
+	int processedTiles = 0;
+	int lastShownProgress = -1;
 
-    for (size_t z = min_z; z <= max_z; z++) {
-        for (int h = 0; h <= last_y; h += m_imageSize) {
-            for (int w = 0; w <= last_x; w += m_imageSize) {
-                memset(pixels, 0, pixels_size);
-                bool empty = true;
+	for (size_t z = min_z; z <= max_z; z++) {
+		for (int h = 0; h <= last_y; h += m_imageSize) {
+			for (int w = 0; w <= last_x; w += m_imageSize) {
+				memset(pixels, 0, pixels_size);
+				bool empty = true;
 
-                int index = 0;
-                for (int y = 0; y < m_imageSize; y++) {
-                    for (int x = 0; x < m_imageSize; x++) {
-                        int tile_x = w + x;
-                        int tile_y = h + y;
-                        if (tile_x > max_x || tile_y > max_y) {
-                            index += rme::PixelFormatRGB;
-                            continue;
-                        }
-                        auto tile = map.getTile(tile_x, tile_y, z);
-                        if (!tile || (!tile->ground && tile->items.empty())) {
-                            index += rme::PixelFormatRGB;
-                            continue;
-                        }
+				int index = 0;
+				for (int y = 0; y < m_imageSize; y++) {
+					for (int x = 0; x < m_imageSize; x++) {
+						int tile_x = w + x;
+						int tile_y = h + y;
+						if (tile_x > max_x || tile_y > max_y) {
+							index += rme::PixelFormatRGB;
+							continue;
+						}
+						auto tile = map.getTile(tile_x, tile_y, z);
+						if (!tile || (!tile->ground && tile->items.empty())) {
+							index += rme::PixelFormatRGB;
+							continue;
+						}
 
-                        processedTiles++;
-                        int progress = static_cast<int>((static_cast<double>(processedTiles) / map.size()) * 100);
-                        if (progress > lastShownProgress) {
-                            if (m_updateLoadbar) {
-                                g_gui.SetLoadDone(progress);
-                            }
-                            lastShownProgress = progress;
-                        }
+						processedTiles++;
+						int progress = static_cast<int>((static_cast<double>(processedTiles) / map.size()) * 100);
+						if (progress > lastShownProgress) {
+							if (m_updateLoadbar) {
+								g_gui.SetLoadDone(progress);
+							}
+							lastShownProgress = progress;
+						}
 
-                        uint8_t color = tile->getMiniMapColor();
-                        pixels[index] = (uint8_t)(static_cast<int>(color / 36) % 6 * 51);
-                        pixels[index + 1] = (uint8_t)(static_cast<int>(color / 6) % 6 * 51);
-                        pixels[index + 2] = (uint8_t)(color % 6 * 51);
-                        index += rme::PixelFormatRGB;
-                        empty = false;
-                    }
-                }
+						uint8_t color = tile->getMiniMapColor();
+						pixels[index] = (uint8_t)(static_cast<int>(color / 36) % 6 * 51);
+						pixels[index + 1] = (uint8_t)(static_cast<int>(color / 6) % 6 * 51);
+						pixels[index + 2] = (uint8_t)(color % 6 * 51);
+						index += rme::PixelFormatRGB;
+						empty = false;
+					}
+				}
 
-                if (!empty) {
-                    image->SetData(pixels, true);
-                    wxString extension = m_format == MinimapExportFormat::Png ? "png" : "bmp";
-                    wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
-                    wxString extension_wx = wxString::FromAscii(extension.mb_str());
-                    wxFileName file = wxString::Format("Minimap_Color_%d_%d_%d.%s", w, h, (int)z, extension_wx);
-                    file.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE, directory);
-                    image->SaveFile(file.GetFullPath(), type);
-                }
-            }
-        }
-    }
+				if (!empty) {
+					image->SetData(pixels, true);
+					wxString extension = m_format == MinimapExportFormat::Png ? "png" : "bmp";
+					wxBitmapType type = m_format == MinimapExportFormat::Png ? wxBITMAP_TYPE_PNG : wxBITMAP_TYPE_BMP;
+					wxString extension_wx = wxString::FromAscii(extension.mb_str());
+					wxFileName file = wxString::Format("Minimap_Color_%d_%d_%d.%s", w, h, (int)z, extension_wx);
+					file.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE, directory);
+					image->SaveFile(file.GetFullPath(), type);
+				}
+			}
+		}
+	}
 
-    g_gui.DestroyLoadBar();
-    image->Destroy();
-    delete[] pixels;
-    return true;
+	g_gui.DestroyLoadBar();
+	image->Destroy();
+	delete[] pixels;
+	return true;
 }
 
 bool IOMinimap::exportSelection(const std::string &directory, const std::string &name) {


### PR DESCRIPTION
In some tests I noticed that the images were not exported completely, so when sending them to the client's minimap it did not show the entire exported custom map. With these modifications, in addition to exporting the custom map completely, there are also more size options that can be used for other purposes.

In addition to these modifications to apply the minimap in the cipsoft client without bugging everything, I developed a way where you need to prepare the images before they are loaded. I will be publishing them in the tutorials on discord and I will record a video teaching how to do it correctly and the result is this:

![map_custom](https://github.com/user-attachments/assets/cd910d1c-a15b-409d-a6da-19c082a9a62f)
