### PR TITLE
fix: 'open with' option

### DIFF
--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -318,7 +318,6 @@ bool GUI::LoadDataFiles(wxString &error, wxArrayString &warnings) {
 		spdlog::warn("[GUI::LoadDataFiles] {}: {}", itemsPath.GetFullPath().ToStdString(), error.ToStdString());
 	}
 
-
 	g_gui.SetLoadDone(45, "Loading monsters.xml ...");
 	spdlog::info("Loading monsters");
 	FileName monstersPath(exec_directory);
@@ -353,7 +352,6 @@ bool GUI::LoadDataFiles(wxString &error, wxArrayString &warnings) {
 		warnings.push_back("Couldn't load npcs.xml: " + error);
 		spdlog::warn("[GUI::LoadDataFiles] {}: {}", npcsPath.GetFullPath().ToStdString(), error.ToStdString());
 	}
-
 
 	g_gui.SetLoadDone(45, "Loading user npcs.xml ...");
 	spdlog::info("Loading user npcs");


### PR DESCRIPTION
Esse PR para abrir o mapa diretamente pelo arquivo.otbm

Antes, ao clicar no map.otbm e ir na opção de _abrir com_ e selecionar o remeres, ele dava erro no items.xml, monsters,xml e npc.xml. Essa alteração corrige isso



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved data file path resolution to use runtime-based directory detection instead of hard-coded paths, enhancing application portability and flexibility for different installation configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->