### PR TITLE
fix: use-after-free on map import and improve error messages

### DIFF
--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -783,6 +783,7 @@ bool Editor::importMap(FileName filename, int import_x_offset, int import_y_offs
 			map.removeSpawnMonster(old_tile);
 		}
 		import_tile->spawnMonster = nullptr;
+		import_tile->spawnNpc = nullptr;
 
 		map.setTile(new_pos, import_tile, true);
 	}

--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -781,6 +781,7 @@ bool Editor::importMap(FileName filename, int import_x_offset, int import_y_offs
 		Tile* old_tile = map.getTile(new_pos);
 		if (old_tile) {
 			map.removeSpawnMonster(old_tile);
+			map.removeSpawnNpc(old_tile);
 		}
 		import_tile->spawnMonster = nullptr;
 		import_tile->spawnNpc = nullptr;

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1124,7 +1124,10 @@ bool GUI::SetLoadDone(int32_t done, const wxString &newMessage) {
 	if (done == 100) {
 		DestroyLoadBar();
 		return true;
-	} else if (done == currentProgress) {
+	}
+
+	bool messageChanged = !newMessage.empty() && newMessage != progressText;
+	if (done == currentProgress && !messageChanged) {
 		return true;
 	}
 

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -752,7 +752,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 			uint16_t base_x, base_y;
 			uint8_t base_z;
 			if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
-				warning("Invalid map node, no base coordinate");
+				warning("Invalid map node (type %d), no base coordinate", node_type);
 				continue;
 			}
 
@@ -760,14 +760,14 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 				Tile* tile = nullptr;
 				uint8_t tile_type;
 				if (!tileNode->getByte(tile_type)) {
-					warning("Invalid tile type");
+					warning("Invalid tile type in area %d:%d:%d", base_x, base_y, base_z);
 					continue;
 				}
 				if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
 					// printf("Start\n");
 					uint8_t x_offset, y_offset;
 					if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
-						warning("Could not read position of tile");
+						warning("Could not read position of tile in area %d:%d:%d", base_x, base_y, base_z);
 						continue;
 					}
 					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
@@ -956,7 +956,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 	}
 
 	if (!f.isOk()) {
-		warning(wxstr(f.getErrorMessage()).wc_str());
+		warning("OTBM loading error: %s (at file position %zu of %zu bytes)", wxstr(f.getErrorMessage()).wc_str(), f.tell(), f.size());
 	}
 	return true;
 }
@@ -1030,7 +1030,7 @@ bool IOMapOTBM::loadSpawnsMonster(Map &map, pugi::xml_document &doc) {
 			const std::string &name = monsterNode.attribute("name").as_string();
 			if (name.empty()) {
 				wxString err;
-				err << "Bad monster position data, discarding monster at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due missing name.";
+				err << "Bad monster position data, discarding monster at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due to missing name.";
 				warnings.Add(err);
 				break;
 			}
@@ -1268,13 +1268,13 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 		spawnPosition.z = spawnNpcNode.attribute("centerz").as_int();
 
 		if (spawnPosition.x == 0 || spawnPosition.y == 0) {
-			warning("Bad position data on one npc spawn, discarding...");
+			warning("Bad position data on npc spawn at %d:%d:%d, discarding...", spawnPosition.x, spawnPosition.y, spawnPosition.z);
 			continue;
 		}
 
 		int32_t radius = spawnNpcNode.attribute("radius").as_int();
 		if (radius < 1) {
-			warning("Couldn't read radius of npc spawn.. discarding spawn...");
+			warning("Invalid radius (%d) for npc spawn at %d:%d:%d, discarding spawn...", radius, spawnPosition.x, spawnPosition.y, spawnPosition.z);
 			continue;
 		}
 
@@ -1302,7 +1302,7 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 			const std::string &name = npcNode.attribute("name").as_string();
 			if (name.empty()) {
 				wxString err;
-				err << "Bad npc position data, discarding npc at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due missing name.";
+				err << "Bad npc position data, discarding npc at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due to missing name.";
 				warnings.Add(err);
 				break;
 			}
@@ -1509,13 +1509,13 @@ bool IOMapOTBM::saveMap(Map &map, const FileName &identifier) {
 		return false;
 	}
 
-	g_gui.SetLoadDone(99, "Saving monster spawns...");
+	g_gui.SetLoadDone(96, "Saving monster spawns...");
 	saveSpawns(map, identifier);
 
-	g_gui.SetLoadDone(99, "Saving houses...");
+	g_gui.SetLoadDone(97, "Saving houses...");
 	saveHouses(map, identifier);
 
-	g_gui.SetLoadDone(99, "Saving zones...");
+	g_gui.SetLoadDone(98, "Saving zones...");
 	saveZones(map, identifier);
 
 	g_gui.SetLoadDone(99, "Saving npcs spawns...");

--- a/source/iomap_otmm.cpp
+++ b/source/iomap_otmm.cpp
@@ -413,7 +413,7 @@ bool IOMapOTMM::loadMap(Map &map, NodeFileReadHandle &f, const FileName &identif
 							uint16_t x_offset, y_offset;
 							uint8_t z_offset;
 							if (!tileNode->getU16(x_offset) || !tileNode->getU16(y_offset) || !tileNode->getU8(z_offset)) {
-								warning("Could not read position of tile");
+								warning("Could not read position of tile (OTMM format, corrupted tile node)");
 								continue;
 							}
 							const Position pos(x_offset, y_offset, z_offset);

--- a/source/spawn_monster.h
+++ b/source/spawn_monster.h
@@ -49,7 +49,7 @@ public:
 	}
 
 	void setSize(int newsize) {
-		ASSERT(size < 100);
+		ASSERT(newsize >= 0 && newsize < 100);
 		size = newsize;
 	}
 

--- a/source/spawn_npc.h
+++ b/source/spawn_npc.h
@@ -49,7 +49,7 @@ public:
 	}
 
 	void setSize(int newsize) {
-		ASSERT(size < 100);
+		ASSERT(newsize >= 0 && newsize < 100);
 		size = newsize;
 	}
 

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -189,12 +189,6 @@ void Tile::merge(Tile* other) {
 		other->spawnNpc = nullptr;
 	}
 
-	if (other->npc) {
-		delete npc;
-		npc = other->npc;
-		other->npc = nullptr;
-	}
-
 	for (const auto monster : other->monsters) {
 		addMonster(monster);
 	}


### PR DESCRIPTION
- Fix use-after-free bug in map import that corrupted NPC spawn data (e.g. `radius="-644630928"`)
- Fix progress bar freezing at "Saving monster spawns... 99%" during save
- Improve vague map loading error messages with position/area context
- Fix `setSize` ASSERT checking old value instead of new value
- Remove duplicate NPC merge block in `Tile::merge()`
- Fix "due missing" typo in warning messages


- When importing a map, existing tiles' NPC spawns were not being removed from the global spawn list before being overwritten
- This left stale positions in `map.spawnsNpc` pointing to tiles with `spawnNpc == nullptr`
- Saving the map would iterate the list and dereference the null pointer, causing a crash at `iomap_otbm.cpp:1918`
- Added `map.removeSpawnNpc(old_tile)` to match the existing `map.removeSpawnMonster(old_tile)` call during import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NPC spawn handling when importing tiles to also remove old NPC spawns and clear new-tile NPC pointers
  * Ensured progress display refreshes when status messages change even if percentage is unchanged
  * Prevented unintended NPC transfer during tile merge operations

* **Improvements**
  * Enhanced map load/save warnings and errors with location/context details
  * Strengthened spawn size validation to reject invalid inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->