### PR TITLE
chore: update C++ standard from C++20 to C++23

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -55,8 +55,14 @@ jobs:
         uses: actions/checkout@main
 
       - name: Install Linux Dependencies
-        run: >
-          sudo apt-get update && sudo apt-get install ccache linux-headers-$(uname -r)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y gcc-13 g++-13 ccache linux-headers-$(uname -r)
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
       - name: CCache
         uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -37,10 +37,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04 ] # Atualizado para 24.04
+        os: [ ubuntu-24.04 ]
         buildtype: [ linux-release ]
         include:
-          - os: ubuntu-24.04 # Atualizado para 24.04
+          - os: ubuntu-24.04
             triplet: x64-linux
 
     steps:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -86,7 +86,7 @@ jobs:
         uses: lukka/get-cmake@main
 
       - name: Install additional libraries
-        run: sudo apt-get install -y libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-dev python3-setuptools libxrender-dev
+        run: sudo apt-get install -y libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-gtk3-dev libxrender-dev libltdl-dev
 
       - name: Run CMake Cache and Build
         uses: lukka/run-cmake@main

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -86,7 +86,7 @@ jobs:
         uses: lukka/get-cmake@main
 
       - name: Install additional libraries
-        run: sudo apt-get install -y libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.0-gtk3-dev python3-distutils libxrender-dev
+        run: sudo apt-get install -y libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-dev python3-setuptools libxrender-dev
 
       - name: Run CMake Cache and Build
         uses: lukka/run-cmake@main

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -37,10 +37,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04 ]
+        os: [ ubuntu-24.04 ] # Atualizado para 24.04
         buildtype: [ linux-release ]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04 # Atualizado para 24.04
             triplet: x64-linux
 
     steps:
@@ -57,12 +57,9 @@ jobs:
       - name: Install Linux Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
           sudo apt-get install -y gcc-13 g++-13 ccache linux-headers-$(uname -r)
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13
+          sudo update-alternatives --set gcc /usr/bin/gcc-13
 
       - name: CCache
         uses: hendrikmuhs/ccache-action@main
@@ -89,7 +86,7 @@ jobs:
         uses: lukka/get-cmake@main
 
       - name: Install additional libraries
-        run: sudo apt-get install libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.0-gtk3-dev python3-distutils libxrender-dev
+        run: sudo apt-get install -y libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.0-gtk3-dev python3-distutils libxrender-dev
 
       - name: Run CMake Cache and Build
         uses: lukka/run-cmake@main

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -86,7 +86,15 @@ jobs:
         uses: lukka/get-cmake@main
 
       - name: Install additional libraries
-        run: sudo apt-get install -y libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-gtk3-dev libxrender-dev libltdl-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasio-dev nlohmann-json3-dev libfmt-dev bison libxi-dev \
+            libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev \
+            libxrandr-dev libxxf86vm-dev libx11-dev libxft-dev libxext-dev \
+            libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev \
+            libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev \
+            libwxgtk3.2-dev libxrender-dev libltdl-dev pkg-config autoconf automake
 
       - name: Run CMake Cache and Build
         uses: lukka/run-cmake@main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(VCPKG_BUILD_TYPE "release")
 # Set Configs
 # *****************************************************************************
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(GNUCXX_MINIMUM_VERSION 11)
 set(MSVC_MINIMUM_VERSION "19.32")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ set(VCPKG_BUILD_TYPE "release")
 # *****************************************************************************
 
 set(CMAKE_CXX_STANDARD 23)
-set(GNUCXX_MINIMUM_VERSION 11)
-set(MSVC_MINIMUM_VERSION "19.32")
+set(GNUCXX_MINIMUM_VERSION 13)
+set(MSVC_MINIMUM_VERSION "19.37")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
@@ -109,7 +109,6 @@ if(OPTIONS_ENABLE_SCCACHE)
 endif()
 
 # === IPO ===
-option(OPTIONS_ENABLE_IPO "Check and Enable interprocedural optimization (IPO/LTO)" ON)
 if(OPTIONS_ENABLE_IPO)
 	log_option_enabled("ipo")
 


### PR DESCRIPTION
## Description      
This PR updates the C++ standard from C++20 to C++23 in the project configuration.      
      
## Changes      
- Updated `CMAKE_CXX_STANDARD` from 20 to 23 in `CMakeLists.txt`  
- Updated minimum compiler versions: `GNUCXX_MINIMUM_VERSION` to 13 and `MSVC_MINIMUM_VERSION` to "19.37"  
- Removed duplicate `OPTIONS_ENABLE_IPO` declaration  
- Updated CI to Ubuntu 24.04 with GCC 13 and required build tools  
- Updated wxWidgets package to `libwxgtk3.2-dev` for Ubuntu 24.04 compatibility  
      
## Testing      
- [x] Project builds successfully with C++23 on Windows (MSVC)  
- [x] Project builds successfully with C++23 on Ubuntu 24.04 (GCC 13)  
- [x] All existing functionality works as expected      
      
## Notes      
Minimum compiler versions updated to ensure proper C++23 support (GCC 13+ and MSVC 19.37+). [18-cite-0](#18-cite-0)  CI migrated to Ubuntu 24.04 for native GCC 13 support. [18-cite-1](#18-cite-1)   
  
MSVC translates `CMAKE_CXX_STANDARD 23` to `-std:c++latest`, which is expected behavior. The `.clang-format` file uses `Standard: Latest` and requires no changes.