### PR TITLE
fix: NPC spawn use-after-free on map import, progress bar freeze, and improved diagnostics

### DIFF
--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -781,8 +781,10 @@ bool Editor::importMap(FileName filename, int import_x_offset, int import_y_offs
 		Tile* old_tile = map.getTile(new_pos);
 		if (old_tile) {
 			map.removeSpawnMonster(old_tile);
+			map.removeSpawnNpc(old_tile);
 		}
 		import_tile->spawnMonster = nullptr;
+		import_tile->spawnNpc = nullptr;
 
 		map.setTile(new_pos, import_tile, true);
 	}

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1129,16 +1129,19 @@ bool GUI::SetLoadDone(int32_t done, const wxString &newMessage) {
 	if (done == 100) {
 		DestroyLoadBar();
 		return true;
-	} else if (done == currentProgress) {
+	}
+
+	int32_t newProgress = progressFrom + static_cast<int32_t>((done / 100.f) * (progressTo - progressFrom));
+	newProgress = std::max<int32_t>(0, std::min<int32_t>(100, newProgress));
+
+	bool messageChanged = !newMessage.empty() && newMessage != progressText;
+	if (newProgress == currentProgress && !messageChanged) {
 		return true;
 	}
 
 	if (!newMessage.empty()) {
 		progressText = newMessage;
 	}
-
-	int32_t newProgress = progressFrom + static_cast<int32_t>((done / 100.f) * (progressTo - progressFrom));
-	newProgress = std::max<int32_t>(0, std::min<int32_t>(100, newProgress));
 
 	bool skip = false;
 	if (progressBar) {

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -752,7 +752,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 			uint16_t base_x, base_y;
 			uint8_t base_z;
 			if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
-				warning("Invalid map node, no base coordinate");
+				warning("Invalid map node (type %d), no base coordinate", node_type);
 				continue;
 			}
 
@@ -760,14 +760,14 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 				Tile* tile = nullptr;
 				uint8_t tile_type;
 				if (!tileNode->getByte(tile_type)) {
-					warning("Invalid tile type");
+					warning("Invalid tile type in area %d:%d:%d", base_x, base_y, base_z);
 					continue;
 				}
 				if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
 					// printf("Start\n");
 					uint8_t x_offset, y_offset;
 					if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
-						warning("Could not read position of tile");
+						warning("Could not read position of tile in area %d:%d:%d", base_x, base_y, base_z);
 						continue;
 					}
 					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
@@ -956,7 +956,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 	}
 
 	if (!f.isOk()) {
-		warning(wxstr(f.getErrorMessage()).wc_str());
+		warning("OTBM loading error: %s (at file position %zu of %zu bytes)", wxstr(f.getErrorMessage()).wc_str(), f.tell(), f.size());
 	}
 	return true;
 }
@@ -1030,7 +1030,7 @@ bool IOMapOTBM::loadSpawnsMonster(Map &map, pugi::xml_document &doc) {
 			const std::string &name = monsterNode.attribute("name").as_string();
 			if (name.empty()) {
 				wxString err;
-				err << "Bad monster position data, discarding monster at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due missing name.";
+				err << "Bad monster position data, discarding monster at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due to missing name.";
 				warnings.Add(err);
 				break;
 			}
@@ -1302,7 +1302,7 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 			const std::string &name = npcNode.attribute("name").as_string();
 			if (name.empty()) {
 				wxString err;
-				err << "Bad npc position data, discarding npc at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due missing name.";
+				err << "Bad npc position data, discarding npc at spawn " << spawnPosition.x << ":" << spawnPosition.y << ":" << spawnPosition.z << " due to missing name.";
 				warnings.Add(err);
 				break;
 			}

--- a/source/iomap_otmm.cpp
+++ b/source/iomap_otmm.cpp
@@ -413,7 +413,7 @@ bool IOMapOTMM::loadMap(Map &map, NodeFileReadHandle &f, const FileName &identif
 							uint16_t x_offset, y_offset;
 							uint8_t z_offset;
 							if (!tileNode->getU16(x_offset) || !tileNode->getU16(y_offset) || !tileNode->getU8(z_offset)) {
-								warning("Could not read position of tile");
+								warning("Could not read position of tile (OTMM format, corrupted tile node)");
 								continue;
 							}
 							const Position pos(x_offset, y_offset, z_offset);

--- a/source/spawn_monster.h
+++ b/source/spawn_monster.h
@@ -49,7 +49,7 @@ public:
 	}
 
 	void setSize(int newsize) {
-		ASSERT(size < 100);
+		ASSERT(newsize >= 0 && newsize < 100);
 		size = newsize;
 	}
 

--- a/source/spawn_npc.h
+++ b/source/spawn_npc.h
@@ -49,7 +49,7 @@ public:
 	}
 
 	void setSize(int newsize) {
-		ASSERT(size < 100);
+		ASSERT(newsize >= 0 && newsize < 100);
 		size = newsize;
 	}
 

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -189,12 +189,6 @@ void Tile::merge(Tile* other) {
 		other->spawnNpc = nullptr;
 	}
 
-	if (other->npc) {
-		delete npc;
-		npc = other->npc;
-		other->npc = nullptr;
-	}
-
 	for (const auto monster : other->monsters) {
 		addMonster(monster);
 	}


### PR DESCRIPTION
## Summary  

Author @luanupdate

Fix use-after-free bug in map import that corrupted NPC spawn data, fix progress  
bar freezing during save, fix setSize ASSERT validating the wrong value, remove  
dead duplicate code in Tile::merge(), fix typo in warning messages, and improve  
vague map loading errors with position/area context.  
  
## Bug Fixes  
  
- Fix use-after-free when importing maps with overlapping NPC spawns. Existing  
  tiles' NPC spawns were not removed from the global spawn list before being  
  overwritten, leaving stale positions in `map.spawnsNpc` pointing to tiles with  
  `spawnNpc == nullptr`. Saving would dereference the null pointer, causing a crash  
  at `iomap_otbm.cpp:1918` and corrupting data (e.g. `radius="-644630928"`). Added  
  `map.removeSpawnNpc(old_tile)` to match the existing `map.removeSpawnMonster(old_tile)`  
  call during import  
- Fix progress bar freezing at "Saving monster spawns... 99%" during save.  
  `SetLoadDone` was skipping UI updates when percentage didn't change, even if the  
  status message changed. Multiple save steps call `SetLoadDone(99, ...)` with  
  different messages. Fixed by detecting message changes and corrected the  
  early-return comparison to use the scaled progress value instead of raw input  
- Fix `SpawnMonster::setSize()` and `SpawnNpc::setSize()` ASSERT checking the old  
  `size` value instead of the new `newsize` parameter. Changed to  
  `ASSERT(newsize >= 0 && newsize < 100)`  
- Remove duplicate `if (other->npc)` block in `Tile::merge()`. The second block was  
  dead code since `other->npc` was already set to `nullptr` by the first block  
- Fix "due missing" typo to "due to missing" in `loadSpawnsMonster()` and  
  `loadSpawnsNpc()` warning messages  
  
## Improvements  
  
- Add tile area coordinates and node type to vague warnings in `IOMapOTBM::loadMap()`  
- Add OTMM format context to tile position warning in `IOMapOTMM::loadMap()`  
- Add file position and size to OTBM loading error message  
  
## Modified Files  
  
| File | Change |  
|---|---|  
| `source/editor.cpp` | Added `removeSpawnNpc` and `spawnNpc` pointer clear on tile import |  
| `source/tile.cpp` | Removed duplicate NPC merge block in `Tile::merge()` |  
| `source/spawn_monster.h` | Fixed `setSize` ASSERT to validate `newsize` parameter |  
| `source/spawn_npc.h` | Fixed `setSize` ASSERT to validate `newsize` parameter |  
| `source/gui.cpp` | Fixed progress bar freeze and raw vs scaled comparison in `SetLoadDone` |  
| `source/iomap_otbm.cpp` | Added position context to warnings, fixed "due missing" typo |  
| `source/iomap_otmm.cpp` | Added context to tile position warning |  
  
## How to Test  
  
1. Open a map that contains NPC spawns  
2. Import a second map (`File > Import`) that overlaps tiles with NPC spawns  
3. Save the merged map and verify it completes without crash and NPC spawn data  
   is not corrupted (no garbage values like `radius="-644630928"`)  
4. Open a map with monster spawns, NPC spawns, houses, and zones  
5. Save the map and observe the progress bar updates its message through each  
   phase instead of freezing at "Saving monster spawns... 99%"  
6. In a debug build, create a monster or NPC spawn and attempt to set its radius  
   to a negative value or >= 100. Verify the ASSERT fires on the invalid input  
7. Perform paste or undo/redo on tiles with NPC data and verify NPC data  
   transfers correctly without duplication  
8. Load a corrupted or malformed `.otbm`/`.otmm` file and verify warnings include  
   area coordinates, node type, or file position context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed tile merge behavior to properly handle both monster and NPC spawns when importing maps.
  * Improved spawn size validation to check input bounds before assignment.
  * Removed duplicate NPC transfer logic in tile operations.

* **Improvements**
  * Enhanced diagnostic messages during map loading with contextual information about tile areas and file positions.
  * Updated error messaging for tile position parsing failures in map formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->