### PR TITLE
fix: resolve crash when opening new map view on Linux

### DIFF
--- a/source/map_display.cpp
+++ b/source/map_display.cpp
@@ -188,6 +188,9 @@ void MapCanvas::GetViewBox(int* view_scroll_x, int* view_scroll_y, int* screensi
 }
 
 void MapCanvas::OnPaint(wxPaintEvent &event) {
+	if (!IsShownOnScreen()) {
+		return;
+	}
 	SetCurrent(*g_gui.GetGLContext(this));
 
 	if (g_gui.IsRenderingEnabled()) {

--- a/source/map_tab.cpp
+++ b/source/map_tab.cpp
@@ -39,7 +39,7 @@ MapTab::MapTab(MapTabbook* aui, Editor* editor) :
 
 MapTab::MapTab(const MapTab* other) :
 	EditorTab(),
-	MapWindow(other->aui, *other->iref->editor),
+	MapWindow(other->aui->notebook, *other->iref->editor),
 	aui(other->aui),
 	iref(other->iref) {
 	iref->owner_count++;


### PR DESCRIPTION
## Summary  
  
Fix crash when clicking **View > New View** on Linux (wxGTK3). The editor would crash immediately after opening the new tab.  
  
## Changes  
  
| File | Description |  
|---|---|  
| `source/map_tab.cpp` | Fix incorrect parent passed to `MapWindow` in the `MapTab` copy constructor — use `other->aui->notebook` instead of `other->aui`, matching the primary constructor |  
| `source/map_display.cpp` | Add `IsShownOnScreen()` guard in `MapCanvas::OnPaint` to prevent GL calls on an unrealized canvas |  
  
## Root cause  
  
Two issues combined to cause the crash:  
  
1. The `MapTab` copy constructor (used by New View) passed `other->aui` (`MapTabbook*`) as the parent to `MapWindow`, while the primary constructor correctly passes `aui->notebook` (`wxAuiNotebook*`). This created the panel under the wrong parent in the widget hierarchy.  
  
2. When `wxAuiNotebook::AddPage` is called with `select=true`, it can trigger a paint event before the new `wxGLCanvas` has a valid native drawable. On Linux/GTK3, calling `SetCurrent`/`SwapBuffers` on an unrealized canvas causes a crash. Windows is more tolerant of this.  
  
## Testing  
  
1. Open any `.otbm` map file  
2. Click **View > New View**
3. Verify the new tab opens without crash  
4. Verify both tabs render correctly and can be switched between  
5. Repeat multiple times to confirm stability  
  
Tested on Ubuntu 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved map rendering efficiency by skipping unnecessary operations when the map canvas is not visible on-screen.

* **Bug Fixes**
  * Fixed initialization inconsistency in map copying to prevent potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->