### PR TITLE
feat: organize monster palette by Lua folder structure and fix hidden file loading

### DIFF
--- a/source/map_drawer.cpp
+++ b/source/map_drawer.cpp
@@ -1266,6 +1266,9 @@ void MapDrawer::BlitCreature(int screenx, int screeny, const Outfit &outfit, con
 	}
 
 	if (outfit.lookType == 0) {
+		Outfit fallback;
+		fallback.lookType = 197; // This looktype is a tribute to our beloved Carl-bot from OpenTibiaBR Discord.
+		BlitCreature(screenx, screeny, fallback, dir, red, green, blue, alpha);
 		return;
 	}
 

--- a/source/materials.cpp
+++ b/source/materials.cpp
@@ -102,17 +102,7 @@ bool Materials::unserializeMaterials(const FileName &filename, pugi::xml_node no
 	return true;
 }
 
-void Materials::createOtherTileset() {
-	Tileset* others;
-	if (tilesets["Others"] != nullptr) {
-		others = tilesets["Others"];
-		others->clear();
-	} else {
-		others = newd Tileset(g_brushes, "Others");
-		tilesets["Others"] = others;
-	}
-
-	// There should really be an iterator to do this
+void Materials::populateRawBrushes(Tileset* others) {
 	for (int32_t id = 0; id <= g_items.getMaxID(); ++id) {
 		auto type = g_items.getRawItemType(id);
 		if (!type) {
@@ -139,11 +129,24 @@ void Materials::createOtherTileset() {
 			type->in_other_tileset = true;
 		}
 	}
+}
+
+void Materials::createOtherTileset() {
+	Tileset* others;
+	if (tilesets["Others"] != nullptr) {
+		others = tilesets["Others"];
+		others->clear();
+	} else {
+		others = newd Tileset(g_brushes, "Others");
+		tilesets["Others"] = others;
+	}
+
+	populateRawBrushes(others);
 
 	// Clear TILESET_MONSTER categories from previous folder tilesets
-	for (auto &pair : tilesets) {
-		if (pair.first != "Others") {
-			TilesetCategory* cat = pair.second->getCategory(TILESET_MONSTER);
+	for (auto &[name, ts] : tilesets) {
+		if (name != "Others") {
+			TilesetCategory* cat = ts->getCategory(TILESET_MONSTER);
 			if (cat) {
 				cat->brushlist.clear();
 			}

--- a/source/materials.cpp
+++ b/source/materials.cpp
@@ -20,6 +20,7 @@
 #include "editor.h"
 #include "items.h"
 #include "monsters.h"
+#include <algorithm>
 
 #include "gui.h"
 #include "materials.h"
@@ -139,17 +140,44 @@ void Materials::createOtherTileset() {
 		}
 	}
 
+	// Clear TILESET_MONSTER categories from previous folder tilesets
+	for (auto &pair : tilesets) {
+		if (pair.first != "Others") {
+			TilesetCategory* cat = pair.second->getCategory(TILESET_MONSTER);
+			if (cat) {
+				cat->brushlist.clear();
+			}
+		}
+	}
+
 	for (MonsterMap::iterator iter = g_monsters.begin(); iter != g_monsters.end(); ++iter) {
 		MonsterType* type = iter->second;
-		if (type->in_other_tileset) {
-			others->getCategory(TILESET_MONSTER)->brushlist.push_back(type->brush);
-		} else if (type->brush == nullptr) {
+
+		if (type->brush == nullptr) {
 			type->brush = newd MonsterBrush(type);
 			g_brushes.addBrush(type->brush);
 			type->brush->flagAsVisible();
 			type->in_other_tileset = true;
+		}
 
-			others->getCategory(TILESET_MONSTER)->brushlist.push_back(type->brush);
+		// Always adds in Others
+		others->getCategory(TILESET_MONSTER)->brushlist.push_back(type->brush);
+
+		// Adds to the folder tileset if it exists
+		if (!type->folder.empty()) {
+			std::string tsName = type->folder;
+			std::replace(tsName.begin(), tsName.end(), '_', ' ');
+			tsName[0] = std::toupper(static_cast<unsigned char>(tsName[0]));
+
+			Tileset* folderTs;
+			auto it = tilesets.find(tsName);
+			if (it != tilesets.end()) {
+				folderTs = it->second;
+			} else {
+				folderTs = newd Tileset(g_brushes, tsName);
+				tilesets[tsName] = folderTs;
+			}
+			folderTs->getCategory(TILESET_MONSTER)->brushlist.push_back(type->brush);
 		}
 	}
 }

--- a/source/materials.cpp
+++ b/source/materials.cpp
@@ -169,6 +169,10 @@ void Materials::createOtherTileset() {
 			std::replace(tsName.begin(), tsName.end(), '_', ' ');
 			tsName[0] = std::toupper(static_cast<unsigned char>(tsName[0]));
 
+			if (tsName == "Others") {
+				continue;
+			}
+
 			Tileset* folderTs;
 			auto it = tilesets.find(tsName);
 			if (it != tilesets.end()) {

--- a/source/materials.cpp
+++ b/source/materials.cpp
@@ -145,7 +145,7 @@ void Materials::createOtherTileset() {
 
 	// Clear TILESET_MONSTER categories from previous folder tilesets
 	for (auto &[name, ts] : tilesets) {
-		if (name != "Others") {
+		if (name != "Others" && name != "Monsters") {
 			TilesetCategory* cat = ts->getCategory(TILESET_MONSTER);
 			if (cat) {
 				cat->brushlist.clear();

--- a/source/materials.h
+++ b/source/materials.h
@@ -51,6 +51,7 @@ protected:
 	bool unserializeTileset(pugi::xml_node node, wxArrayString &warnings);
 
 private:
+	void populateRawBrushes(Tileset* others);
 	bool modified = false;
 	Materials(const Materials &);
 	Materials &operator=(const Materials &);

--- a/source/monsters.cpp
+++ b/source/monsters.cpp
@@ -300,6 +300,31 @@ wxArrayString MonsterDatabase::getMissingMonsterNames() const {
 	return missingMonsters;
 }
 
+static std::string extractTopFolder(const wxString &filePath, const wxString &directory) {
+	wxFileName fn(filePath);
+	wxString relPath = fn.GetPath().Lower();
+	wxString dirLower = directory.Lower();
+	if (!relPath.StartsWith(dirLower)) {
+		return "";
+	}
+	relPath = relPath.Mid(dirLower.Length());
+	if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
+		relPath = relPath.Mid(1);
+	}
+	const int slash = relPath.Find('/');
+	const int backslash = relPath.Find('\\');
+	int sep = wxNOT_FOUND;
+	if (slash != wxNOT_FOUND && backslash != wxNOT_FOUND) {
+		sep = std::min(slash, backslash);
+	} else if (slash != wxNOT_FOUND) {
+		sep = slash;
+	} else if (backslash != wxNOT_FOUND) {
+		sep = backslash;
+	}
+	wxString fld = (sep == wxNOT_FOUND) ? relPath : relPath.Left(sep);
+	return fld.ToStdString();
+}
+
 bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error, wxArrayString &warnings) {
 	if (directory.IsEmpty()) {
 		return true;
@@ -334,27 +359,7 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 		MonsterType* existing = (*this)[name];
 		if (existing) {
 			if (existing->folder.empty()) {
-				wxFileName fn(filePath);
-				wxString relPath = fn.GetPath().Lower();
-				wxString dirLower = directory.Lower();
-				if (relPath.StartsWith(dirLower)) {
-					relPath = relPath.Mid(dirLower.Length());
-					if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
-						relPath = relPath.Mid(1);
-					}
-					const int slash = relPath.Find('/');
-					const int backslash = relPath.Find('\\');
-					int sep = wxNOT_FOUND;
-					if (slash != wxNOT_FOUND && backslash != wxNOT_FOUND) {
-						sep = std::min(slash, backslash);
-					} else if (slash != wxNOT_FOUND) {
-						sep = slash;
-					} else if (backslash != wxNOT_FOUND) {
-						sep = backslash;
-					}
-					wxString fld = (sep == wxNOT_FOUND) ? relPath : relPath.Left(sep);
-					existing->folder = fld.ToStdString();
-				}
+				existing->folder = extractTopFolder(filePath, directory);
 			}
 			if (!existing->missing) {
 				continue;
@@ -373,29 +378,7 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 		ct->outfit.name = name;
 		ct->standard = false;
 
-		{
-			wxFileName fn(filePath);
-			wxString relPath = fn.GetPath().Lower();
-			wxString dirLower = directory.Lower();
-			if (relPath.StartsWith(dirLower)) {
-				relPath = relPath.Mid(dirLower.Length());
-				if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
-					relPath = relPath.Mid(1);
-				}
-				const int slash = relPath.Find('/');
-				const int backslash = relPath.Find('\\');
-				int sep = wxNOT_FOUND;
-				if (slash != wxNOT_FOUND && backslash != wxNOT_FOUND) {
-					sep = std::min(slash, backslash);
-				} else if (slash != wxNOT_FOUND) {
-					sep = slash;
-				} else if (backslash != wxNOT_FOUND) {
-					sep = backslash;
-				}
-				wxString fld = (sep == wxNOT_FOUND) ? relPath : relPath.Left(sep);
-				ct->folder = fld.ToStdString();
-			}
-		}
+		ct->folder = extractTopFolder(filePath, directory);
 
 		if (!LuaParser::parseOutfit(content, ct->outfit)) {
 			delete ct;

--- a/source/monsters.cpp
+++ b/source/monsters.cpp
@@ -342,10 +342,17 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 					if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
 						relPath = relPath.Mid(1);
 					}
-					wxString fld = relPath.BeforeFirst('/');
-					if (fld.IsEmpty()) {
-						fld = relPath.BeforeFirst('\\');
+					const int slash = relPath.Find('/');
+					const int backslash = relPath.Find('\\');
+					int sep = wxNOT_FOUND;
+					if (slash != wxNOT_FOUND && backslash != wxNOT_FOUND) {
+						sep = std::min(slash, backslash);
+					} else if (slash != wxNOT_FOUND) {
+						sep = slash;
+					} else if (backslash != wxNOT_FOUND) {
+						sep = backslash;
 					}
+					wxString fld = (sep == wxNOT_FOUND) ? relPath : relPath.Left(sep);
 					existing->folder = fld.ToStdString();
 				}
 			}
@@ -375,10 +382,17 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 				if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
 					relPath = relPath.Mid(1);
 				}
-				wxString fld = relPath.BeforeFirst('/');
-				if (fld.IsEmpty()) {
-					fld = relPath.BeforeFirst('\\');
+				const int slash = relPath.Find('/');
+				const int backslash = relPath.Find('\\');
+				int sep = wxNOT_FOUND;
+				if (slash != wxNOT_FOUND && backslash != wxNOT_FOUND) {
+					sep = std::min(slash, backslash);
+				} else if (slash != wxNOT_FOUND) {
+					sep = slash;
+				} else if (backslash != wxNOT_FOUND) {
+					sep = backslash;
 				}
+				wxString fld = (sep == wxNOT_FOUND) ? relPath : relPath.Left(sep);
 				ct->folder = fld.ToStdString();
 			}
 		}

--- a/source/monsters.cpp
+++ b/source/monsters.cpp
@@ -34,6 +34,7 @@ MonsterType::MonsterType() :
 	in_other_tileset(false),
 	standard(false),
 	name(""),
+	folder(""),
 	brush(nullptr) {
 	////
 }
@@ -43,6 +44,7 @@ MonsterType::MonsterType(const MonsterType &ct) :
 	in_other_tileset(ct.in_other_tileset),
 	standard(ct.standard),
 	name(ct.name),
+	folder(ct.folder),
 	outfit(ct.outfit),
 	brush(ct.brush) {
 	////
@@ -53,6 +55,7 @@ MonsterType &MonsterType::operator=(const MonsterType &ct) {
 	in_other_tileset = ct.in_other_tileset;
 	standard = ct.standard;
 	name = ct.name;
+	folder = ct.folder;
 	outfit = ct.outfit;
 	brush = ct.brush;
 	return *this;
@@ -307,7 +310,7 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 	}
 
 	wxArrayString luaFiles;
-	wxDir::GetAllFiles(directory, &luaFiles, "*.lua", wxDIR_FILES | wxDIR_DIRS);
+	wxDir::GetAllFiles(directory, &luaFiles, "*.lua", wxDIR_FILES | wxDIR_DIRS | wxDIR_HIDDEN);
 
 	int fileCount = 0;
 	for (const auto &filePath : luaFiles) {
@@ -330,6 +333,21 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 
 		MonsterType* existing = (*this)[name];
 		if (existing) {
+			if (existing->folder.empty()) {
+				wxFileName fn(filePath);
+				wxString relPath = fn.GetPath();
+				if (relPath.StartsWith(directory)) {
+					relPath = relPath.Mid(directory.Length());
+					if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
+						relPath = relPath.Mid(1);
+					}
+					wxString fld = relPath.BeforeFirst('/');
+					if (fld.IsEmpty()) {
+						fld = relPath.BeforeFirst('\\');
+					}
+					existing->folder = fld.ToStdString();
+				}
+			}
 			if (!existing->missing) {
 				continue;
 			}
@@ -346,6 +364,22 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 		ct->name = name;
 		ct->outfit.name = name;
 		ct->standard = false;
+
+		{
+			wxFileName fn(filePath);
+			wxString relPath = fn.GetPath();
+			if (relPath.StartsWith(directory)) {
+				relPath = relPath.Mid(directory.Length());
+				if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
+					relPath = relPath.Mid(1);
+				}
+				wxString fld = relPath.BeforeFirst('/');
+				if (fld.IsEmpty()) {
+					fld = relPath.BeforeFirst('\\');
+				}
+				ct->folder = fld.ToStdString();
+			}
+		}
 
 		if (!LuaParser::parseOutfit(content, ct->outfit)) {
 			delete ct;

--- a/source/monsters.cpp
+++ b/source/monsters.cpp
@@ -335,9 +335,10 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 		if (existing) {
 			if (existing->folder.empty()) {
 				wxFileName fn(filePath);
-				wxString relPath = fn.GetPath();
-				if (relPath.StartsWith(directory)) {
-					relPath = relPath.Mid(directory.Length());
+				wxString relPath = fn.GetPath().Lower();
+				wxString dirLower = directory.Lower();
+				if (relPath.StartsWith(dirLower)) {
+					relPath = relPath.Mid(dirLower.Length());
 					if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
 						relPath = relPath.Mid(1);
 					}
@@ -367,9 +368,10 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 
 		{
 			wxFileName fn(filePath);
-			wxString relPath = fn.GetPath();
-			if (relPath.StartsWith(directory)) {
-				relPath = relPath.Mid(directory.Length());
+			wxString relPath = fn.GetPath().Lower();
+			wxString dirLower = directory.Lower();
+			if (relPath.StartsWith(dirLower)) {
+				relPath = relPath.Mid(dirLower.Length());
 				if (!relPath.IsEmpty() && (relPath[0] == '/' || relPath[0] == '\\')) {
 					relPath = relPath.Mid(1);
 				}

--- a/source/monsters.h
+++ b/source/monsters.h
@@ -71,6 +71,7 @@ public:
 	bool in_other_tileset;
 	bool standard;
 	std::string name;
+	std::string folder;
 	Outfit outfit;
 	MonsterBrush* brush;
 

--- a/source/npcs.cpp
+++ b/source/npcs.cpp
@@ -257,7 +257,7 @@ bool NpcDatabase::loadFromLuaDir(const wxString &directory, wxString &error, wxA
 	}
 
 	wxArrayString luaFiles;
-	wxDir::GetAllFiles(directory, &luaFiles, "*.lua", wxDIR_FILES | wxDIR_DIRS);
+	wxDir::GetAllFiles(directory, &luaFiles, "*.lua", wxDIR_FILES | wxDIR_DIRS | wxDIR_HIDDEN);
 
 	int fileCount = 0;
 	for (const auto &filePath : luaFiles) {

--- a/source/palette_brushlist.cpp
+++ b/source/palette_brushlist.cpp
@@ -819,6 +819,9 @@ void BrushListBox::OnDrawItem(wxDC &dc, const wxRect &rect, size_t index) const 
 		} else if (npcType) {
 			lookType = npcType->outfit.lookType;
 		}
+		if (lookType == 0) {
+			lookType = 197; // This looktype is a tribute to our beloved Carl-bot from OpenTibiaBR Discord.
+		}
 		auto creatureSprite = g_gui.gfx.getCreatureSprite(lookType);
 		if (creatureSprite) {
 			creatureSprite->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());

--- a/source/palette_monster.cpp
+++ b/source/palette_monster.cpp
@@ -25,6 +25,8 @@
 #include "spawn_monster_brush.h"
 #include "materials.h"
 
+#include <algorithm>
+
 // ============================================================================
 // Monster palette
 
@@ -198,10 +200,10 @@ void MonsterPalettePanel::OnUpdate() {
 	TilesetCategory* allCategory = nullptr;
 
 	for (auto iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
-		TilesetCategory* tsc = const_cast<TilesetCategory*>(iter->second->getCategory(TILESET_MONSTER));
+		auto tsc = iter->second->getCategory(TILESET_MONSTER);
 		if (iter->second->name == "Others") {
 			if (!tsc) {
-				Tileset* ts = const_cast<Tileset*>(iter->second);
+				auto ts = iter->second;
 				tsc = ts->getCategory(TILESET_MONSTER);
 			}
 			allCategory = tsc;
@@ -211,7 +213,7 @@ void MonsterPalettePanel::OnUpdate() {
 	}
 
 	// Sort alphabetically
-	std::sort(entries.begin(), entries.end(), [](const auto &a, const auto &b) {
+	std::ranges::sort(entries, [](const auto &a, const auto &b) {
 		return a.first.CmpNoCase(b.first) < 0;
 	});
 

--- a/source/palette_monster.cpp
+++ b/source/palette_monster.cpp
@@ -193,16 +193,39 @@ void MonsterPalettePanel::OnUpdate() {
 	tileset_choice->Clear();
 	g_materials.createOtherTileset();
 
-	for (TilesetContainer::const_iterator iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
-		const TilesetCategory* tsc = iter->second->getCategory(TILESET_MONSTER);
-		if (tsc && tsc->size() > 0) {
-			tileset_choice->Append(wxstr(iter->second->name), const_cast<TilesetCategory*>(tsc));
-		} else if (iter->second->name == "Others") {
-			Tileset* ts = const_cast<Tileset*>(iter->second);
-			TilesetCategory* rtsc = ts->getCategory(TILESET_MONSTER);
-			tileset_choice->Append(wxstr(ts->name), rtsc);
+	// Collect entries with TILESET_MONSTER
+	std::vector<std::pair<wxString, TilesetCategory*>> entries;
+	TilesetCategory* allCategory = nullptr;
+
+	for (auto iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
+		TilesetCategory* tsc = const_cast<TilesetCategory*>(iter->second->getCategory(TILESET_MONSTER));
+		if (iter->second->name == "Others") {
+			if (!tsc) {
+				Tileset* ts = const_cast<Tileset*>(iter->second);
+				tsc = ts->getCategory(TILESET_MONSTER);
+			}
+			allCategory = tsc;
+		} else if (tsc && tsc->size() > 0) {
+			entries.push_back({ wxstr(iter->second->name), tsc });
 		}
 	}
+
+	// Sort alphabetically
+	std::sort(entries.begin(), entries.end(), [](const auto &a, const auto &b) {
+		return a.first.CmpNoCase(b.first) < 0;
+	});
+
+	// "All" first
+	if (allCategory) {
+		tileset_choice->Append("All", allCategory);
+	}
+
+	// Then the rest alphabetically
+	for (auto &entry : entries) {
+		tileset_choice->Append(entry.first, entry.second);
+	}
+
+	SelectTileset(0);
 	SelectTileset(0);
 }
 

--- a/source/palette_monster.cpp
+++ b/source/palette_monster.cpp
@@ -226,7 +226,6 @@ void MonsterPalettePanel::OnUpdate() {
 	}
 
 	SelectTileset(0);
-	SelectTileset(0);
 }
 
 void MonsterPalettePanel::OnUpdateBrushSize(BrushShape shape, int size) {


### PR DESCRIPTION
## Summary  
  
This PR introduces dynamic folder-based categorization for the monster palette,  
improves creature rendering for lookType 0, and fixes hidden file loading on  
Linux/macOS.  
  
### Monster palette organized by folder  
  
Monsters loaded from Lua are now grouped in the palette dropdown based on their  
subfolder in the monster directory (e.g., `amphibics/`, `demons/`, `undeads/`).  
Folder names are read dynamically at runtime — nothing is hardcoded.  
  
- Folder names with underscores are displayed with spaces  
  (e.g., `event_creatures` → "Event creatures")  
- The "Others" entry is renamed to "All" and always appears first  
- Remaining categories are sorted alphabetically  
- Monsters with `lookType = 0` now render using lookType 197 (Tortoise)  
  instead of being invisible  
  
### Fix hidden file loading on Linux/macOS  
  
Added `wxDIR_HIDDEN` flag to `wxDir::GetAllFiles` in both `npcs.cpp` and  
`monsters.cpp`. Files starting with `.` (e.g., `....lua` for an NPC named `...`)  
are considered hidden on Unix and were silently skipped.  
  
## Changes  
  
- `source/monsters.h` — Added `std::string folder` field to `MonsterType`  
- `source/monsters.cpp` — Extract subfolder name from file path during Lua  
  loading; updated constructors and assignment operator; added `wxDIR_HIDDEN`  
- `source/materials.cpp` — Create per-folder tilesets dynamically for  
  `TILESET_MONSTER` in `createOtherTileset()`; replace underscores with spaces  
  in folder display names  
- `source/palette_monster.cpp` — Display "All" instead of "Others"; sort  
  categories alphabetically with "All" always first  
- `source/map_drawer.cpp` — Render lookType 197 (Tortoise) as fallback when  
  `lookType == 0` in `BlitCreature`  
- `source/palette_brushlist.cpp` — Render lookType 197 (Tortoise) as fallback  
  when `lookType == 0` in palette list drawing  
- `source/npcs.cpp` — Added `wxDIR_HIDDEN` flag to `wxDir::GetAllFiles`  
  
## How to Test  
  
### Monster palette folders  
1. Set the monsters Lua directory to Canary's  
   `data-otservbr-global/monster/` (contains subfolders like `amphibics/`,  
   `demons/`, `undeads/`, etc.)  
2. Open or create a map  
3. Open the monster palette — the dropdown should show "All" first, followed  
   by folder-based categories sorted alphabetically (e.g., "Amphibics",  
   "Demons", "Event creatures", "Wild magics")  
4. Each category should contain only the monsters from that subfolder  
5. "All" should contain every monster  
6. Folder names with underscores should appear with spaces  
  
### lookType 0 fallback  
1. Place a monster that has `lookType = 0` on the map  
2. It should render as a Tortoise (lookType 197) instead of being invisible  
3. The same fallback should appear in the palette list  
  
### Hidden file fix (NPC `...`)  
1. Ensure the NPC Lua directory contains `....lua` (NPC named `...`)  
2. Place a spawn with the NPC `...` on the map  
3. The NPC should load correctly and not appear as missing  
4. Verify on Linux — this was the affected platform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fallback creature appearance so a proper default sprite is shown when an outfit lacks a valid look.

* **New Features**
  * Monsters can be organized by folder into palette categories; tilesets now include an "All" option and are sorted alphabetically.
  * Monster entries are consistently included in the "Others" category and duplicated into derived folder tilesets.

* **Chores**
  * File scanning now includes hidden files/directories when loading monsters and NPCs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->