### PR TITLE
fix: resolve zoom discard and NumberTextCtrl format mismatch

### DIFF
--- a/source/gl_renderer.cpp
+++ b/source/gl_renderer.cpp
@@ -814,24 +814,47 @@ void GLRenderer::flushCommands() {
 		}
 
 		current_texture = cmd.state.textureId;
-		if (cmd.isQuadBatch) {
-			auto base = (GLuint)batch.size();
-			batch.insert(batch.end(), cmd.vertices.begin(), cmd.vertices.end());
-			for (size_t q = 0; q < cmd.vertices.size(); q += 4) {
-				GLuint b = base + (GLuint)q;
-				indexBatch.push_back(b);
-				indexBatch.push_back(b + 1);
-				indexBatch.push_back(b + 2);
-				indexBatch.push_back(b);
-				indexBatch.push_back(b + 2);
-				indexBatch.push_back(b + 3);
+
+		// Processes command vertices in slices that fit into the buffer
+		const auto &verts = cmd.vertices;
+		size_t vertStep = cmd.isQuadBatch ? 4 : 3;
+		size_t idxPerStep = cmd.isQuadBatch ? 6 : 3;
+		size_t i = 0;
+
+		while (i < verts.size()) {
+			size_t remaining = verts.size() - i;
+			size_t batchFree = STREAM_VBO_CAPACITY - batch.size();
+			// Number of vertices that still fit (rounded to a multiple of vertStep)
+			size_t canTake = (batchFree / vertStep) * vertStep;
+
+			if (canTake == 0) {
+				flushBatch();
+				canTake = (STREAM_VBO_CAPACITY / vertStep) * vertStep;
 			}
-		} else {
-			auto base = (GLuint)batch.size();
-			batch.insert(batch.end(), cmd.vertices.begin(), cmd.vertices.end());
-			for (GLuint i = 0; i < (GLuint)cmd.vertices.size(); ++i) {
-				indexBatch.push_back(base + i);
+
+			size_t take = std::min(remaining, canTake);
+
+			if (cmd.isQuadBatch) {
+				auto base = (GLuint)batch.size();
+				batch.insert(batch.end(), verts.begin() + i, verts.begin() + i + take);
+				for (size_t q = 0; q < take; q += 4) {
+					GLuint b = base + (GLuint)q;
+					indexBatch.push_back(b);
+					indexBatch.push_back(b + 1);
+					indexBatch.push_back(b + 2);
+					indexBatch.push_back(b);
+					indexBatch.push_back(b + 2);
+					indexBatch.push_back(b + 3);
+				}
+			} else {
+				auto base = (GLuint)batch.size();
+				batch.insert(batch.end(), verts.begin() + i, verts.begin() + i + take);
+				for (GLuint j = 0; j < (GLuint)take; ++j) {
+					indexBatch.push_back(base + j);
+				}
 			}
+
+			i += take;
 		}
 	}
 	commandList.clear();

--- a/source/numbertextctrl.cpp
+++ b/source/numbertextctrl.cpp
@@ -52,7 +52,7 @@ void NumberTextCtrl::OnTextEnter(wxCommandEvent &evt) {
 
 void NumberTextCtrl::SetIntValue(long value) {
 	// Will generate events
-	SetValue(wxString::Format("%i", value));
+	SetValue(wxString::Format("%ld", value));
 }
 
 long NumberTextCtrl::GetIntValue() {
@@ -91,11 +91,11 @@ void NumberTextCtrl::CheckRange() {
 		}
 
 		newText.clear();
-		newText = wxString::Format("%i", v);
+		newText = wxString::Format("%ld", v);
 		lastValue = v;
 	} else {
 		newText.clear();
-		newText = wxString::Format("%i", lastValue);
+		newText = wxString::Format("%ld", lastValue);
 	}
 
 	// Check if there was any change

--- a/source/numbertextctrl.h
+++ b/source/numbertextctrl.h
@@ -23,11 +23,11 @@ class NumberTextCtrl : public wxTextCtrl {
 public:
 	// Please avoid using wxTextValidator rather than wxFILTER_NONE, because it prevents the event clipboard paste to be fired.
 	NumberTextCtrl(wxWindow* parent, wxWindowID id, long value, long minValue, long maxValue, const wxPoint &pos, const wxSize &sz, long style, const wxString &name) :
-		wxTextCtrl(parent, id, wxString::Format("%i", value), pos, sz, style, wxTextValidator(wxFILTER_NONE), name),
+		wxTextCtrl(parent, id, wxString::Format("%ld", value), pos, sz, style, wxTextValidator(wxFILTER_NONE), name),
 		minValue(minValue), maxValue(maxValue), lastValue(value) { }
 	// Please avoid using wxTextValidator rather than wxFILTER_NONE, because it prevents the event clipboard paste to be fired.
 	NumberTextCtrl(wxWindow* parent, wxWindowID id, long value, long minValue, long maxValue, long style, const wxString &name, const wxPoint &pos, const wxSize &sz) :
-		wxTextCtrl(parent, id, wxString::Format("%i", value), pos, sz, style, wxTextValidator(wxFILTER_NONE), name),
+		wxTextCtrl(parent, id, wxString::Format("%ld", value), pos, sz, style, wxTextValidator(wxFILTER_NONE), name),
 		minValue(minValue), maxValue(maxValue), lastValue(value) { }
 	~NumberTextCtrl() = default;
 


### PR DESCRIPTION
## Summary

This PR fixes two unrelated regressions affecting rendering stability and wxWidgets runtime validation.

### Fixes

- Prevents silent geometry discard in the GL renderer when zooming out by flushing oversized VBO work in slices that fit the streaming buffers.
- Fixes `wxString::Format()` type mismatches in `NumberTextCtrl` by using the correct format specifier for `long` values.

## Details

### GL renderer batch slicing

Large merged draw commands could exceed the streaming VBO capacity during zoomed-out rendering. When that happened, the batch was cleared without being drawn, causing silent visual loss.

This change processes command vertices in buffer-sized slices while preserving draw order and batch state, avoiding overflow and preventing dropped geometry.

### NumberTextCtrl format fix

`NumberTextCtrl` stores and formats numeric values as `long`, but used `%i` in `wxString::Format()`, which expects `int`. With newer wxWidgets builds, this triggers runtime format validation asserts.

This change replaces those format strings with the correct `long` specifier, resolving the assertion on Linux and keeping behavior correct across platforms.

## Impact

- Fixes missing rendered content when zooming out in the modern GL path.
- Fixes wxWidgets runtime asserts triggered by position toolbar number fields.
- Keeps behavior unchanged aside from the corrected failure cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced numeric input handling to properly support and format larger integer values
* Optimized graphics rendering performance through improved batch processing efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->