### PR TITLE
feat: Brush Editor - introduce a unified in-app tool for editing borders, grounds, and walls

### DIFF
--- a/data/menubar.xml
+++ b/data/menubar.xml
@@ -52,16 +52,6 @@
             <item name="Ra$ndomize Selection" action="RANDOMIZE_SELECTION" help="Randomizes the ground tiles of the selected area."/>
             <item name="$Randomize Map" action="RANDOMIZE_MAP" help="Randomizes all tiles of the entire map."/>
         </menu>
-        <menu name="$Tools">
-            <item name="$Remove Items by ID..." action="MAP_REMOVE_ITEMS" help="Removes all items with the selected ID from the map."/>
-            <item name="Remove $all corpses..." action="MAP_REMOVE_CORPSES" help="Removes all corpses from the map."/>
-            <item name="Remove all $unreachable tiles..." action="MAP_REMOVE_UNREACHABLE_TILES" help="Removes all tiles that cannot be reached (or seen) by the player from the map."/>
-            <item name="Remove all $duplicated items..." action="REMOVE_ON_MAP_DUPLICATED_ITEMS" help="Removes all items duplicated on map."/>
-            <item name="Remove empty monsters spawns" action="MAP_REMOVE_EMPTY_MONSTERS_SPAWNS" help="Removes all empty monsters spawns from the map."/>
-            <item name="Remove empty npcs spawns" action="MAP_REMOVE_EMPTY_NPCS_SPAWNS" help="Removes all empty npcs spawns from the map."/>
-            <item name="$Clear Invalid Houses" action="CLEAR_INVALID_HOUSES" help="Clears house tiles not belonging to any house."/>
-            <item name="Clear $Modified State" action="CLEAR_MODIFIED_STATE" help="Clears the modified state from all tiles."/>
-        </menu>
         <separator/>
         <item name="Go To P$revious Position" hotkey="P" action="GOTO_PREVIOUS_POSITION" help="Go to the previous screen center position."/>
         <item name="$Go To Position..." hotkey="Ctrl+G" action="GOTO_POSITION" help="Go to a specific XYZ position."/>
@@ -72,14 +62,30 @@
         <item name="C$opy" hotkey="Ctrl+C" action="COPY" help="Copy a part of the map."/>
         <item name="$Paste" hotkey="Ctrl+V" action="PASTE" help="Paste a part of the map."/>
     </menu>
-    <menu name="$Map">
-        <item name="Edit $Towns" hotkey="Ctrl+T" action="EDIT_TOWNS" help="Edit towns."/>
-        <item name="Edit $Items" hotkey="Ctrl+I" action="EDIT_ITEMS" help="Edit items."/>
-        <item name="Edit $Monsters" action="EDIT_MONSTERS" help="Edit monsters."/>
-        <separator/>
-        <item name="$Cleanup..." action="MAP_CLEANUP" help="Removes all unknown items from the map."/>
-        <item name="$Properties..." hotkey="Ctrl+P" action="MAP_PROPERTIES" help="Show and change the map properties."/>
-        <item name="$Statistics" hotkey="F8" action="MAP_STATISTICS" help="Show map statistics."/>
+    <menu name="$World">  
+        <item name="Edit $Towns" hotkey="Ctrl+T" action="EDIT_TOWNS" help="Edit towns."/>  
+        <separator/>  
+        <menu name="$Items">  
+            <item name="$Remove Items by ID..." action="MAP_REMOVE_ITEMS" help="Removes all items with the selected ID from the map."/>  
+            <item name="Remove all $duplicated items..." action="REMOVE_ON_MAP_DUPLICATED_ITEMS" help="Removes all items duplicated on map."/>  
+        </menu>  
+        <menu name="$NPCs">  
+            <item name="Remove empty npcs spawns" action="MAP_REMOVE_EMPTY_NPCS_SPAWNS" help="Removes all empty npcs spawns from the map."/>  
+        </menu>  
+        <menu name="$Monsters">  
+            <item name="Remove empty monsters spawns" action="MAP_REMOVE_EMPTY_MONSTERS_SPAWNS" help="Removes all empty monsters spawns from the map."/>  
+        </menu>  
+        <menu name="$Houses">  
+            <item name="$Clear Invalid Houses" action="CLEAR_INVALID_HOUSES" help="Clears house tiles not belonging to any house."/>  
+        </menu>  
+        <separator/>  
+        <item name="Remove $all corpses..." action="MAP_REMOVE_CORPSES" help="Removes all corpses from the map."/>  
+        <item name="Remove all $unreachable tiles..." action="MAP_REMOVE_UNREACHABLE_TILES" help="Removes all tiles that cannot be reached (or seen) by the player from the map."/>  
+        <item name="Clear $Modified State" action="CLEAR_MODIFIED_STATE" help="Clears the modified state from all tiles."/>  
+        <separator/>  
+        <item name="$Cleanup..." action="MAP_CLEANUP" help="Removes all unknown items from the map."/>  
+        <item name="$Properties..." hotkey="Ctrl+P" action="MAP_PROPERTIES" help="Show and change the map properties."/>  
+        <item name="$Statistics" hotkey="F8" action="MAP_STATISTICS" help="Show map statistics."/>  
     </menu>
     <menu name="$Select">
         <item name="Replace Items on Selection" action="REPLACE_ON_SELECTION_ITEMS" help="Replace items on selected area."/>
@@ -172,6 +178,9 @@
         <item name="$Waypoint Palette" hotkey="W" action="SELECT_WAYPOINT" help="Select the Waypoint palette."/>
         <item name="$Zones Palette" hotkey="Z" action="SELECT_ZONES" help="Select the Zones palette."/>
         <item name="$RAW Palette" hotkey="R" action="SELECT_RAW" help="Select the RAW palette."/>
+    </menu>
+    <menu name="$Tools">
+        <item name="$Brush Editor" action="BRUSH_EDITOR" help="Visual editor for brushs and border patterns."/>
     </menu>
     <!--
     <menu name="$Live">

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -176,6 +176,8 @@ target_sources(
           artprovider.cpp
           basemap.cpp
           brush_editor_window.cpp
+          brush_editor_model.cpp
+          brush_editor_catalog_service.cpp
           bitmap_to_map_window.cpp
           bitmap_to_map_converter.cpp
           brush.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -175,6 +175,7 @@ target_sources(
           application.cpp
           artprovider.cpp
           basemap.cpp
+          brush_editor_window.cpp
           bitmap_to_map_window.cpp
           bitmap_to_map_converter.cpp
           brush.cpp

--- a/source/brush_browser_grid_panel.h
+++ b/source/brush_browser_grid_panel.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <wx/scrolwin.h>
+#include <wx/dcbuffer.h>
+#include <wx/event.h>
+#include <wx/string.h>
+
+#include <vector>
+
+#include "gui.h"
+#include "items.h"
+#include "graphics.h"
+
+class BrushBrowserGridPanel : public wxScrolledWindow {
+public:
+    struct Entry {
+        wxString label;
+        wxString key;
+        uint16_t previewItemId = 0;
+    };
+
+    BrushBrowserGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY) :
+        wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxVSCROLL | wxBORDER_NONE)
+    {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetScrollRate(0, m_cellSize + m_padding);
+
+        Bind(wxEVT_PAINT, &BrushBrowserGridPanel::OnPaint, this);
+        Bind(wxEVT_LEFT_UP, &BrushBrowserGridPanel::OnLeftUp, this);
+        Bind(wxEVT_SIZE, &BrushBrowserGridPanel::OnSize, this);
+    }
+
+    void SetEntries(std::vector<Entry> entries) {
+        m_entries = std::move(entries);
+        if (m_selected >= (int)m_entries.size()) {
+            m_selected = -1;
+        }
+        RecalculateLayout();
+        Refresh();
+    }
+
+    void SetSelectionByKey(const wxString& key) {
+        m_selected = -1;
+        if (!key.IsEmpty()) {
+            for (size_t i = 0; i < m_entries.size(); ++i) {
+                if (m_entries[i].key == key) {
+                    m_selected = (int)i;
+                    break;
+                }
+            }
+        }
+        Refresh();
+    }
+
+private:
+    std::vector<Entry> m_entries;
+    int m_cellSize = 32;
+    int m_padding = 2;
+    int m_cols = 1;
+    int m_rows = 0;
+    int m_selected = -1;
+
+    void RecalculateLayout() {
+        int w, h;
+        GetClientSize(&w, &h);
+        if (w < m_cellSize) w = m_cellSize;
+
+        m_cols = (w - m_padding) / (m_cellSize + m_padding);
+        if (m_cols < 1) m_cols = 1;
+        m_rows = (m_entries.size() + m_cols - 1) / m_cols;
+
+        int unitY = m_cellSize + m_padding;
+        SetVirtualSize(m_cols * (m_cellSize + m_padding) + m_padding, m_rows * unitY + m_padding);
+        SetScrollRate(0, unitY);
+    }
+
+    int HitTest(const wxPoint& pt) const {
+        int col = (pt.x - m_padding) / (m_cellSize + m_padding);
+        int row = (pt.y - m_padding) / (m_cellSize + m_padding);
+
+        if (col >= 0 && col < m_cols && row >= 0) {
+            int index = row * m_cols + col;
+            if (index >= 0 && index < (int)m_entries.size()) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    void OnSize(wxSizeEvent& event) {
+        RecalculateLayout();
+        event.Skip();
+    }
+
+    void OnPaint(wxPaintEvent&) {
+        wxAutoBufferedPaintDC dc(this);
+        DoPrepareDC(dc);
+
+        dc.SetBackground(wxBrush(wxColour(0, 0, 0)));
+        dc.Clear();
+
+        int startUnitX, startUnitY;
+        GetViewStart(&startUnitX, &startUnitY);
+
+        int clientW, clientH;
+        GetClientSize(&clientW, &clientH);
+
+        int unitY = m_cellSize + m_padding;
+        int startRow = startUnitY;
+        int endRow = startRow + (clientH / unitY) + 2;
+        if (startRow < 0) startRow = 0;
+
+        int startIndex = startRow * m_cols;
+        int endIndex = endRow * m_cols;
+        if (endIndex > (int)m_entries.size()) endIndex = (int)m_entries.size();
+
+        for (int i = startIndex; i < endIndex; ++i) {
+            int col = i % m_cols;
+            int row = i / m_cols;
+            int x = m_padding + col * (m_cellSize + m_padding);
+            int y = m_padding + row * (m_cellSize + m_padding);
+
+            wxRect rect(x, y, m_cellSize, m_cellSize);
+
+            if (i == m_selected) {
+                dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
+                dc.SetBrush(*wxTRANSPARENT_BRUSH);
+                dc.DrawRectangle(rect);
+            }
+
+            uint16_t itemId = m_entries[i].previewItemId;
+            if (itemId > 0) {
+                const ItemType& type = g_items.getItemType(itemId);
+                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+                if (sprite) {
+                    sprite->DrawTo(&dc, SPRITE_SIZE_32x32, x, y, m_cellSize, m_cellSize);
+                }
+            }
+        }
+    }
+
+    void OnLeftUp(wxMouseEvent& event) {
+        wxPoint pos = event.GetPosition();
+        CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
+
+        int index = HitTest(pos);
+        if (index >= 0 && index < (int)m_entries.size()) {
+            m_selected = index;
+            Refresh();
+
+            wxCommandEvent evt(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
+            evt.SetEventObject(this);
+            evt.SetString(m_entries[index].key);
+            wxPostEvent(GetParent(), evt);
+        }
+    }
+};

--- a/source/brush_editor_catalog_service.cpp
+++ b/source/brush_editor_catalog_service.cpp
@@ -1,0 +1,537 @@
+//////////////////////////////////////////////////////////////////////
+// brush_editor_catalog_service.cpp - Read-only catalog builder
+//////////////////////////////////////////////////////////////////////
+
+#include "main.h"
+
+#include "brush_editor_catalog_service.h"
+#include "brush.h"
+#include "items.h"
+#include "materials.h"
+
+namespace {
+wxString CategoryTypeToLabel(TilesetCategoryType type) {
+	switch (type) {
+		case TILESET_TERRAIN:
+			return "Terrain";
+		case TILESET_MONSTER:
+			return "Monster";
+		case TILESET_NPC:
+			return "NPC";
+		case TILESET_DOODAD:
+			return "Doodad";
+		case TILESET_ITEM:
+			return "Item";
+		case TILESET_RAW:
+			return "Raw";
+		case TILESET_HOUSE:
+			return "House";
+		case TILESET_WAYPOINT:
+			return "Waypoint";
+		case TILESET_ZONES:
+			return "Zone";
+		case TILESET_UNKNOWN:
+		default:
+			return "Unknown";
+	}
+}
+
+wxString MakePaletteName(const wxString &tilesetName, TilesetCategoryType categoryType) {
+	return tilesetName + " [" + CategoryTypeToLabel(categoryType) + "]";
+}
+
+bool HasMembership(const BrushEditorBrushDefinition &definition, const wxString &tilesetName, TilesetCategoryType categoryType) {
+	for (const BrushEditorPaletteMembership &membership : definition.memberships) {
+		if (membership.tilesetName == tilesetName && membership.categoryType == categoryType) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void AddMembership(BrushEditorBrushDefinition &definition, const wxString &tilesetName, TilesetCategoryType categoryType, int orderHint) {
+	if (tilesetName.IsEmpty() || categoryType == TILESET_UNKNOWN) {
+		return;
+	}
+
+	if (HasMembership(definition, tilesetName, categoryType)) {
+		return;
+	}
+
+	BrushEditorPaletteMembership membership;
+	membership.tilesetName = tilesetName;
+	membership.categoryType = categoryType;
+	membership.orderHint = orderHint;
+	definition.memberships.push_back(membership);
+}
+
+void AddStorageLocation(BrushEditorBrushDefinition &definition, const wxString &filePath, const wxString &elementName, const wxString &logicalId) {
+	for (const BrushEditorStorageLocation &location : definition.storageLocations) {
+		if (location.filePath == filePath && location.xmlElementName == elementName && location.logicalId == logicalId) {
+			return;
+		}
+	}
+
+	BrushEditorStorageLocation location;
+	location.filePath = filePath;
+	location.xmlElementName = elementName;
+	location.logicalId = logicalId;
+	definition.storageLocations.push_back(location);
+}
+
+BrushEditorBrushKind InferBrushKind(Brush* brush, TilesetCategoryType categoryType) {
+	if (!brush) {
+		return BrushEditorBrushKind::Unknown;
+	}
+
+	if (brush->isGround()) {
+		return BrushEditorBrushKind::Ground;
+	}
+	if (brush->isWall()) {
+		return BrushEditorBrushKind::Wall;
+	}
+	if (brush->isRaw()) {
+		return BrushEditorBrushKind::Raw;
+	}
+	if (brush->isDoodad()) {
+		return BrushEditorBrushKind::Doodad;
+	}
+	if (brush->isMonster() || brush->isNpc()) {
+		return BrushEditorBrushKind::Creature;
+	}
+	if (brush->isSpawnMonster() || brush->isSpawnNpc()) {
+		return BrushEditorBrushKind::Spawn;
+	}
+	if (brush->isHouse() || brush->isHouseExit()) {
+		return BrushEditorBrushKind::House;
+	}
+	if (brush->isWaypoint()) {
+		return BrushEditorBrushKind::Waypoint;
+	}
+	if (brush->isZone() || brush->isFlag()) {
+		return BrushEditorBrushKind::Zone;
+	}
+
+	switch (categoryType) {
+		case TILESET_TERRAIN:
+			return BrushEditorBrushKind::Ground;
+		case TILESET_DOODAD:
+			return BrushEditorBrushKind::Doodad;
+		case TILESET_ITEM:
+			return BrushEditorBrushKind::Item;
+		case TILESET_RAW:
+			return BrushEditorBrushKind::Raw;
+		case TILESET_MONSTER:
+		case TILESET_NPC:
+			return BrushEditorBrushKind::Creature;
+		case TILESET_HOUSE:
+			return BrushEditorBrushKind::House;
+		case TILESET_WAYPOINT:
+			return BrushEditorBrushKind::Waypoint;
+		case TILESET_ZONES:
+			return BrushEditorBrushKind::Zone;
+		case TILESET_UNKNOWN:
+		default:
+			return BrushEditorBrushKind::Unknown;
+	}
+}
+
+uint16_t GetPreviewItemId(Brush* brush) {
+	if (!brush) {
+		return 0;
+	}
+
+	const int lookId = brush->getLookID();
+	if (lookId > 0 && lookId <= std::numeric_limits<uint16_t>::max()) {
+		return static_cast<uint16_t>(lookId);
+	}
+
+	const uint32_t brushId = brush->getID();
+	if (brushId > 0 && brushId <= std::numeric_limits<uint16_t>::max()) {
+		return static_cast<uint16_t>(brushId);
+	}
+
+	return 0;
+}
+
+void ApplyCapabilitiesForKind(BrushEditorBrushDefinition &definition) {
+	definition.AddCapability(BRUSH_CAP_GENERAL);
+
+	if (!definition.memberships.empty()) {
+		definition.AddCapability(BRUSH_CAP_PALETTES);
+	}
+
+	switch (definition.kind) {
+		case BrushEditorBrushKind::Ground:
+			definition.AddCapability(BRUSH_CAP_VARIATIONS);
+			definition.AddCapability(BRUSH_CAP_BORDERS);
+			definition.AddCapability(BRUSH_CAP_FLAGS);
+			break;
+		case BrushEditorBrushKind::Wall:
+			definition.AddCapability(BRUSH_CAP_STRUCTURE);
+			definition.AddCapability(BRUSH_CAP_FLAGS);
+			break;
+		case BrushEditorBrushKind::Border:
+			definition.AddCapability(BRUSH_CAP_FLAGS);
+			break;
+		default:
+			break;
+	}
+}
+
+wxString BuildBrushXmlPath(const wxString &dataDirectory, const wxString &fileName) {
+	return dataDirectory + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + fileName;
+}
+
+wxString BuildBorderXmlPath(const wxString &dataDirectory) {
+	return dataDirectory + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+}
+
+bool LoadDocumentIfExists(const wxString &filePath, pugi::xml_document &doc, wxArrayString &warnings) {
+	if (!wxFileExists(filePath)) {
+		return false;
+	}
+
+	const pugi::xml_parse_result result = doc.load_file(nstr(filePath).c_str());
+	if (!result) {
+		warnings.push_back("Failed to parse " + filePath);
+		return false;
+	}
+
+	return true;
+}
+
+void LoadPaletteMembershipsFromMaterials(BrushEditorCatalog &catalog) {
+	for (const auto &tilesetEntry : g_materials.tilesets) {
+		const wxString tilesetName = wxString(tilesetEntry.first);
+		Tileset* const tileset = tilesetEntry.second;
+		if (!tileset) {
+			continue;
+		}
+
+		for (TilesetCategory* category : tileset->categories) {
+			if (!category || category->brushlist.empty()) {
+				continue;
+			}
+
+			const wxString paletteName = MakePaletteName(tilesetName, category->getType());
+			BrushEditorPaletteDefinition &palette = catalog.GetOrCreatePalette(paletteName);
+			palette.categoryType = category->getType();
+			palette.builtin = true;
+
+			for (size_t index = 0; index < category->brushlist.size(); ++index) {
+				Brush* brush = category->brushlist[index];
+				if (!brush) {
+					continue;
+				}
+
+				const wxString brushName = wxstr(brush->getName()).Trim(false).Trim(true);
+				if (brushName.IsEmpty()) {
+					continue;
+				}
+
+				BrushEditorBrushDefinition &definition = catalog.GetOrCreateBrush(brushName);
+				if (definition.kind == BrushEditorBrushKind::Unknown) {
+					definition.kind = InferBrushKind(brush, category->getType());
+				}
+
+				if (definition.previewItemId == 0) {
+					definition.previewItemId = GetPreviewItemId(brush);
+				}
+				if (definition.serverLookId == 0) {
+					definition.serverLookId = definition.previewItemId;
+				}
+
+				AddMembership(definition, tilesetName, category->getType(), static_cast<int>(index));
+				palette.AddBrush(brushName);
+				ApplyCapabilitiesForKind(definition);
+			}
+		}
+	}
+}
+
+void LoadGroundBrushes(BrushEditorCatalog &catalog, const wxString &dataDirectory, wxArrayString &warnings) {
+	const wxString groundsFile = BuildBrushXmlPath(dataDirectory, "grounds.xml");
+
+	pugi::xml_document doc;
+	if (!LoadDocumentIfExists(groundsFile, doc, warnings)) {
+		return;
+	}
+
+	const pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		warnings.push_back("grounds.xml: missing <materials> root");
+		return;
+	}
+
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		const wxString brushName = wxString(brushNode.attribute("name").as_string());
+		if (brushName.IsEmpty()) {
+			continue;
+		}
+
+		const wxString typeValue = wxString(brushNode.attribute("type").as_string());
+		BrushEditorBrushDefinition &definition = catalog.GetOrCreateBrush(brushName);
+
+		if (!typeValue.IsEmpty()) {
+			const BrushEditorBrushKind parsedKind = BrushEditorBrushKindFromString(typeValue);
+			if (parsedKind != BrushEditorBrushKind::Unknown) {
+				definition.kind = parsedKind;
+			}
+		}
+		if (definition.kind == BrushEditorBrushKind::Unknown) {
+			definition.kind = BrushEditorBrushKind::Ground;
+		}
+
+		definition.zOrder = brushNode.attribute("z-order").as_int(definition.zOrder);
+		definition.optional = brushNode.child("optional");
+		definition.ground = (definition.kind == BrushEditorBrushKind::Ground);
+
+		uint16_t mainLookId = 0;
+		if (pugi::xml_attribute attr = brushNode.attribute("server_lookid")) {
+			mainLookId = attr.as_uint();
+		} else if (pugi::xml_attribute attr = brushNode.attribute("lookid")) {
+			mainLookId = attr.as_uint();
+		}
+		if (mainLookId != 0) {
+			definition.serverLookId = mainLookId;
+			if (definition.previewItemId == 0) {
+				definition.previewItemId = mainLookId;
+			}
+		}
+
+		AddStorageLocation(definition, groundsFile, "brush", brushName);
+
+		definition.variations.clear();
+		definition.borders.clear();
+
+		for (pugi::xml_node itemNode = brushNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
+			const uint16_t itemId = itemNode.attribute("id").as_uint();
+			if (itemId == 0) {
+				continue;
+			}
+
+			BrushEditorVariation variation;
+			variation.label = wxString::Format("Item %u", static_cast<unsigned>(itemId));
+			variation.chance = std::max(1, itemNode.attribute("chance").as_int(1));
+
+			BrushEditorCompositeTile tile;
+			tile.x = 0;
+			tile.y = 0;
+			tile.itemId = itemId;
+			tile.chance = variation.chance;
+
+			variation.tiles.push_back(tile);
+			definition.variations.push_back(variation);
+
+			if (definition.previewItemId == 0) {
+				definition.previewItemId = itemId;
+			}
+		}
+
+		for (pugi::xml_node compositeNode = brushNode.child("composite"); compositeNode; compositeNode = compositeNode.next_sibling("composite")) {
+			BrushEditorVariation variation;
+			variation.label = "Composite";
+			variation.chance = std::max(1, compositeNode.attribute("chance").as_int(1));
+
+			for (pugi::xml_node tileNode = compositeNode.child("tile"); tileNode; tileNode = tileNode.next_sibling("tile")) {
+				BrushEditorCompositeTile tile;
+				tile.x = tileNode.attribute("x").as_int();
+				tile.y = tileNode.attribute("y").as_int();
+				tile.chance = variation.chance;
+
+				pugi::xml_node itemNode = tileNode.child("item");
+				if (itemNode) {
+					tile.itemId = itemNode.attribute("id").as_uint();
+				}
+
+				if (tile.IsValid()) {
+					variation.tiles.push_back(tile);
+					if (definition.previewItemId == 0) {
+						definition.previewItemId = tile.itemId;
+					}
+				}
+			}
+
+			if (!variation.tiles.empty()) {
+				definition.variations.push_back(variation);
+			}
+		}
+
+		for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+			const int borderId = borderNode.attribute("id").as_int();
+			if (borderId <= 0) {
+				continue;
+			}
+
+			BrushEditorBorderConfig border;
+			border.borderId = borderId;
+			border.alignment = wxString(borderNode.attribute("align").as_string());
+			if (border.alignment.IsEmpty()) {
+				border.alignment = "outer";
+			}
+			border.includeToNone = wxString(borderNode.attribute("to").as_string()) == "none";
+			border.includeInner = border.alignment == "inner";
+			border.optional = definition.optional;
+			border.ground = definition.ground;
+			border.group = definition.group;
+
+			definition.borders.push_back(border);
+		}
+
+		ApplyCapabilitiesForKind(definition);
+		if (definition.variations.empty()) {
+			definition.RemoveCapability(BRUSH_CAP_VARIATIONS);
+		}
+		if (definition.borders.empty()) {
+			definition.RemoveCapability(BRUSH_CAP_BORDERS);
+		}
+	}
+}
+
+void AppendItemsToWallPart(BrushEditorWallPart &part, pugi::xml_node parentNode) {
+	for (pugi::xml_node itemNode = parentNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
+		const uint16_t itemId = itemNode.attribute("id").as_uint();
+		if (itemId == 0) {
+			continue;
+		}
+
+		const int chance = itemNode.attribute("chance").as_int(1);
+		part.items.push_back({ itemId, chance });
+
+		if (part.typeName.IsEmpty()) {
+			part.typeName = "wall";
+		}
+	}
+}
+
+void LoadWallBrushes(BrushEditorCatalog &catalog, const wxString &dataDirectory, wxArrayString &warnings) {
+	const wxString wallFiles[] = {
+		BuildBrushXmlPath(dataDirectory, "walls.xml"),
+		BuildBrushXmlPath(dataDirectory, "doodads.xml")
+	};
+	for (const wxString &sourceFile : wallFiles) {
+		pugi::xml_document doc;
+		if (!LoadDocumentIfExists(sourceFile, doc, warnings)) {
+			continue;
+		}
+		const pugi::xml_node materials = doc.child("materials");
+		if (!materials) {
+			warnings.push_back(wxFileName(sourceFile).GetFullName() + ": missing <materials> root");
+			continue;
+		}
+		for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+			const wxString brushName = wxString(brushNode.attribute("name").as_string());
+			const wxString typeValue = wxString(brushNode.attribute("type").as_string()).Lower();
+			if (brushName.IsEmpty() || (typeValue != "wall" && !brushNode.child("wall"))) {
+				continue;
+			}
+			BrushEditorBrushDefinition &definition = catalog.GetOrCreateBrush(brushName);
+			if (definition.kind != BrushEditorBrushKind::Wall) {
+				definition.variations.clear();
+				definition.borders.clear();
+				definition.wallParts.clear();
+			}
+			definition.kind = BrushEditorBrushKind::Wall;
+			definition.optional = false;
+			definition.ground = false;
+			const uint16_t serverLookId = brushNode.attribute("server_lookid").as_uint();
+			if (serverLookId != 0) {
+				definition.serverLookId = serverLookId;
+				if (definition.previewItemId == 0) definition.previewItemId = serverLookId;
+			}
+			AddStorageLocation(definition, sourceFile, "brush", brushName);
+			for (pugi::xml_node wallNode = brushNode.child("wall"); wallNode; wallNode = wallNode.next_sibling("wall")) {
+				const wxString typeName = wxString(wallNode.attribute("type").as_string());
+				if (typeName.IsEmpty()) continue;
+				BrushEditorWallPart part;
+				part.typeName = typeName;
+				AppendItemsToWallPart(part, wallNode);
+				for (pugi::xml_node alternateNode = wallNode.child("alternate"); alternateNode; alternateNode = alternateNode.next_sibling("alternate")) AppendItemsToWallPart(part, alternateNode);
+				if (!part.items.empty()) {
+					definition.wallParts[typeName] = part;
+					if (definition.previewItemId == 0) definition.previewItemId = part.items.front().first;
+				}
+			}
+			for (pugi::xml_node alternateNode = brushNode.child("alternate"); alternateNode; alternateNode = alternateNode.next_sibling("alternate")) {
+				BrushEditorWallPart part;
+				part.typeName = "alternate";
+				AppendItemsToWallPart(part, alternateNode);
+				if (!part.items.empty()) {
+					definition.wallParts["alternate"] = part;
+					if (definition.previewItemId == 0) definition.previewItemId = part.items.front().first;
+				}
+			}
+			ApplyCapabilitiesForKind(definition);
+			if (definition.wallParts.empty()) definition.RemoveCapability(BRUSH_CAP_STRUCTURE);
+		}
+	}
+}
+
+void LoadBorderBrushes(BrushEditorCatalog &catalog, const wxString &dataDirectory, wxArrayString &warnings) {
+	const wxString bordersFile = BuildBorderXmlPath(dataDirectory);
+
+	pugi::xml_document doc;
+	if (!LoadDocumentIfExists(bordersFile, doc, warnings)) {
+		return;
+	}
+
+	const pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		warnings.push_back("borders.xml: missing <materials> root");
+		return;
+	}
+
+	for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+		const int borderId = borderNode.attribute("id").as_int();
+		if (borderId <= 0) {
+			continue;
+		}
+
+		const wxString explicitName = wxString(borderNode.attribute("name").as_string());
+		const wxString brushName = explicitName.IsEmpty()
+			? wxString::Format("Border %d", borderId)
+			: explicitName;
+
+		BrushEditorBrushDefinition &definition = catalog.GetOrCreateBrush(brushName);
+		definition.kind = BrushEditorBrushKind::Border;
+		definition.group = borderNode.attribute("group").as_int(0);
+		definition.optional = wxString(borderNode.attribute("type").as_string()) == "optional";
+		definition.ground = borderNode.attribute("ground").as_bool(false);
+
+		AddStorageLocation(definition, bordersFile, "border", wxString::Format("%d", borderId));
+
+		for (pugi::xml_node borderItemNode = borderNode.child("borderitem"); borderItemNode; borderItemNode = borderItemNode.next_sibling("borderitem")) {
+			const uint16_t itemId = borderItemNode.attribute("item").as_uint();
+			if (itemId != 0) {
+				definition.previewItemId = itemId;
+				definition.serverLookId = itemId;
+				break;
+			}
+		}
+
+		ApplyCapabilitiesForKind(definition);
+	}
+}
+} // namespace
+
+bool BrushEditorCatalogService::LoadCatalog(const wxString &dataDirectory, BrushEditorCatalog &catalog, wxArrayString &warnings) const {
+	catalog.Clear();
+
+	LoadPaletteMembershipsFromMaterials(catalog);
+	LoadGroundBrushes(catalog, dataDirectory, warnings);
+	LoadWallBrushes(catalog, dataDirectory, warnings);
+	LoadBorderBrushes(catalog, dataDirectory, warnings);
+
+	for (BrushEditorBrushDefinition &brush : catalog.brushes) {
+		if (!brush.memberships.empty()) {
+			brush.AddCapability(BRUSH_CAP_PALETTES);
+		}
+		if (brush.serverLookId == 0) {
+			brush.serverLookId = brush.previewItemId;
+		}
+	}
+
+	catalog.Sort();
+	return true;
+}

--- a/source/brush_editor_catalog_service.h
+++ b/source/brush_editor_catalog_service.h
@@ -1,0 +1,15 @@
+//////////////////////////////////////////////////////////////////////
+// brush_editor_catalog_service.h - Read-only catalog builder
+//////////////////////////////////////////////////////////////////////
+
+#ifndef RME_BRUSH_EDITOR_CATALOG_SERVICE_H_
+#define RME_BRUSH_EDITOR_CATALOG_SERVICE_H_
+
+#include "brush_editor_model.h"
+
+class BrushEditorCatalogService {
+public:
+	bool LoadCatalog(const wxString &dataDirectory, BrushEditorCatalog &catalog, wxArrayString &warnings) const;
+};
+
+#endif

--- a/source/brush_editor_model.cpp
+++ b/source/brush_editor_model.cpp
@@ -1,0 +1,323 @@
+//////////////////////////////////////////////////////////////////////
+// brush_editor_model.cpp - Unified domain model for brush/palette editor
+//////////////////////////////////////////////////////////////////////
+
+#include "main.h"
+#include "brush_editor_model.h"
+
+bool BrushEditorStorageLocation::IsValid() const {
+	return !filePath.IsEmpty() && !xmlElementName.IsEmpty();
+}
+
+bool BrushEditorPaletteMembership::IsValid() const {
+	return !tilesetName.IsEmpty() && categoryType != TILESET_UNKNOWN;
+}
+
+bool BrushEditorCompositeTile::IsValid() const {
+	return itemId != 0;
+}
+
+bool BrushEditorVariation::IsValid() const {
+	if (chance <= 0 || tiles.empty()) {
+		return false;
+	}
+
+	for (const BrushEditorCompositeTile &tile : tiles) {
+		if (!tile.IsValid()) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool BrushEditorWallPart::IsValid() const {
+	if (typeName.IsEmpty() || items.empty()) {
+		return false;
+	}
+
+	for (const auto &item : items) {
+		if (item.first == 0 || item.second <= 0) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool BrushEditorBorderConfig::IsValid() const {
+	if (borderId < 0) {
+		return false;
+	}
+
+	if (alignment.IsEmpty()) {
+		return false;
+	}
+
+	return true;
+}
+
+bool BrushEditorBrushDefinition::HasCapability(BrushEditorCapability capability) const {
+	return (capabilities & static_cast<uint32_t>(capability)) != 0;
+}
+
+void BrushEditorBrushDefinition::AddCapability(BrushEditorCapability capability) {
+	capabilities |= static_cast<uint32_t>(capability);
+}
+
+void BrushEditorBrushDefinition::RemoveCapability(BrushEditorCapability capability) {
+	capabilities &= ~static_cast<uint32_t>(capability);
+}
+
+bool BrushEditorBrushDefinition::IsPersisted() const {
+	for (const BrushEditorStorageLocation &storage : storageLocations) {
+		if (storage.IsValid()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool BrushEditorBrushDefinition::IsValid() const {
+	if (name.IsEmpty() || deleted) {
+		return false;
+	}
+
+	if (kind == BrushEditorBrushKind::Unknown) {
+		return false;
+	}
+
+	if (HasCapability(BRUSH_CAP_VARIATIONS) && variations.empty()) {
+		return false;
+	}
+
+	if (HasCapability(BRUSH_CAP_STRUCTURE) && wallParts.empty()) {
+		return false;
+	}
+
+	if (HasCapability(BRUSH_CAP_BORDERS) && borders.empty()) {
+		return false;
+	}
+
+	for (const BrushEditorVariation &variation : variations) {
+		if (!variation.IsValid()) {
+			return false;
+		}
+	}
+
+	for (const auto &entry : wallParts) {
+		if (!entry.second.IsValid()) {
+			return false;
+		}
+	}
+
+	for (const BrushEditorBorderConfig &border : borders) {
+		if (!border.IsValid()) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+const BrushEditorStorageLocation* BrushEditorBrushDefinition::GetPrimaryStorage() const {
+	if (storageLocations.empty()) {
+		return nullptr;
+	}
+	return &storageLocations.front();
+}
+
+BrushEditorStorageLocation* BrushEditorBrushDefinition::GetPrimaryStorage() {
+	if (storageLocations.empty()) {
+		return nullptr;
+	}
+	return &storageLocations.front();
+}
+
+bool BrushEditorPaletteDefinition::ContainsBrush(const wxString &brushName) const {
+	return std::find(brushNames.begin(), brushNames.end(), brushName) != brushNames.end();
+}
+
+bool BrushEditorPaletteDefinition::AddBrush(const wxString &brushName) {
+	if (brushName.IsEmpty() || ContainsBrush(brushName)) {
+		return false;
+	}
+
+	brushNames.push_back(brushName);
+	return true;
+}
+
+bool BrushEditorPaletteDefinition::RemoveBrush(const wxString &brushName) {
+	const auto it = std::remove(brushNames.begin(), brushNames.end(), brushName);
+	if (it == brushNames.end()) {
+		return false;
+	}
+
+	brushNames.erase(it, brushNames.end());
+	return true;
+}
+
+bool BrushEditorPaletteDefinition::IsValid() const {
+	return !name.IsEmpty() && categoryType != TILESET_UNKNOWN && !deleted;
+}
+
+void BrushEditorCatalog::Clear() {
+	brushes.clear();
+	palettes.clear();
+	InvalidateBrushIndex();
+}
+
+void BrushEditorCatalog::InvalidateBrushIndex() {
+	m_brushIndexDirty = true;
+	m_brushIndexByName.clear();
+}
+
+void BrushEditorCatalog::RebuildBrushIndex() const {
+	m_brushIndexByName.clear();
+	m_brushIndexByName.reserve(brushes.size());
+	for (size_t i = 0; i < brushes.size(); ++i) {
+		m_brushIndexByName[nstr(brushes[i].name)] = i;
+	}
+	m_brushIndexDirty = false;
+}
+
+BrushEditorBrushDefinition* BrushEditorCatalog::FindBrushByName(const wxString &name) {
+	const BrushEditorCatalog &self = *this;
+	const BrushEditorBrushDefinition* found = self.FindBrushByName(name);
+	return const_cast<BrushEditorBrushDefinition*>(found);
+}
+
+const BrushEditorBrushDefinition* BrushEditorCatalog::FindBrushByName(const wxString &name) const {
+	if (m_brushIndexDirty) {
+		RebuildBrushIndex();
+	}
+	const auto it = m_brushIndexByName.find(nstr(name));
+	if (it == m_brushIndexByName.end() || it->second >= brushes.size()) {
+		return nullptr;
+	}
+	return &brushes[it->second];
+}
+
+BrushEditorPaletteDefinition* BrushEditorCatalog::FindPaletteByName(const wxString &name) {
+	for (BrushEditorPaletteDefinition &palette : palettes) {
+		if (palette.name == name) {
+			return &palette;
+		}
+	}
+	return nullptr;
+}
+
+const BrushEditorPaletteDefinition* BrushEditorCatalog::FindPaletteByName(const wxString &name) const {
+	for (const BrushEditorPaletteDefinition &palette : palettes) {
+		if (palette.name == name) {
+			return &palette;
+		}
+	}
+	return nullptr;
+}
+
+BrushEditorBrushDefinition& BrushEditorCatalog::GetOrCreateBrush(const wxString &name) {
+	if (BrushEditorBrushDefinition* existing = FindBrushByName(name)) {
+		return *existing;
+	}
+
+	BrushEditorBrushDefinition brush;
+	brush.name = name;
+	brush.AddCapability(BRUSH_CAP_GENERAL);
+	brushes.push_back(brush);
+	InvalidateBrushIndex();
+	return brushes.back();
+}
+
+BrushEditorPaletteDefinition& BrushEditorCatalog::GetOrCreatePalette(const wxString &name) {
+	if (BrushEditorPaletteDefinition* existing = FindPaletteByName(name)) {
+		return *existing;
+	}
+
+	BrushEditorPaletteDefinition palette;
+	palette.name = name;
+	palettes.push_back(palette);
+	return palettes.back();
+}
+
+void BrushEditorCatalog::Sort() {
+	std::sort(brushes.begin(), brushes.end(), [](const BrushEditorBrushDefinition &a, const BrushEditorBrushDefinition &b) {
+		return a.name.CmpNoCase(b.name) < 0;
+	});
+
+	std::sort(palettes.begin(), palettes.end(), [](const BrushEditorPaletteDefinition &a, const BrushEditorPaletteDefinition &b) {
+		return a.name.CmpNoCase(b.name) < 0;
+	});
+
+	InvalidateBrushIndex();
+}
+
+wxString BrushEditorBrushKindToString(BrushEditorBrushKind kind) {
+	switch (kind) {
+		case BrushEditorBrushKind::Ground:
+			return "ground";
+		case BrushEditorBrushKind::Wall:
+			return "wall";
+		case BrushEditorBrushKind::Border:
+			return "border";
+		case BrushEditorBrushKind::Raw:
+			return "raw";
+		case BrushEditorBrushKind::Doodad:
+			return "doodad";
+		case BrushEditorBrushKind::Item:
+			return "item";
+		case BrushEditorBrushKind::Creature:
+			return "creature";
+		case BrushEditorBrushKind::Spawn:
+			return "spawn";
+		case BrushEditorBrushKind::House:
+			return "house";
+		case BrushEditorBrushKind::Waypoint:
+			return "waypoint";
+		case BrushEditorBrushKind::Zone:
+			return "zone";
+		case BrushEditorBrushKind::Unknown:
+		default:
+			return "unknown";
+	}
+}
+
+BrushEditorBrushKind BrushEditorBrushKindFromString(const wxString &value) {
+	const wxString lower = value.Lower();
+
+	if (lower == "ground") {
+		return BrushEditorBrushKind::Ground;
+	}
+	if (lower == "wall") {
+		return BrushEditorBrushKind::Wall;
+	}
+	if (lower == "border") {
+		return BrushEditorBrushKind::Border;
+	}
+	if (lower == "raw") {
+		return BrushEditorBrushKind::Raw;
+	}
+	if (lower == "doodad") {
+		return BrushEditorBrushKind::Doodad;
+	}
+	if (lower == "item") {
+		return BrushEditorBrushKind::Item;
+	}
+	if (lower == "creature") {
+		return BrushEditorBrushKind::Creature;
+	}
+	if (lower == "spawn") {
+		return BrushEditorBrushKind::Spawn;
+	}
+	if (lower == "house") {
+		return BrushEditorBrushKind::House;
+	}
+	if (lower == "waypoint") {
+		return BrushEditorBrushKind::Waypoint;
+	}
+	if (lower == "zone") {
+		return BrushEditorBrushKind::Zone;
+	}
+
+	return BrushEditorBrushKind::Unknown;
+}

--- a/source/brush_editor_model.h
+++ b/source/brush_editor_model.h
@@ -1,0 +1,166 @@
+//////////////////////////////////////////////////////////////////////
+// brush_editor_model.h - Unified domain model for brush/palette editor
+//////////////////////////////////////////////////////////////////////
+
+#ifndef RME_BRUSH_EDITOR_MODEL_H_
+#define RME_BRUSH_EDITOR_MODEL_H_
+
+#include "main.h"
+#include "tileset.h"
+#include <unordered_map>
+
+enum class BrushEditorBrushKind {
+	Unknown,
+	Ground,
+	Wall,
+	Border,
+	Raw,
+	Doodad,
+	Item,
+	Creature,
+	Spawn,
+	House,
+	Waypoint,
+	Zone,
+};
+
+enum BrushEditorCapability : uint32_t {
+	BRUSH_CAP_NONE = 0,
+	BRUSH_CAP_GENERAL = 1 << 0,
+	BRUSH_CAP_VARIATIONS = 1 << 1,
+	BRUSH_CAP_STRUCTURE = 1 << 2,
+	BRUSH_CAP_BORDERS = 1 << 3,
+	BRUSH_CAP_FLAGS = 1 << 4,
+	BRUSH_CAP_PALETTES = 1 << 5,
+};
+
+struct BrushEditorStorageLocation {
+	wxString filePath;
+	wxString xmlElementName;
+	wxString logicalId;
+
+	bool IsValid() const;
+};
+
+struct BrushEditorPaletteMembership {
+	wxString tilesetName;
+	TilesetCategoryType categoryType = TILESET_UNKNOWN;
+	int orderHint = -1;
+
+	bool IsValid() const;
+};
+
+struct BrushEditorCompositeTile {
+	int x = 0;
+	int y = 0;
+	uint16_t itemId = 0;
+	int chance = 1;
+
+	bool IsValid() const;
+};
+
+struct BrushEditorVariation {
+	wxString label;
+	int chance = 1;
+	std::vector<BrushEditorCompositeTile> tiles;
+
+	bool IsValid() const;
+};
+
+struct BrushEditorWallPart {
+	wxString typeName;
+	std::vector<std::pair<uint16_t, int>> items;
+
+	bool IsValid() const;
+};
+
+struct BrushEditorBorderConfig {
+	int borderId = 0;
+	wxString alignment = "outer";
+	bool includeToNone = true;
+	bool includeInner = false;
+	bool optional = false;
+	bool ground = false;
+	int group = 0;
+
+	bool IsValid() const;
+};
+
+class BrushEditorBrushDefinition {
+public:
+	wxString name;
+	BrushEditorBrushKind kind = BrushEditorBrushKind::Unknown;
+	uint32_t capabilities = BRUSH_CAP_NONE;
+
+	uint16_t previewItemId = 0;
+	uint16_t serverLookId = 0;
+	int zOrder = 0;
+
+	bool optional = false;
+	bool ground = false;
+	int group = 0;
+	bool deleted = false;
+
+	std::vector<BrushEditorPaletteMembership> memberships;
+	std::vector<BrushEditorVariation> variations;
+	std::map<wxString, BrushEditorWallPart> wallParts;
+	std::vector<BrushEditorBorderConfig> borders;
+	std::vector<BrushEditorStorageLocation> storageLocations;
+
+	bool HasCapability(BrushEditorCapability capability) const;
+	void AddCapability(BrushEditorCapability capability);
+	void RemoveCapability(BrushEditorCapability capability);
+
+	bool IsPersisted() const;
+	bool IsValid() const;
+
+	const BrushEditorStorageLocation* GetPrimaryStorage() const;
+	BrushEditorStorageLocation* GetPrimaryStorage();
+};
+
+class BrushEditorPaletteDefinition {
+public:
+	wxString name;
+	TilesetCategoryType categoryType = TILESET_UNKNOWN;
+	wxString sourceFile;
+	bool builtin = true;
+	bool deleted = false;
+
+	std::vector<wxString> brushNames;
+
+	bool ContainsBrush(const wxString &brushName) const;
+	bool AddBrush(const wxString &brushName);
+	bool RemoveBrush(const wxString &brushName);
+	bool IsValid() const;
+};
+
+class BrushEditorCatalog {
+public:
+	void Clear();
+
+	BrushEditorBrushDefinition* FindBrushByName(const wxString &name);
+	const BrushEditorBrushDefinition* FindBrushByName(const wxString &name) const;
+
+	BrushEditorPaletteDefinition* FindPaletteByName(const wxString &name);
+	const BrushEditorPaletteDefinition* FindPaletteByName(const wxString &name) const;
+
+	BrushEditorBrushDefinition& GetOrCreateBrush(const wxString &name);
+	BrushEditorPaletteDefinition& GetOrCreatePalette(const wxString &name);
+
+	void Sort();
+
+	std::vector<BrushEditorBrushDefinition> brushes;
+	std::vector<BrushEditorPaletteDefinition> palettes;
+
+private:
+	void InvalidateBrushIndex();
+	void RebuildBrushIndex() const;
+
+	mutable bool m_brushIndexDirty = true;
+	mutable std::unordered_map<std::string, size_t> m_brushIndexByName;
+};
+
+wxString BrushEditorBrushKindToString(BrushEditorBrushKind kind);
+BrushEditorBrushKind BrushEditorBrushKindFromString(const wxString &value);
+
+#endif

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -354,6 +354,188 @@ BorderEditorPanel::~BorderEditorPanel() {
     // Nothing to destroy manually
 }
 
+void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
+    if (m_isRestoringDraft) {
+        return;
+    }
+    if (tileId == 0) {
+        return;
+    }
+
+    switch (tab) {
+        case 0: {
+            BorderDraftState& d = m_borderDrafts[tileId];
+            d.currentBorderId = m_currentBorderId;
+            d.name = m_nameCtrl ? m_nameCtrl->GetValue() : wxString();
+            d.group = m_groupCheck ? m_groupCheck->GetValue() : false;
+            d.optional = m_isOptionalCheck ? m_isOptionalCheck->GetValue() : false;
+            d.ground = m_isGroundCheck ? m_isGroundCheck->GetValue() : false;
+            d.items = m_borderItems;
+            d.dirty = d.dirty || markDirty;
+            break;
+        }
+        case 1: {
+            GroundDraftState& d = m_groundDrafts[tileId];
+            d.name = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
+            d.serverLookId = m_serverLookIdCtrl ? m_serverLookIdCtrl->GetValue() : 0;
+            d.zOrder = m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0;
+            d.borderAlignmentSelection = m_borderAlignmentSelection;
+            d.includeToNone = m_includeToNoneCheck ? m_includeToNoneCheck->GetValue() : true;
+            d.includeInner = m_includeInnerCheck ? m_includeInnerCheck->GetValue() : false;
+            d.items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
+            d.dirty = d.dirty || markDirty;
+            break;
+        }
+        case 2: {
+            WallDraftState& d = m_wallDrafts[tileId];
+            d.name = m_wallNameCtrl ? m_wallNameCtrl->GetValue() : wxString();
+            d.serverLookId = m_wallServerLookIdCtrl ? m_wallServerLookIdCtrl->GetValue() : 0;
+            d.wallTypes = m_wallTypes;
+            d.selectedType = m_wallGridPanel ? m_wallGridPanel->GetSelectedType() : std::string();
+            d.dirty = d.dirty || markDirty;
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
+    if (tileId == 0) {
+        return false;
+    }
+
+    if (tab == 0) {
+        auto it = m_borderDrafts.find(tileId);
+        if (it == m_borderDrafts.end()) return false;
+
+        m_isRestoringDraft = true;
+        ClearItems(false);
+
+        const BorderDraftState& d = it->second;
+        m_currentBorderId = d.currentBorderId;
+        if (m_nameCtrl) m_nameCtrl->SetValue(d.name);
+        if (m_groupCheck) m_groupCheck->SetValue(d.group);
+        if (m_isOptionalCheck) m_isOptionalCheck->SetValue(d.optional);
+        if (m_isGroundCheck) m_isGroundCheck->SetValue(d.ground);
+
+        m_borderItems = d.items;
+        if (m_gridPanel) {
+            for (const BorderItem& item : m_borderItems) {
+                m_gridPanel->SetItemId(item.position, item.itemId);
+            }
+        }
+        UpdatePreview();
+        m_isRestoringDraft = false;
+        return true;
+    }
+
+    if (tab == 1) {
+        auto it = m_groundDrafts.find(tileId);
+        if (it == m_groundDrafts.end()) return false;
+
+        m_isRestoringDraft = true;
+        ClearGroundItems(false);
+
+        const GroundDraftState& d = it->second;
+        if (m_groundNameCtrl) m_groundNameCtrl->SetValue(d.name);
+        if (m_serverLookIdCtrl) m_serverLookIdCtrl->SetValue(d.serverLookId);
+        if (m_zOrderCtrl) m_zOrderCtrl->SetValue(d.zOrder);
+        m_borderAlignmentSelection = d.borderAlignmentSelection;
+        if (m_borderAlignmentButton) {
+            m_borderAlignmentButton->SetLabel((m_borderAlignmentSelection == 1 ? "Inner" : "Outer") + wxString(" \u25BC"));
+        }
+        if (m_includeToNoneCheck) m_includeToNoneCheck->SetValue(d.includeToNone);
+        if (m_includeInnerCheck) m_includeInnerCheck->SetValue(d.includeInner);
+
+        if (m_groundGridContainer) {
+            m_groundGridContainer->Clear();
+            for (const auto& item : d.items) {
+                if (item.first > 0) {
+                    m_groundGridContainer->AddItem(item.first, item.second, true);
+                }
+            }
+        }
+        if (m_groundPreviewPanel && m_groundGridContainer) {
+            m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+        }
+
+        m_isRestoringDraft = false;
+        return true;
+    }
+
+    if (tab == 2) {
+        auto it = m_wallDrafts.find(tileId);
+        if (it == m_wallDrafts.end()) return false;
+
+        m_isRestoringDraft = true;
+        ClearWallItems(false);
+
+        const WallDraftState& d = it->second;
+        if (m_wallNameCtrl) m_wallNameCtrl->SetValue(d.name);
+        if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(d.serverLookId);
+
+        m_wallTypes = d.wallTypes;
+        if (m_wallGridPanel) {
+            m_wallGridPanel->SetWallTypes(m_wallTypes);
+            m_wallGridPanel->SetSelectedType(d.selectedType.empty() ? std::string("vertical") : d.selectedType);
+        }
+        if (m_wallVisualPanel) {
+            m_wallVisualPanel->SetWallItems(m_wallTypes);
+        }
+        UpdateWallItemsList();
+
+        m_isRestoringDraft = false;
+        return true;
+    }
+
+    return false;
+}
+
+void BorderEditorPanel::DiscardDraft(int tab, uint16_t tileId) {
+    if (tileId == 0) {
+        return;
+    }
+
+    switch (tab) {
+        case 0: m_borderDrafts.erase(tileId); break;
+        case 1: m_groundDrafts.erase(tileId); break;
+        case 2: m_wallDrafts.erase(tileId); break;
+        default: break;
+    }
+}
+
+void BorderEditorPanel::SaveCurrentDraft(bool markDirty) {
+    if (m_selectedBrowserTileId == 0) {
+        return;
+    }
+
+    SaveDraft(m_activeTab, m_selectedBrowserTileId, markDirty);
+}
+
+void BorderEditorPanel::DiscardCurrentDraft() {
+    if (m_selectedBrowserTileId == 0) {
+        return;
+    }
+
+    DiscardDraft(m_activeTab, m_selectedBrowserTileId);
+}
+
+void BorderEditorPanel::OnBorderDraftChange(wxCommandEvent& event) {
+    SaveCurrentDraft(true);
+    event.Skip();
+}
+
+void BorderEditorPanel::OnGroundDraftChange(wxCommandEvent& event) {
+    SaveCurrentDraft(true);
+    event.Skip();
+}
+
+void BorderEditorPanel::OnWallDraftChange(wxCommandEvent& event) {
+    SaveCurrentDraft(true);
+    event.Skip();
+}
+
 void BorderEditorPanel::CreateGUIControls() {
     wxBoxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
     
@@ -372,19 +554,23 @@ void BorderEditorPanel::CreateGUIControls() {
     toolbarSizer->Add(new wxStaticText(m_borderPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
     m_nameCtrl = new wxTextCtrl(m_borderPanel, wxID_ANY);
     m_nameCtrl->SetToolTip("Descriptive name for the border/brush");
+    m_nameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnBorderDraftChange, this);
     toolbarSizer->Add(m_nameCtrl, 1, wxEXPAND | wxRIGHT, 15);
     
     // Checkboxes (Right side of toolbar)
     m_groupCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Group");
     m_groupCheck->SetToolTip("Check to assign this border to a group");
+    m_groupCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
     toolbarSizer->Add(m_groupCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
     
     m_isOptionalCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Optional");
     m_isOptionalCheck->SetToolTip("Marks this border as optional");
+    m_isOptionalCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
     toolbarSizer->Add(m_isOptionalCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
     
     m_isGroundCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Ground");
     m_isGroundCheck->SetToolTip("Marks this border as a ground border");
+    m_isGroundCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
     toolbarSizer->Add(m_isGroundCheck, 0, wxALIGN_CENTER_VERTICAL);
     
     borderSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 5);
@@ -471,12 +657,14 @@ void BorderEditorPanel::CreateGUIControls() {
     wxBoxSizer* row1 = new wxBoxSizer(wxHORIZONTAL);
     row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
     m_groundNameCtrl = new wxTextCtrl(m_groundPanel, wxID_ANY, "");
+    m_groundNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnGroundDraftChange, this);
     row1->Add(m_groundNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
 
     row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
     m_serverLookIdCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "", wxDefaultPosition, wxSize(80, -1));
     m_serverLookIdCtrl->SetRange(0, 99999);
     m_serverLookIdCtrl->SetToolTip("Server-side item ID");
+    m_serverLookIdCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnGroundDraftChange, this);
     row1->Add(m_serverLookIdCtrl, 0, wxALIGN_CENTER_VERTICAL);
     groundLeftSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 5);
 
@@ -484,6 +672,7 @@ void BorderEditorPanel::CreateGUIControls() {
     row2->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Z-Order:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
     m_zOrderCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(60, -1));
     m_zOrderCtrl->SetRange(-100, 100);
+    m_zOrderCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnGroundDraftChange, this);
     row2->Add(m_zOrderCtrl, 0);
     groundLeftSizer->Add(row2, 0, wxEXPAND | wxBOTTOM, 5);
     
@@ -562,9 +751,11 @@ void BorderEditorPanel::CreateGUIControls() {
     
     m_includeToNoneCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "To None");
     m_includeToNoneCheck->SetValue(true);
+    m_includeToNoneCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnGroundDraftChange, this);
     borderOptionsRow->Add(m_includeToNoneCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
     
     m_includeInnerCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Inner Border");
+    m_includeInnerCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnGroundDraftChange, this);
     borderOptionsRow->Add(m_includeInnerCheck, 0, wxALIGN_CENTER_VERTICAL);
     
     borderOptionsBoxSizer->Add(borderOptionsRow, 0, wxEXPAND | wxALL, 5);
@@ -604,6 +795,7 @@ void BorderEditorPanel::CreateGUIControls() {
     // Name Field (Expand)
     wallHeaderSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
     m_wallNameCtrl = new wxTextCtrl(m_wallPanel, wxID_ANY);
+    m_wallNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnWallDraftChange, this);
     wallHeaderSizer->Add(m_wallNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
     
     // wallHeaderSizer->AddStretchSpacer(1); // Spacer usage adjustments if needed, but 1 expand on Name is good.
@@ -612,6 +804,7 @@ void BorderEditorPanel::CreateGUIControls() {
     wallHeaderSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
     m_wallServerLookIdCtrl = new wxSpinCtrl(m_wallPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(70, -1), wxSP_ARROW_KEYS, 0, 65535);
     m_wallServerLookIdCtrl->SetToolTip("Server-side item ID");
+    m_wallServerLookIdCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnWallDraftChange, this);
     wallHeaderSizer->Add(m_wallServerLookIdCtrl, 0, wxALIGN_CENTER_VERTICAL);
     
     wallSizer->Add(wallHeaderSizer, 0, wxEXPAND | wxALL, 5);
@@ -708,6 +901,7 @@ void BorderEditorPanel::CreateGUIControls() {
     wxButton* wallNewButton = new wxButton(m_wallPanel, wxID_ANY, "New Wall");
     wallNewButton->SetToolTip("Start creating a new wall brush (clears current form)");
     wallNewButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent& ev) { 
+        DiscardCurrentDraft();
         ClearWallItems();
         m_nameCtrl->SetValue("");
         if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(0);
@@ -947,6 +1141,7 @@ void BorderEditorPanel::OnBorderAlignmentMenuSelect(wxCommandEvent& event) {
         m_borderAlignmentButton->SetLabel((id == 0 ? "Outer" : "Inner") + wxString(" \u25BC"));
     }
 
+    SaveCurrentDraft(true);
     FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
@@ -964,6 +1159,8 @@ void BorderEditorPanel::OnWallPaletteSelect(wxCommandEvent& event) {
 void BorderEditorPanel::OnWallGridSelect(wxCommandEvent& event) {
     std::string type = event.GetString().ToStdString();
     if (type.empty()) return;
+
+    bool changed = false;
 
     // Select the type
     m_wallGridPanel->SetSelectedType(type);
@@ -984,6 +1181,7 @@ void BorderEditorPanel::OnWallGridSelect(wxCommandEvent& event) {
         
         if (!exists) {
             data.items.push_back(GroundItem(m_currentWallItemId, 10)); // Default chance
+            changed = true;
             
             // Refresh previews
             m_wallVisualPanel->SetWallItems(m_wallTypes);
@@ -992,6 +1190,7 @@ void BorderEditorPanel::OnWallGridSelect(wxCommandEvent& event) {
     }
     
     UpdateWallItemsList(); // Keeps internal logic sync if needed (pointer null checked inside)
+    SaveCurrentDraft(changed);
 }
 
 
@@ -1279,6 +1478,8 @@ void BorderEditorPanel::SaveWallBrush() {
     
     // Save
     if (doc.save_file(nstr(wallsFile).c_str())) {
+        DiscardDraft(2, m_selectedBrowserTileId);
+
         TriggerReloadDataFiles();
         ReloadCurrentBrushEditorXml(name);
 
@@ -1323,6 +1524,7 @@ void BorderEditorPanel::ClearWallItems(bool clearBrowser) {
 
     if (clearBrowser && m_borderBrowserList) {
         m_borderBrowserList->SetSelection(wxNOT_FOUND);
+        m_selectedBrowserTileId = 0;
     }
 }
 
@@ -1494,6 +1696,8 @@ void BorderEditorPanel::LoadBorderById(int borderId) {
 
 // Browser sidebar selection handler - dispatches based on active tab
 void BorderEditorPanel::OnBorderBrowserSelection(wxCommandEvent& event) {
+    SaveCurrentDraft(false);
+
     if (!m_borderBrowserList) return;
 
     int selection = m_borderBrowserList->GetSelection();
@@ -1517,6 +1721,8 @@ void BorderEditorPanel::OnBorderBrowserSelection(wxCommandEvent& event) {
 }
 
 void BorderEditorPanel::OnBrowserGridSelection(wxCommandEvent& event) {
+    SaveCurrentDraft(false);
+
     const wxString key = event.GetString();
     if (key.IsEmpty()) {
         return;
@@ -1653,6 +1859,7 @@ void BorderEditorPanel::OnPositionSelected(wxCommandEvent& event) {
         
         // Update the preview
         UpdatePreview();
+        SaveCurrentDraft(true);
         
         // Log the addition
         wxLogDebug("Added border item at position %s with item ID %d", 
@@ -1756,6 +1963,8 @@ void BorderEditorPanel::OnAddItem(wxCommandEvent& event) {
 }
 
 void BorderEditorPanel::OnClear(wxCommandEvent& event) {
+    DiscardCurrentDraft();
+
     if (m_activeTab == 0) {
         // Border tab
     ClearItems();
@@ -1780,6 +1989,7 @@ void BorderEditorPanel::ClearItems(bool clearBrowser) {
     // Deselect browser list
     if (clearBrowser && m_borderBrowserList) {
         m_borderBrowserList->SetSelection(wxNOT_FOUND);
+        m_selectedBrowserTileId = 0;
     }
 }
 
@@ -1945,6 +2155,8 @@ void BorderEditorPanel::SaveBorder() {
         wxMessageBox("Failed to save changes to borders.xml", "Error", wxICON_ERROR);
         return;
     }
+
+    DiscardDraft(0, m_selectedBrowserTileId);
 
     TriggerReloadDataFiles();
     ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
@@ -2906,10 +3118,13 @@ void BorderEditorPanel::ClearGroundItems(bool clearBrowser) {
     // Deselect browser list
     if (clearBrowser && m_borderBrowserList) {
         m_borderBrowserList->SetSelection(wxNOT_FOUND);
+        m_selectedBrowserTileId = 0;
     }
 }
 
 void BorderEditorPanel::OnPageChanged(wxBookCtrlEvent& event) {
+    SaveCurrentDraft(false);
+
     m_activeTab = event.GetSelection();
 
     LoadTilesets();
@@ -2947,6 +3162,8 @@ void BorderEditorPanel::UpdateBrowserLabel() {
 }
 
 void BorderEditorPanel::OnModeSwitch(wxCommandEvent& event) {
+    SaveCurrentDraft(false);
+
     wxToggleButton* clickedBtn = dynamic_cast<wxToggleButton*>(event.GetEventObject());
     if (!clickedBtn) return;
     
@@ -4773,6 +4990,7 @@ void BorderEditorPanel::OnGroundPaletteSelect(wxCommandEvent& event) {
         if (m_groundPreviewPanel) {
             m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
         }
+        SaveCurrentDraft(true);
     }
 }
 
@@ -4780,6 +4998,7 @@ void BorderEditorPanel::OnGroundContainerChange(wxCommandEvent& event) {
     if (m_groundPreviewPanel && m_groundGridContainer) {
         m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
     }
+    SaveCurrentDraft(true);
 }
 
 void BorderEditorPanel::SaveGroundBrush() {
@@ -4916,6 +5135,8 @@ void BorderEditorPanel::SaveGroundBrush() {
     
     // Save the file
     if (doc.save_file(nstr(groundsFile).c_str())) {
+        DiscardDraft(1, m_selectedBrowserTileId);
+
         TriggerReloadDataFiles();
         ReloadCurrentBrushEditorXml(name);
 
@@ -4931,6 +5152,10 @@ void BorderEditorPanel::SaveGroundBrush() {
 }
 
 void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {
+    if (RestoreDraft(0, tileId)) {
+        return;
+    }
+
     ClearItems(false);
     if (tileId == 0) {
         return;
@@ -4990,6 +5215,10 @@ void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {
 }
 
 void BorderEditorPanel::LoadGroundBrushByMainTileId(uint16_t tileId) {
+    if (RestoreDraft(1, tileId)) {
+        return;
+    }
+
     ClearGroundItems(false);
     if (tileId == 0) {
         return;
@@ -5040,6 +5269,10 @@ void BorderEditorPanel::LoadGroundBrushByMainTileId(uint16_t tileId) {
 }
 
 void BorderEditorPanel::LoadWallBrushByMainTileId(uint16_t tileId) {
+    if (RestoreDraft(2, tileId)) {
+        return;
+    }
+
     ClearWallItems(false);
     if (tileId == 0) {
         return;

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -366,7 +366,7 @@ void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
         case 0: {
             BorderDraftState& d = m_borderDrafts[tileId];
             d.currentBorderId = m_currentBorderId;
-            d.name = m_nameCtrl ? m_nameCtrl->GetValue() : wxString();
+            d.borderName = m_loadedBorderName;
             d.group = m_groupCheck ? m_groupCheck->GetValue() : false;
             d.optional = m_isOptionalCheck ? m_isOptionalCheck->GetValue() : false;
             d.ground = m_isGroundCheck ? m_isGroundCheck->GetValue() : false;
@@ -377,7 +377,6 @@ void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
         case 1: {
             GroundDraftState& d = m_groundDrafts[tileId];
             d.name = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
-            d.serverLookId = m_serverLookIdCtrl ? m_serverLookIdCtrl->GetValue() : 0;
             d.zOrder = m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0;
             d.borderAlignmentSelection = m_borderAlignmentSelection;
             d.includeToNone = m_includeToNoneCheck ? m_includeToNoneCheck->GetValue() : true;
@@ -388,8 +387,7 @@ void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
         }
         case 2: {
             WallDraftState& d = m_wallDrafts[tileId];
-            d.name = m_wallNameCtrl ? m_wallNameCtrl->GetValue() : wxString();
-            d.serverLookId = m_wallServerLookIdCtrl ? m_wallServerLookIdCtrl->GetValue() : 0;
+            d.brushName = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
             d.wallTypes = m_wallTypes;
             d.selectedType = m_wallGridPanel ? m_wallGridPanel->GetSelectedType() : std::string();
             d.dirty = d.dirty || markDirty;
@@ -414,7 +412,7 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 
         const BorderDraftState& d = it->second;
         m_currentBorderId = d.currentBorderId;
-        if (m_nameCtrl) m_nameCtrl->SetValue(d.name);
+        m_loadedBorderName = d.borderName;
         if (m_groupCheck) m_groupCheck->SetValue(d.group);
         if (m_isOptionalCheck) m_isOptionalCheck->SetValue(d.optional);
         if (m_isGroundCheck) m_isGroundCheck->SetValue(d.ground);
@@ -439,7 +437,6 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 
         const GroundDraftState& d = it->second;
         if (m_groundNameCtrl) m_groundNameCtrl->SetValue(d.name);
-        if (m_serverLookIdCtrl) m_serverLookIdCtrl->SetValue(d.serverLookId);
         if (m_zOrderCtrl) m_zOrderCtrl->SetValue(d.zOrder);
         m_borderAlignmentSelection = d.borderAlignmentSelection;
         if (m_borderAlignmentButton) {
@@ -472,8 +469,7 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
         ClearWallItems(false);
 
         const WallDraftState& d = it->second;
-        if (m_wallNameCtrl) m_wallNameCtrl->SetValue(d.name);
-        if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(d.serverLookId);
+        if (m_groundNameCtrl) m_groundNameCtrl->SetValue(d.brushName);
 
         m_wallTypes = d.wallTypes;
         if (m_wallGridPanel) {
@@ -549,13 +545,6 @@ void BorderEditorPanel::CreateGUIControls() {
     
     // --- Top Toolbar: Name + Checkboxes (Merged) ---
     wxBoxSizer* toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // Name Field (Left side of toolbar)
-    toolbarSizer->Add(new wxStaticText(m_borderPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_nameCtrl = new wxTextCtrl(m_borderPanel, wxID_ANY);
-    m_nameCtrl->SetToolTip("Descriptive name for the border/brush");
-    m_nameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnBorderDraftChange, this);
-    toolbarSizer->Add(m_nameCtrl, 1, wxEXPAND | wxRIGHT, 15);
     
     // Checkboxes (Right side of toolbar)
     m_groupCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Group");
@@ -659,13 +648,6 @@ void BorderEditorPanel::CreateGUIControls() {
     m_groundNameCtrl = new wxTextCtrl(m_groundPanel, wxID_ANY, "");
     m_groundNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnGroundDraftChange, this);
     row1->Add(m_groundNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-
-    row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_serverLookIdCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "", wxDefaultPosition, wxSize(80, -1));
-    m_serverLookIdCtrl->SetRange(0, 99999);
-    m_serverLookIdCtrl->SetToolTip("Server-side item ID");
-    m_serverLookIdCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnGroundDraftChange, this);
-    row1->Add(m_serverLookIdCtrl, 0, wxALIGN_CENTER_VERTICAL);
     groundLeftSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 5);
 
     wxBoxSizer* row2 = new wxBoxSizer(wxHORIZONTAL);
@@ -789,26 +771,6 @@ void BorderEditorPanel::CreateGUIControls() {
     m_wallPanel = new wxPanel(m_notebook);
     wxBoxSizer* wallSizer = new wxBoxSizer(wxVERTICAL);
     
-    // --- Header: Name + ID (Single Row) ---
-    wxBoxSizer* wallHeaderSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // Name Field (Expand)
-    wallHeaderSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_wallNameCtrl = new wxTextCtrl(m_wallPanel, wxID_ANY);
-    m_wallNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnWallDraftChange, this);
-    wallHeaderSizer->Add(m_wallNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-    
-    // wallHeaderSizer->AddStretchSpacer(1); // Spacer usage adjustments if needed, but 1 expand on Name is good.
-    
-    // Server Look ID
-    wallHeaderSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_wallServerLookIdCtrl = new wxSpinCtrl(m_wallPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(70, -1), wxSP_ARROW_KEYS, 0, 65535);
-    m_wallServerLookIdCtrl->SetToolTip("Server-side item ID");
-    m_wallServerLookIdCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnWallDraftChange, this);
-    wallHeaderSizer->Add(m_wallServerLookIdCtrl, 0, wxALIGN_CENTER_VERTICAL);
-    
-    wallSizer->Add(wallHeaderSizer, 0, wxEXPAND | wxALL, 5);
-    
     // --- Main Body: Palette (Left) + Editor (Right) ---
     wxBoxSizer* wallContentSizer = new wxBoxSizer(wxHORIZONTAL);
     
@@ -903,8 +865,7 @@ void BorderEditorPanel::CreateGUIControls() {
     wallNewButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent& ev) { 
         DiscardCurrentDraft();
         ClearWallItems();
-        m_nameCtrl->SetValue("");
-        if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(0);
+        if (m_groundNameCtrl) m_groundNameCtrl->SetValue("");
         if (m_borderBrowserList) m_borderBrowserList->SetSelection(wxNOT_FOUND);
     });
     wallButtonSizer->Add(wallNewButton, 0, wxRIGHT, 5);
@@ -1315,10 +1276,6 @@ void TilesetFilterDialog::OnSelectNone(wxCommandEvent& event) {
 
 void BorderEditorPanel::LoadWallBrushByName(const wxString& name) {
     if (name.IsEmpty()) {
-        // Clear all fields for new brush
-        if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(0);
-        if (m_wallIsOptionalCheck) m_wallIsOptionalCheck->SetValue(false);
-        if (m_wallIsGroundCheck) m_wallIsGroundCheck->SetValue(false);
         ClearWallItems();
         return;
     }
@@ -1340,17 +1297,10 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString& name) {
     for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
         pugi::xml_attribute nameAttr = brushNode.attribute("name");
         if (nameAttr && wxString(nameAttr.as_string()) == name) {
-            // Found it! Load properties
-            if (m_wallNameCtrl) m_wallNameCtrl->SetValue(name);
-            
-            // Server look ID
-            pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
-            if (lookIdAttr && m_wallServerLookIdCtrl) {
-                m_wallServerLookIdCtrl->SetValue(lookIdAttr.as_int());
-            }
-            
-            // Clear existing items
             ClearWallItems(false);
+            if (m_groundNameCtrl) {
+                m_groundNameCtrl->SetValue(name);
+            }
             m_wallTypes.clear();
             
             // Iterate over children to find <wall> nodes
@@ -1401,8 +1351,7 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString& name) {
 
 
 void BorderEditorPanel::SaveWallBrush() {
-    wxString name;
-    if (m_wallNameCtrl) name = m_wallNameCtrl->GetValue();
+    wxString name = m_groundNameCtrl ? m_groundNameCtrl->GetValue().Trim() : wxString();
     
     if (name.IsEmpty()) {
         wxMessageBox("Please enter a name for the wall brush.", "Error", wxICON_ERROR);
@@ -1419,7 +1368,18 @@ void BorderEditorPanel::SaveWallBrush() {
         return;
     }
 
-    int serverLookId = m_wallServerLookIdCtrl->GetValue();
+    uint16_t mainTileId = m_selectedBrowserTileId;
+    if (mainTileId == 0) {
+        for (const auto& pair : m_wallTypes) {
+            const WallTypeData& typeData = pair.second;
+            if (!typeData.items.empty()) {
+                mainTileId = typeData.items.front().itemId;
+                break;
+            }
+        }
+    }
+
+    const int serverLookId = static_cast<int>(mainTileId);
     
     // Find walls.xml
     wxString dataDir = g_gui.GetDataDirectory();
@@ -1478,10 +1438,10 @@ void BorderEditorPanel::SaveWallBrush() {
     
     // Save
     if (doc.save_file(nstr(wallsFile).c_str())) {
-        DiscardDraft(2, m_selectedBrowserTileId);
+        DiscardDraft(2, mainTileId);
 
         TriggerReloadDataFiles();
-        ReloadCurrentBrushEditorXml(name);
+        ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
 
         wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
     } else {
@@ -1514,12 +1474,8 @@ void BorderEditorPanel::ClearWallItems(bool clearBrowser) {
     m_wallTypes.clear();
     m_currentWallItemId = 0;
 
-    if (m_wallNameCtrl) {
-        m_wallNameCtrl->SetValue("");
-    }
-
-    if (m_wallServerLookIdCtrl) {
-        m_wallServerLookIdCtrl->SetValue(0);
+    if (m_groundNameCtrl) {
+        m_groundNameCtrl->SetValue("");
     }
 
     if (clearBrowser && m_borderBrowserList) {
@@ -1662,7 +1618,7 @@ void BorderEditorPanel::LoadBorderById(int borderId) {
         
         // Name
         pugi::xml_attribute nameAttr = borderNode.attribute("name");
-        m_nameCtrl->SetValue(nameAttr ? wxString(nameAttr.as_string()) : "");
+        m_loadedBorderName = nameAttr ? wxString(nameAttr.as_string()) : "";
         
         // Type
         pugi::xml_attribute typeAttr = borderNode.attribute("type");
@@ -1981,7 +1937,7 @@ void BorderEditorPanel::ClearItems(bool clearBrowser) {
     
     // Reset controls to defaults
     m_currentBorderId = m_nextBorderId; // Use m_currentBorderId instead of m_idCtrl
-    if (m_nameCtrl) m_nameCtrl->SetValue("");
+    m_loadedBorderName.clear();
     if (m_isOptionalCheck) m_isOptionalCheck->SetValue(false);
     if (m_isGroundCheck) m_isGroundCheck->SetValue(false);
     if (m_groupCheck) m_groupCheck->SetValue(false);
@@ -1999,12 +1955,6 @@ void BorderEditorPanel::UpdatePreview() {
 }
 
 bool BorderEditorPanel::ValidateBorder() {
-    // Check for empty name
-    if (m_nameCtrl->GetValue().IsEmpty()) {
-        wxMessageBox("Please enter a name for the border.", "Validation Error", wxICON_ERROR);
-        return false;
-    }
-    
     if (m_borderItems.empty()) {
         wxMessageBox("The border must have at least one item.", "Validation Error", wxICON_ERROR);
         return false;
@@ -2047,13 +1997,7 @@ void BorderEditorPanel::SaveBorder() {
     
     // Get the border properties
     int id = m_currentBorderId; // Use m_currentBorderId
-    wxString name = m_nameCtrl->GetValue();
-    
-    // Double check that we have a name (it's also checked in ValidateBorder)
-    if (name.IsEmpty()) {
-        wxMessageBox("You must provide a name for the border.", "Error", wxICON_ERROR);
-        return;
-    }
+    wxString name = m_loadedBorderName;
     bool isOptional = m_isOptionalCheck->GetValue();
     bool isGround = m_isGroundCheck->GetValue();
     int group = m_groupCheck->GetValue() ? 1 : 0; // Read m_groupCheck as checkbox
@@ -3103,7 +3047,6 @@ void BorderEditorPanel::LoadExistingGroundBrushes() {
 void BorderEditorPanel::ClearGroundItems(bool clearBrowser) {
     if (m_groundGridContainer) m_groundGridContainer->Clear();
     if (m_groundNameCtrl) m_groundNameCtrl->SetValue("");
-    if (m_serverLookIdCtrl) m_serverLookIdCtrl->SetValue(0);
     if (m_zOrderCtrl) m_zOrderCtrl->SetValue(0);
     
     // Reset border alignment options
@@ -5027,7 +4970,9 @@ void BorderEditorPanel::SaveGroundBrush() {
     }
 
     // Get form values
-    int serverLookId = m_serverLookIdCtrl->GetValue();
+    const uint16_t mainTileId = (m_selectedBrowserTileId != 0)
+        ? m_selectedBrowserTileId
+        : (!items.empty() ? items.front().first : 0);
     int zOrder = m_zOrderCtrl->GetValue();
     wxString alignment = (m_borderAlignmentSelection == 1) ? "inner" : "outer";
     bool includeToNone = m_includeToNoneCheck->GetValue();
@@ -5074,12 +5019,11 @@ void BorderEditorPanel::SaveGroundBrush() {
         brushNode.append_attribute("name") = nstr(name).c_str();
     }
     
-    // Set or update server_lookid
-    if (serverLookId > 0) {
+    if (mainTileId != 0) {
         if (brushNode.attribute("server_lookid")) {
-            brushNode.attribute("server_lookid") = serverLookId;
+            brushNode.attribute("server_lookid") = mainTileId;
         } else {
-            brushNode.append_attribute("server_lookid") = serverLookId;
+            brushNode.append_attribute("server_lookid") = mainTileId;
         }
     }
     
@@ -5135,10 +5079,10 @@ void BorderEditorPanel::SaveGroundBrush() {
     
     // Save the file
     if (doc.save_file(nstr(groundsFile).c_str())) {
-        DiscardDraft(1, m_selectedBrowserTileId);
+        DiscardDraft(1, mainTileId);
 
         TriggerReloadDataFiles();
-        ReloadCurrentBrushEditorXml(name);
+        ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
 
         wxMessageBox(
             wxString::Format("Ground brush '%s' saved successfully.", name),
@@ -5339,13 +5283,6 @@ void BorderEditorPanel::LoadGroundBrushByName(const wxString& name) {
         
         // Found the brush - populate the form
         m_groundNameCtrl->SetValue(name);
-        
-        // Server look ID
-        pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
-        if (!lookIdAttr) {
-            lookIdAttr = brushNode.attribute("lookid");
-        }
-        m_serverLookIdCtrl->SetValue(lookIdAttr ? lookIdAttr.as_int() : 0);
         
         // Z-order
         pugi::xml_attribute zOrderAttr = brushNode.attribute("z-order");

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -21,6 +21,7 @@
 #include "materials.h" // For g_materials
 
 #include "brush_editor_window.h"
+#include "brush_editor_catalog_service.h"
 #include "brush_browser_grid_panel.h"
 #include "browse_tile_window.h"
 #include "find_item_window.h"
@@ -47,6 +48,7 @@
 #include <pugixml.hpp>
 #include <wx/file.h>
 #include <wx/stdpaths.h>
+#include <wx/wupdlock.h>
 #include <sstream>
 
 #define BorderEditorPanel BrushEditorPanel
@@ -104,7 +106,112 @@ struct GridMetrics {
 #define ID_BORDER_GRID_SELECT wxID_HIGHEST + 1
 #define ID_GROUND_ITEM_LIST wxID_HIGHEST + 2
 
-static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions();
+static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions(int activeTab, const BrushEditorCatalog* catalog);
+
+static bool CatalogBrushHasTileset(const BrushEditorBrushDefinition &brush, const wxString &tilesetName) {
+	for (const BrushEditorPaletteMembership &membership : brush.memberships) {
+		if (membership.tilesetName == tilesetName) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static wxString BuildCatalogTilesetLabel(const BrushEditorBrushDefinition &brush) {
+	wxString out;
+	std::set<wxString> seen;
+	for (const BrushEditorPaletteMembership &membership : brush.memberships) {
+		if (membership.tilesetName.IsEmpty() || !seen.insert(membership.tilesetName).second) {
+			continue;
+		}
+		if (!out.IsEmpty()) {
+			out += ", ";
+		}
+		out += membership.tilesetName;
+	}
+	return out;
+}
+
+static wxString ExtractTilesetNameFromPaletteLabel(const wxString &label) {
+	const int sep = label.Find(" [");
+	return sep == wxNOT_FOUND ? label : label.Left(sep);
+}
+
+static wxString GetPaletteCategoryLabel(TilesetCategoryType type) {
+	switch (type) {
+		case TILESET_TERRAIN: return "Terrain";
+		case TILESET_MONSTER: return "Monster";
+		case TILESET_NPC: return "NPC";
+		case TILESET_DOODAD: return "Doodad";
+		case TILESET_ITEM: return "Item";
+		case TILESET_RAW: return "Raw";
+		case TILESET_HOUSE: return "House";
+		case TILESET_WAYPOINT: return "Waypoint";
+		case TILESET_ZONES: return "Zone";
+		case TILESET_UNKNOWN:
+		default: return "Unknown";
+	}
+}
+
+static TilesetCategoryType GetPaletteCategoryTypeFromLabel(const wxString &label) {
+	if (label == "Terrain") return TILESET_TERRAIN;
+	if (label == "Monster") return TILESET_MONSTER;
+	if (label == "NPC") return TILESET_NPC;
+	if (label == "Doodad") return TILESET_DOODAD;
+	if (label == "Item") return TILESET_ITEM;
+	if (label == "Raw") return TILESET_RAW;
+	if (label == "House") return TILESET_HOUSE;
+	if (label == "Waypoint") return TILESET_WAYPOINT;
+	if (label == "Zone") return TILESET_ZONES;
+	return TILESET_UNKNOWN;
+}
+
+static const char* GetPaletteCategoryXmlNodeName(TilesetCategoryType type) {
+	switch (type) {
+		case TILESET_TERRAIN: return "terrain";
+		case TILESET_MONSTER: return "monster";
+		case TILESET_NPC: return "npc";
+		case TILESET_DOODAD: return "doodad";
+		case TILESET_ITEM: return "item";
+		case TILESET_RAW: return "raw";
+		case TILESET_HOUSE: return "house";
+		case TILESET_WAYPOINT: return "waypoint";
+		case TILESET_ZONES: return "zone";
+		default: return nullptr;
+	}
+}
+
+static bool BrushHasPaletteMembership(const BrushEditorBrushDefinition &brush, const wxString &paletteName) {
+	for (const BrushEditorPaletteMembership &membership : brush.memberships) {
+		if (membership.tilesetName.IsEmpty()) continue;
+		const wxString membershipLabel = membership.tilesetName + " [" + GetPaletteCategoryLabel(membership.categoryType) + "]";
+		if (membershipLabel == paletteName) return true;
+	}
+	return false;
+}
+
+static bool CatalogBorderHasTileset(const BrushEditorCatalog &catalog, int borderId, const wxString &tilesetName) {
+	for (const BrushEditorBrushDefinition &brush : catalog.brushes) {
+		if (brush.kind != BrushEditorBrushKind::Ground || !CatalogBrushHasTileset(brush, tilesetName)) continue;
+		for (const BrushEditorBorderConfig &border : brush.borders) {
+			if (border.borderId == borderId) return true;
+		}
+	}
+	return false;
+}
+
+static wxString BuildCatalogBrowserLabel(const BrushEditorBrushDefinition &brush) {
+	wxString label = brush.name;
+	const wxString kind = BrushEditorBrushKindToString(brush.kind);
+	if (!kind.IsEmpty() && kind != "unknown") {
+		label += " [" + kind + "]";
+	}
+	const wxString tilesets = BuildCatalogTilesetLabel(brush);
+	if (!tilesets.IsEmpty()) {
+		label += " - " + tilesets;
+	}
+	return label;
+}
 
 static bool ReadAllText(const wxString &path, wxString &out) {
 	wxFile file(path, wxFile::read);
@@ -516,15 +623,15 @@ bool BorderEditorPanel::RestoreBrowserSelection(const wxString &selectionKey) {
 		return false;
 	}
 
-	const int wanted = wxAtoi(selectionKey);
-
 	for (unsigned int i = 0; i < m_borderBrowserList->GetCount(); ++i) {
 		wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(i));
 		if (!data) {
 			continue;
 		}
 
-		if (wxAtoi(data->GetData()) == wanted) {
+		const wxString key = data->GetData();
+		const bool matches = (m_activeTab == 0) ? (wxAtoi(key) == wxAtoi(selectionKey)) : (key == selectionKey);
+		if (matches) {
 			m_borderBrowserList->SetSelection(i);
 			if (m_browserGrid) {
 				m_browserGrid->SetSelectionByKey(selectionKey);
@@ -546,22 +653,14 @@ void BorderEditorPanel::ReloadCurrentBrushEditorXml(const wxString &selectionKey
 	}
 
 	LoadTilesets();
+	MarkBrushCatalogDirty();
+	EnsureBrushCatalogUpToDate();
 	PopulateUnifiedList();
 
+	SetSelectionKeyForTab(m_activeTab, selectionKey);
 	RestoreBrowserSelection(selectionKey);
-
-	const uint16_t tileId = static_cast<uint16_t>(wxAtoi(selectionKey));
-	switch (m_activeTab) {
-		case 0:
-			LoadBorderByMainTileId(tileId);
-			break;
-		case 1:
-			LoadGroundBrushByMainTileId(tileId);
-			break;
-		case 2:
-			LoadWallBrushByMainTileId(tileId);
-			break;
-	}
+	LoadSelectionForTab(m_activeTab, selectionKey);
+	UpdateBrowserLabel();
 
 	Layout();
 	Refresh();
@@ -604,11 +703,12 @@ BorderEditorPanel::BorderEditorPanel(wxWindow* parent) :
 
 	// Load saved filter configuration (before creating UI)
 	LoadFilterConfig();
+	m_browserPaletteCategoryFilter = "Terrain";
 
 	CreateGUIControls();
 
-	// Default to Ground tab
-	m_notebook->SetSelection(1);
+	// Default to Ground tab without firing page-changed initialization twice
+	m_notebook->ChangeSelection(1);
 	if (m_borderModeBtn) {
 		m_borderModeBtn->SetValue(false);
 	}
@@ -619,105 +719,217 @@ BorderEditorPanel::BorderEditorPanel(wxWindow* parent) :
 		m_wallModeBtn->SetValue(false);
 	}
 
-	// Explicitly populate the sidebar (unified list) for the initial tab
-	// (OnPageChanged may not fire for the initial selection on all platforms)
-	PopulateUnifiedList();
-	UpdateBrowserLabel();
-
 	// Set initial border ID
 	m_currentBorderId = m_nextBorderId;
 
-	Layout();
+	CallAfter([this]() {
+		Layout();
+		if (!m_tabInitialized[m_activeTab]) {
+			PopulateUnifiedList();
+		}
+		RefreshBrowserPaletteList();
+		UpdateBrowserLabel();
+		CallAfter([this]() {
+			LoadTilesets();
+			UpdateBrowserLabel();
+		});
+	});
 }
 
 BorderEditorPanel::~BorderEditorPanel() {
 	// Nothing to destroy manually
 }
 
-void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
-	if (m_isRestoringDraft) {
+wxString BorderEditorPanel::GetSelectionKeyForTab(int tab) const {
+	if (tab < 0 || tab > 2) {
+		return wxString();
+	}
+	if (!m_browserSelectionKeys[tab].IsEmpty()) {
+		return m_browserSelectionKeys[tab];
+	}
+	if (tab == 0 && m_selectedBrowserTileId != 0) {
+		return wxString::Format("%u", (unsigned)m_selectedBrowserTileId);
+	}
+	if (tab != 0 && !m_selectedBrowserBrushName.IsEmpty()) {
+		return m_selectedBrowserBrushName;
+	}
+	return wxString();
+}
+
+bool BorderEditorPanel::HasSelectionForTab(int tab) const {
+	return !GetSelectionKeyForTab(tab).IsEmpty();
+}
+
+void BorderEditorPanel::SetSelectionKeyForTab(int tab, const wxString &selectionKey) {
+	if (tab < 0 || tab > 2) {
 		return;
 	}
-	if (tileId == 0) {
+	m_browserSelectionKeys[tab] = selectionKey;
+	if (tab == 0) {
+		m_selectedBrowserTileId = static_cast<uint16_t>(wxAtoi(selectionKey));
+		if (!selectionKey.IsEmpty()) {
+			m_selectedBrowserBrushName.clear();
+		}
+	} else {
+		m_selectedBrowserBrushName = selectionKey;
+	}
+}
+
+void BorderEditorPanel::ClearSelectionForTab(int tab) {
+	if (tab < 0 || tab > 2) {
+		return;
+	}
+	m_browserSelectionKeys[tab].clear();
+	if (tab == 0) {
+		m_selectedBrowserTileId = 0;
+	} else {
+		m_selectedBrowserBrushName.clear();
+	}
+}
+
+void BorderEditorPanel::LoadSelectionForTab(int tab, const wxString &selectionKey) {
+	if (selectionKey.IsEmpty()) {
+		return;
+	}
+	if (tab == 0) {
+		LoadBorderById(wxAtoi(selectionKey));
+	} else if (tab == 1) {
+		LoadGroundBrushByName(selectionKey);
+	} else if (tab == 2) {
+		LoadWallBrushByName(selectionKey);
+	}
+}
+
+bool BorderEditorPanel::RebuildBrushCatalog() {
+	m_catalogWarnings.Clear();
+	BrushEditorCatalogService service;
+	const bool ok = service.LoadCatalog(g_gui.GetDataDirectory(), m_catalog, m_catalogWarnings);
+	if (ok) {
+		m_catalogDirty = false;
+		m_browserPaletteListDirty = true;
+	}
+	return ok;
+}
+
+bool BorderEditorPanel::EnsureBrushCatalogUpToDate() {
+	if (!m_catalogDirty) {
+		return true;
+	}
+	return RebuildBrushCatalog();
+}
+
+void BorderEditorPanel::MarkBrushCatalogDirty() {
+	m_catalogDirty = true;
+	m_browserPaletteListDirty = true;
+	for (int i = 0; i < 3; ++i) {
+		m_tabInitialized[i] = false;
+		m_cachedBrowserLists[i].Clear();
+		m_cachedBrowserIds[i].Clear();
+		m_cachedBrowserPreviewIds[i].clear();
+	}
+}
+
+void BorderEditorPanel::CacheBrowserDataForActiveTab() {
+	if (m_activeTab < 0 || m_activeTab > 2) return;
+	m_cachedBrowserLists[m_activeTab] = m_fullBrowserList;
+	m_cachedBrowserIds[m_activeTab] = m_fullBrowserIds;
+	m_cachedBrowserPreviewIds[m_activeTab] = m_fullBrowserPreviewIds;
+	m_tabInitialized[m_activeTab] = true;
+}
+
+bool BorderEditorPanel::RestoreCachedBrowserDataForTab(int tab) {
+	if (tab < 0 || tab > 2 || !m_tabInitialized[tab]) return false;
+	if (m_cachedBrowserIds[tab].GetCount() == 0 && m_cachedBrowserPreviewIds[tab].empty()) return false;
+	m_fullBrowserList = m_cachedBrowserLists[tab];
+	m_fullBrowserIds = m_cachedBrowserIds[tab];
+	m_fullBrowserPreviewIds = m_cachedBrowserPreviewIds[tab];
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	return true;
+}
+
+void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
+	if (m_isRestoringDraft || tileId == 0 || tab != 0) {
 		return;
 	}
 
-	switch (tab) {
-		case 0: {
-			BorderDraftState &d = m_borderDrafts[tileId];
-			d.currentBorderId = m_currentBorderId;
-			d.borderName = m_loadedBorderName;
-			d.group = m_groupCheck ? m_groupCheck->GetValue() : false;
-			d.optional = m_isOptionalCheck ? m_isOptionalCheck->GetValue() : false;
-			d.ground = m_isGroundCheck ? m_isGroundCheck->GetValue() : false;
-			d.items = m_borderItems;
-			d.dirty = d.dirty || markDirty;
-			break;
-		}
-		case 1: {
-			GroundDraftState &d = m_groundDrafts[tileId];
-			d.name = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
-			d.zOrder = m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0;
-			d.borderAlignmentSelection = m_borderAlignmentSelection;
-			d.includeToNone = m_includeToNoneCheck ? m_includeToNoneCheck->GetValue() : true;
-			d.includeInner = m_includeInnerCheck ? m_includeInnerCheck->GetValue() : false;
-			d.items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
-			d.dirty = d.dirty || markDirty;
-			break;
-		}
-		case 2: {
-			WallDraftState &d = m_wallDrafts[tileId];
-			d.brushName = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
-			d.wallTypes = m_wallTypes;
-			d.selectedType = m_wallGridPanel ? m_wallGridPanel->GetSelectedType() : std::string();
-			d.dirty = d.dirty || markDirty;
-			break;
-		}
-		default:
-			break;
+	BorderDraftState &d = m_borderDrafts[tileId];
+	d.currentBorderId = m_currentBorderId;
+	d.borderName = m_loadedBorderName;
+	d.group = m_groupCheck ? m_groupCheck->GetValue() : false;
+	d.optional = m_isOptionalCheck ? m_isOptionalCheck->GetValue() : false;
+	d.ground = m_isGroundCheck ? m_isGroundCheck->GetValue() : false;
+	d.items = m_borderItems;
+	d.dirty = d.dirty || markDirty;
+}
+
+void BorderEditorPanel::SaveDraft(int tab, const wxString &brushName, bool markDirty) {
+	if (m_isRestoringDraft || brushName.IsEmpty()) {
+		return;
+	}
+
+	if (tab == 1) {
+		GroundDraftState &d = m_groundDrafts[brushName];
+		d.name = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
+		d.zOrder = m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0;
+		d.borderAlignmentSelection = m_borderAlignmentSelection;
+		d.includeToNone = m_includeToNoneCheck ? m_includeToNoneCheck->GetValue() : true;
+		d.includeInner = m_includeInnerCheck ? m_includeInnerCheck->GetValue() : false;
+		d.items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
+		d.dirty = d.dirty || markDirty;
+	} else if (tab == 2) {
+		WallDraftState &d = m_wallDrafts[brushName];
+		d.brushName = m_wallNameCtrl ? m_wallNameCtrl->GetValue() : wxString();
+		d.wallTypes = m_wallTypes;
+		d.selectedType = m_wallGridPanel ? m_wallGridPanel->GetSelectedType() : std::string();
+		d.dirty = d.dirty || markDirty;
 	}
 }
 
 bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
-	if (tileId == 0) {
+	if (tileId == 0 || tab != 0) {
 		return false;
 	}
 
-	if (tab == 0) {
-		auto it = m_borderDrafts.find(tileId);
-		if (it == m_borderDrafts.end()) {
-			return false;
-		}
+	auto it = m_borderDrafts.find(tileId);
+	if (it == m_borderDrafts.end()) {
+		return false;
+	}
 
-		m_isRestoringDraft = true;
-		ClearItems(false);
+	m_isRestoringDraft = true;
+	ClearItems(false);
 
-		const BorderDraftState &d = it->second;
-		m_currentBorderId = d.currentBorderId;
-		m_loadedBorderName = d.borderName;
-		if (m_groupCheck) {
-			m_groupCheck->SetValue(d.group);
-		}
-		if (m_isOptionalCheck) {
-			m_isOptionalCheck->SetValue(d.optional);
-		}
-		if (m_isGroundCheck) {
-			m_isGroundCheck->SetValue(d.ground);
-		}
+	const BorderDraftState &d = it->second;
+	m_currentBorderId = d.currentBorderId;
+	m_loadedBorderName = d.borderName;
+	if (m_groupCheck) {
+		m_groupCheck->SetValue(d.group);
+	}
+	if (m_isOptionalCheck) {
+		m_isOptionalCheck->SetValue(d.optional);
+	}
+	if (m_isGroundCheck) {
+		m_isGroundCheck->SetValue(d.ground);
+	}
 
-		m_borderItems = d.items;
-		if (m_gridPanel) {
-			for (const BorderItem &item : m_borderItems) {
-				m_gridPanel->SetItemId(item.position, item.itemId);
-			}
+	m_borderItems = d.items;
+	if (m_gridPanel) {
+		for (const BorderItem &item : m_borderItems) {
+			m_gridPanel->SetItemId(item.position, item.itemId);
 		}
-		UpdatePreview();
-		m_isRestoringDraft = false;
-		return true;
+	}
+	UpdatePreview();
+	m_isRestoringDraft = false;
+	UpdateBrowserLabel();
+	return true;
+}
+
+bool BorderEditorPanel::RestoreDraft(int tab, const wxString &brushName) {
+	if (brushName.IsEmpty()) {
+		return false;
 	}
 
 	if (tab == 1) {
-		auto it = m_groundDrafts.find(tileId);
+		auto it = m_groundDrafts.find(brushName);
 		if (it == m_groundDrafts.end()) {
 			return false;
 		}
@@ -742,7 +954,6 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 		if (m_includeInnerCheck) {
 			m_includeInnerCheck->SetValue(d.includeInner);
 		}
-
 		if (m_groundGridContainer) {
 			m_groundGridContainer->Clear();
 			for (const auto &item : d.items) {
@@ -754,13 +965,13 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 		if (m_groundPreviewPanel && m_groundGridContainer) {
 			m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
 		}
-
 		m_isRestoringDraft = false;
+		UpdateBrowserLabel();
 		return true;
 	}
 
 	if (tab == 2) {
-		auto it = m_wallDrafts.find(tileId);
+		auto it = m_wallDrafts.find(brushName);
 		if (it == m_wallDrafts.end()) {
 			return false;
 		}
@@ -769,10 +980,9 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 		ClearWallItems(false);
 
 		const WallDraftState &d = it->second;
-		if (m_groundNameCtrl) {
-			m_groundNameCtrl->SetValue(d.brushName);
+		if (m_wallNameCtrl) {
+			m_wallNameCtrl->SetValue(d.brushName);
 		}
-
 		m_wallTypes = d.wallTypes;
 		if (m_wallGridPanel) {
 			m_wallGridPanel->SetWallTypes(m_wallTypes);
@@ -782,8 +992,8 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 			m_wallVisualPanel->SetWallItems(m_wallTypes);
 		}
 		UpdateWallItemsList();
-
 		m_isRestoringDraft = false;
+		UpdateBrowserLabel();
 		return true;
 	}
 
@@ -791,39 +1001,45 @@ bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
 }
 
 void BorderEditorPanel::DiscardDraft(int tab, uint16_t tileId) {
-	if (tileId == 0) {
+	if (tileId == 0 || tab != 0) {
 		return;
 	}
+	m_borderDrafts.erase(tileId);
+}
 
-	switch (tab) {
-		case 0:
-			m_borderDrafts.erase(tileId);
-			break;
-		case 1:
-			m_groundDrafts.erase(tileId);
-			break;
-		case 2:
-			m_wallDrafts.erase(tileId);
-			break;
-		default:
-			break;
+void BorderEditorPanel::DiscardDraft(int tab, const wxString &brushName) {
+	if (brushName.IsEmpty()) {
+		return;
+	}
+	if (tab == 1) {
+		m_groundDrafts.erase(brushName);
+	} else if (tab == 2) {
+		m_wallDrafts.erase(brushName);
 	}
 }
 
 void BorderEditorPanel::SaveCurrentDraft(bool markDirty) {
-	if (m_selectedBrowserTileId == 0) {
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	if (selectionKey.IsEmpty()) {
 		return;
 	}
-
-	SaveDraft(m_activeTab, m_selectedBrowserTileId, markDirty);
+	if (m_activeTab == 0) {
+		SaveDraft(m_activeTab, static_cast<uint16_t>(wxAtoi(selectionKey)), markDirty);
+	} else {
+		SaveDraft(m_activeTab, selectionKey, markDirty);
+	}
 }
 
 void BorderEditorPanel::DiscardCurrentDraft() {
-	if (m_selectedBrowserTileId == 0) {
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	if (selectionKey.IsEmpty()) {
 		return;
 	}
-
-	DiscardDraft(m_activeTab, m_selectedBrowserTileId);
+	if (m_activeTab == 0) {
+		DiscardDraft(m_activeTab, static_cast<uint16_t>(wxAtoi(selectionKey)));
+	} else {
+		DiscardDraft(m_activeTab, selectionKey);
+	}
 }
 
 void BorderEditorPanel::OnBorderDraftChange(wxCommandEvent &event) {
@@ -844,6 +1060,34 @@ void BorderEditorPanel::OnWallDraftChange(wxCommandEvent &event) {
 void BorderEditorPanel::CreateGUIControls() {
 	wxBoxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
 
+	wxStaticBoxSizer* inspectorHeaderSizer = new wxStaticBoxSizer(wxVERTICAL, this, "Inspector");
+	m_inspectorTitleLabel = new wxStaticText(inspectorHeaderSizer->GetStaticBox(), wxID_ANY, "No brush selected");
+	wxFont inspectorTitleFont = m_inspectorTitleLabel->GetFont();
+	inspectorTitleFont.MakeBold();
+	m_inspectorTitleLabel->SetFont(inspectorTitleFont);
+	inspectorHeaderSizer->Add(m_inspectorTitleLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 6);
+	m_inspectorMetaLabel = new wxStaticText(inspectorHeaderSizer->GetStaticBox(), wxID_ANY, "Select a brush or palette to see summary, flags, and source info.");
+	inspectorHeaderSizer->Add(m_inspectorMetaLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
+	m_inspectorGeneralButton = nullptr;
+	m_inspectorPaletteButton = nullptr;
+	m_inspectorEditorButton = nullptr;
+	m_inspectorPreviewButton = nullptr;
+
+	wxFlexGridSizer* inspectorSectionsSizer = new wxFlexGridSizer(2, 2, 4, 12);
+	inspectorSectionsSizer->AddGrowableCol(0, 1);
+	inspectorSectionsSizer->AddGrowableCol(1, 1);
+
+	m_inspectorGeneralStateLabel = new wxStaticText(inspectorHeaderSizer->GetStaticBox(), wxID_ANY, "General: No brush selected");
+	inspectorSectionsSizer->Add(m_inspectorGeneralStateLabel, 1, wxEXPAND | wxTOP, 2);
+	m_inspectorPalettesStateLabel = new wxStaticText(inspectorHeaderSizer->GetStaticBox(), wxID_ANY, "Palettes: No palette data");
+	inspectorSectionsSizer->Add(m_inspectorPalettesStateLabel, 1, wxEXPAND | wxTOP, 2);
+	m_inspectorFlagsStateLabel = new wxStaticText(inspectorHeaderSizer->GetStaticBox(), wxID_ANY, "Flags: No flags available");
+	inspectorSectionsSizer->Add(m_inspectorFlagsStateLabel, 1, wxEXPAND | wxBOTTOM, 2);
+	m_inspectorAdvancedStateLabel = new wxStaticText(inspectorHeaderSizer->GetStaticBox(), wxID_ANY, "Advanced: No source loaded");
+	inspectorSectionsSizer->Add(m_inspectorAdvancedStateLabel, 1, wxEXPAND | wxBOTTOM, 2);
+
+	inspectorHeaderSizer->Add(inspectorSectionsSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 6);
+
 	// Create simplebook (no visible tabs - switching via sidebar buttons)
 	m_notebook = new wxSimplebook(this, wxID_ANY);
 
@@ -851,32 +1095,33 @@ void BorderEditorPanel::CreateGUIControls() {
 	m_borderPanel = new wxPanel(m_notebook);
 	wxBoxSizer* borderSizer = new wxBoxSizer(wxVERTICAL);
 
-	// --- Top Toolbar: Name + Checkboxes (Merged) ---
+	// --- General Section ---
+	wxStaticBoxSizer* borderGeneralSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "General");
 	wxBoxSizer* toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
 
-	// Checkboxes (Right side of toolbar)
-	m_groupCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Group");
+	m_groupCheck = new wxCheckBox(borderGeneralSizer->GetStaticBox(), wxID_ANY, "Group");
 	m_groupCheck->SetToolTip("Check to assign this border to a group");
 	m_groupCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
 	toolbarSizer->Add(m_groupCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
 
-	m_isOptionalCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Optional");
+	m_isOptionalCheck = new wxCheckBox(borderGeneralSizer->GetStaticBox(), wxID_ANY, "Optional");
 	m_isOptionalCheck->SetToolTip("Marks this border as optional");
 	m_isOptionalCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
 	toolbarSizer->Add(m_isOptionalCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
 
-	m_isGroundCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Ground");
+	m_isGroundCheck = new wxCheckBox(borderGeneralSizer->GetStaticBox(), wxID_ANY, "Ground");
 	m_isGroundCheck->SetToolTip("Marks this border as a ground border");
 	m_isGroundCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
 	toolbarSizer->Add(m_isGroundCheck, 0, wxALIGN_CENTER_VERTICAL);
 
-	borderSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 5);
+	borderGeneralSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 5);
+	borderSizer->Add(borderGeneralSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
 
 	// --- Main Content: Palette (Left) + Editor/Preview (Right) ---
 	wxBoxSizer* borderContentSizer = new wxBoxSizer(wxHORIZONTAL);
 
-	// === Left Column: Raw Item Palette (takes full height) ===
-	wxBoxSizer* leftColumnSizer = new wxBoxSizer(wxVERTICAL);
+	// === Left Column: Assets / Source ===
+	wxStaticBoxSizer* leftColumnSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Assets");
 
 	// Raw Item Palette - shows all raw items for selection    // Raw Item Palette - shows all raw items for selection
 	// Category Selector Row (ComboBox + Filter Button)
@@ -898,12 +1143,11 @@ void BorderEditorPanel::CreateGUIControls() {
 	borderFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
 	borderTilesetRowSizer->Add(borderFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
 
-	leftColumnSizer->Add(borderTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+	leftColumnSizer->Add(borderTilesetRowSizer, 0, wxEXPAND | wxALL, 5);
 
-	m_itemPalettePanel = new SimpleRawPalettePanel(m_borderPanel);
-	// m_itemPalettePanel->SetListType(BRUSHLIST_LARGE_ICONS);
-	m_itemPalettePanel->SetMinSize(wxSize(220, 300));
-	leftColumnSizer->Add(m_itemPalettePanel, 1, wxEXPAND | wxALL, 5);
+	m_itemPalettePanel = new SimpleRawPalettePanel(leftColumnSizer->GetStaticBox());
+	m_itemPalettePanel->SetMinSize(wxSize(220, 220));
+	leftColumnSizer->Add(m_itemPalettePanel, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
 	borderContentSizer->Add(leftColumnSizer, 0, wxEXPAND);
 
@@ -947,30 +1191,32 @@ void BorderEditorPanel::CreateGUIControls() {
 	m_groundPanel = new wxPanel(m_notebook);
 	wxBoxSizer* groundSizer = new wxBoxSizer(wxVERTICAL);
 
-	// === Left Column: Form Controls ===
-	wxBoxSizer* groundLeftSizer = new wxBoxSizer(wxVERTICAL);
+	// === General Section ===
+	wxStaticBoxSizer* groundGeneralSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "General");
 
 	wxBoxSizer* row1 = new wxBoxSizer(wxHORIZONTAL);
-	row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-	m_groundNameCtrl = new wxTextCtrl(m_groundPanel, wxID_ANY, "");
+	row1->Add(new wxStaticText(groundGeneralSizer->GetStaticBox(), wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	m_groundNameCtrl = new wxTextCtrl(groundGeneralSizer->GetStaticBox(), wxID_ANY, "");
 	m_groundNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnGroundDraftChange, this);
 	row1->Add(m_groundNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-	groundLeftSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 5);
+	groundGeneralSizer->Add(row1, 0, wxEXPAND | wxALL, 5);
 
 	wxBoxSizer* row2 = new wxBoxSizer(wxHORIZONTAL);
-	row2->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Z-Order:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-	m_zOrderCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(60, -1));
+	row2->Add(new wxStaticText(groundGeneralSizer->GetStaticBox(), wxID_ANY, "Z-Order:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	m_zOrderCtrl = new wxSpinCtrl(groundGeneralSizer->GetStaticBox(), wxID_ANY, "0", wxDefaultPosition, wxSize(60, -1));
 	m_zOrderCtrl->SetRange(-100, 100);
 	m_zOrderCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnGroundDraftChange, this);
 	row2->Add(m_zOrderCtrl, 0);
-	groundLeftSizer->Add(row2, 0, wxEXPAND | wxBOTTOM, 5);
+	groundGeneralSizer->Add(row2, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
 	// Item Palette / Selection
 	wxBoxSizer* row3 = new wxBoxSizer(wxHORIZONTAL);
 	// Chance control removed
-	groundLeftSizer->Add(row3, 0, wxEXPAND | wxBOTTOM, 5);
+	groundGeneralSizer->Add(row3, 0, wxEXPAND | wxBOTTOM, 5);
+	groundSizer->Add(groundGeneralSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
 
 	// Preview Panel moved to right column
+	wxStaticBoxSizer* groundAssetsSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Palettes & Source");
 	wxBoxSizer* tilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
 	tilesetRowSizer->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
 
@@ -980,33 +1226,28 @@ void BorderEditorPanel::CreateGUIControls() {
 	// === Left Column: Raw Item Palette ===
 	// Tileset selector row (ComboBox + Gear button)
 
-	m_groundTilesetButton = new wxButton(m_groundPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+	m_groundTilesetButton = new wxButton(groundAssetsSizer->GetStaticBox(), wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
 	m_groundTilesetButton->SetToolTip("Select Tileset");
 	m_groundTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnGroundTilesetButtonClick, this);
 	tilesetRowSizer->Add(m_groundTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
 
 	// Filter button with Cut icon (scissors)
-	m_tilesetFilterBtn = new wxBitmapButton(m_groundPanel, wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+	m_tilesetFilterBtn = new wxBitmapButton(groundAssetsSizer->GetStaticBox(), wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
 	m_tilesetFilterBtn->SetToolTip("Filter visible tilesets");
 	m_tilesetFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
 	tilesetRowSizer->Add(m_tilesetFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
 
-	groundLeftSizer->Add(tilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+	groundAssetsSizer->Add(tilesetRowSizer, 0, wxEXPAND | wxALL, 5);
 
-	m_groundPalette = new SimpleRawPalettePanel(m_groundPanel);
-	m_groundPalette->SetMinSize(wxSize(220, 200));
+	m_groundPalette = new SimpleRawPalettePanel(groundAssetsSizer->GetStaticBox());
+	m_groundPalette->SetMinSize(wxSize(180, 110));
 	m_groundPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundPaletteSelect, this);
-	groundLeftSizer->Add(m_groundPalette, 1, wxEXPAND | wxALL, 5);
-	groundContentSizer->Add(groundLeftSizer, 0, wxEXPAND);
+	groundAssetsSizer->Add(m_groundPalette, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	groundAssetsSizer->GetStaticBox()->SetMinSize(wxSize(230, -1));
+	groundContentSizer->Add(groundAssetsSizer, 0, wxEXPAND | wxRIGHT, 5);
 
-	// === Right Column: Editor Controls (Scrollable List) ===
-	// === Right Column: Editor Controls (Scrollable List) ===
+	// === Right Column: Editor Controls ===
 	wxBoxSizer* groundRightSizer = new wxBoxSizer(wxVERTICAL);
-
-	// Preview (Directly in sizer for seamless look)
-	m_groundPreviewPanel = new GroundPreviewPanel(m_groundPanel, wxID_ANY);
-	// m_groundPreviewPanel size is set in constructor (96x96)
-	groundRightSizer->Add(m_groundPreviewPanel, 0, wxALIGN_CENTER | wxALL, 10);
 
 	wxStaticBoxSizer* groundEditorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Variations");
 
@@ -1025,7 +1266,11 @@ void BorderEditorPanel::CreateGUIControls() {
 	addVarSizer->Add(m_addVariationBtn, 0);
 	groundEditorBoxSizer->Add(addVarSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-	groundRightSizer->Add(groundEditorBoxSizer, 1, wxEXPAND | wxALL, 5);
+	groundRightSizer->Add(groundEditorBoxSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	wxBoxSizer* groundBottomSizer = new wxBoxSizer(wxHORIZONTAL);
+	m_groundPreviewPanel = new GroundPreviewPanel(m_groundPanel, wxID_ANY);
+	groundBottomSizer->Add(m_groundPreviewPanel, 0, wxALIGN_TOP | wxRIGHT, 10);
 
 	// Border Options inside StaticBox
 	wxStaticBoxSizer* borderOptionsBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Border Options");
@@ -1047,9 +1292,10 @@ void BorderEditorPanel::CreateGUIControls() {
 	borderOptionsRow->Add(m_includeInnerCheck, 0, wxALIGN_CENTER_VERTICAL);
 
 	borderOptionsBoxSizer->Add(borderOptionsRow, 0, wxEXPAND | wxALL, 5);
-	groundRightSizer->Add(borderOptionsBoxSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	groundBottomSizer->Add(borderOptionsBoxSizer, 1, wxEXPAND);
+	groundRightSizer->Add(groundBottomSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-	groundContentSizer->Add(groundRightSizer, 1, wxEXPAND | wxLEFT, 5);
+	groundContentSizer->Add(groundRightSizer, 1, wxEXPAND);
 	groundSizer->Add(groundContentSizer, 1, wxEXPAND | wxALL, 5);
 
 	// --- Footer: Right-aligned buttons ---
@@ -1077,39 +1323,47 @@ void BorderEditorPanel::CreateGUIControls() {
 	m_wallPanel = new wxPanel(m_notebook);
 	wxBoxSizer* wallSizer = new wxBoxSizer(wxVERTICAL);
 
+	wxStaticBoxSizer* wallGeneralSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "General");
+	wxBoxSizer* wallNameRow = new wxBoxSizer(wxHORIZONTAL);
+	wallNameRow->Add(new wxStaticText(wallGeneralSizer->GetStaticBox(), wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	m_wallNameCtrl = new wxTextCtrl(wallGeneralSizer->GetStaticBox(), wxID_ANY, "");
+	m_wallNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnWallDraftChange, this);
+	wallNameRow->Add(m_wallNameCtrl, 1, wxALIGN_CENTER_VERTICAL);
+	wallGeneralSizer->Add(wallNameRow, 0, wxEXPAND | wxALL, 5);
+	wallSizer->Add(wallGeneralSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
+
 	// --- Main Body: Palette (Left) + Editor (Right) ---
 	wxBoxSizer* wallContentSizer = new wxBoxSizer(wxHORIZONTAL);
 
-	// === Left Column: Raw Item Palette ===
-	// === Left Column: Raw Item Palette ===
-	wxBoxSizer* wallLeftSizer = new wxBoxSizer(wxVERTICAL);
+	// === Left Column: Palettes / Source ===
+	wxStaticBoxSizer* wallAssetsSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Palettes & Source");
 
 	// Tileset selector row (ComboBox + Filter button)
 	wxBoxSizer* wallTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
-	wallTilesetRowSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	wallTilesetRowSizer->Add(new wxStaticText(wallAssetsSizer->GetStaticBox(), wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
 
-	m_wallTilesetButton = new wxButton(m_wallPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+	m_wallTilesetButton = new wxButton(wallAssetsSizer->GetStaticBox(), wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
 	m_wallTilesetButton->SetToolTip("Select Tileset");
 	m_wallTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnWallTilesetButtonClick, this);
 	wallTilesetRowSizer->Add(m_wallTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
 
 	// Filter button
-	wxBitmapButton* wallFilterBtn = new wxBitmapButton(m_wallPanel, wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+	wxBitmapButton* wallFilterBtn = new wxBitmapButton(wallAssetsSizer->GetStaticBox(), wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
 	wallFilterBtn->SetToolTip("Filter visible tilesets");
 	wallFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
 	wallTilesetRowSizer->Add(wallFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
 
-	wallLeftSizer->Add(wallTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+	wallAssetsSizer->Add(wallTilesetRowSizer, 0, wxEXPAND | wxALL, 5);
 
-	m_wallPalette = new SimpleRawPalettePanel(m_wallPanel);
-	m_wallPalette->SetMinSize(wxSize(220, 300));
+	m_wallPalette = new SimpleRawPalettePanel(wallAssetsSizer->GetStaticBox());
+	m_wallPalette->SetMinSize(wxSize(220, 220));
 	m_wallPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnWallPaletteSelect, this);
-	wallLeftSizer->Add(m_wallPalette, 1, wxEXPAND | wxALL, 5);
+	wallAssetsSizer->Add(m_wallPalette, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-	wallContentSizer->Add(wallLeftSizer, 0, wxEXPAND);
+	wallContentSizer->Add(wallAssetsSizer, 0, wxEXPAND);
 
 	// === Right Column: Editor Controls ===
-	wxBoxSizer* wallRightSizer = new wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* wallRightSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	// Wall Structure inside StaticBox
 	wxStaticBoxSizer* structureSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Wall Structure");
@@ -1149,14 +1403,14 @@ void BorderEditorPanel::CreateGUIControls() {
 	// wallItemInputSizer->Add(remWallItemBtn, 0);
 
 	// structureSizer->Add(wallItemInputSizer, 0, wxEXPAND | wxALL, 5);
-	wallRightSizer->Add(structureSizer, 1, wxEXPAND | wxALL, 5);
+	wallRightSizer->Add(structureSizer, 1, wxEXPAND | wxTOP | wxBOTTOM | wxLEFT, 5);
 
 	// Preview inside StaticBox
 	wxStaticBoxSizer* wallVisualSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Preview");
 	m_wallVisualPanel = new WallVisualPanel(wallVisualSizer->GetStaticBox());
-	m_wallVisualPanel->SetMinSize(wxSize(150, 150));
+	m_wallVisualPanel->SetMinSize(wxSize(170, 170));
 	wallVisualSizer->Add(m_wallVisualPanel, 1, wxEXPAND | wxALL, 5);
-	wallRightSizer->Add(wallVisualSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	wallRightSizer->Add(wallVisualSizer, 0, wxEXPAND | wxALL, 5);
 
 	wallContentSizer->Add(wallRightSizer, 1, wxEXPAND | wxLEFT, 5);
 	wallSizer->Add(wallContentSizer, 1, wxEXPAND | wxALL, 5);
@@ -1170,8 +1424,8 @@ void BorderEditorPanel::CreateGUIControls() {
 	wallNewButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent &ev) {
 		DiscardCurrentDraft();
 		ClearWallItems();
-		if (m_groundNameCtrl) {
-			m_groundNameCtrl->SetValue("");
+		if (m_wallNameCtrl) {
+			m_wallNameCtrl->SetValue("");
 		}
 		if (m_borderBrowserList) {
 			m_borderBrowserList->SetSelection(wxNOT_FOUND);
@@ -1192,11 +1446,14 @@ void BorderEditorPanel::CreateGUIControls() {
 	// ========== HORIZONTAL LAYOUT: Content (Left) + Browser (Right) ==========
 	wxBoxSizer* mainHorizSizer = new wxBoxSizer(wxHORIZONTAL);
 
-	// LEFT: Add notebook (existing content)
-	mainHorizSizer->Add(m_notebook, 1, wxEXPAND | wxALL, 5);
+	wxBoxSizer* leftContentSizer = new wxBoxSizer(wxVERTICAL);
+	leftContentSizer->Add(inspectorHeaderSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
+	leftContentSizer->Add(m_notebook, 1, wxEXPAND | wxALL, 5);
+	mainHorizSizer->Add(leftContentSizer, 1, wxEXPAND);
 
 	// RIGHT: Browser Sidebar
 	wxBoxSizer* browserSizer = new wxBoxSizer(wxVERTICAL);
+	browserSizer->SetMinSize(wxSize(290, -1));
 
 	// Mode Switcher Buttons (replaces m_browserLabel)
 	wxBoxSizer* modeSwitcherSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -1217,16 +1474,78 @@ void BorderEditorPanel::CreateGUIControls() {
 
 	browserSizer->Add(modeSwitcherSizer, 0, wxEXPAND | wxALL, 5);
 
-	m_browserTilesetFilterButton = new wxButton(this, wxID_ANY, "Tileset: Select ▼", wxDefaultPosition, wxSize(280, -1), wxBU_LEFT);
+	m_browserPaletteCategoryButton = new wxButton(this, wxID_ANY, "Category: Terrain ▼", wxDefaultPosition, wxSize(240, -1), wxBU_LEFT);
+	m_browserPaletteCategoryButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserPaletteCategoryButtonClick, this);
+	browserSizer->Add(m_browserPaletteCategoryButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	m_browserTilesetFilterButton = new wxButton(this, wxID_ANY, "Tileset: All ▼", wxDefaultPosition, wxSize(240, -1), wxBU_LEFT);
 	m_browserTilesetFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserTilesetFilterButtonClick, this);
 	browserSizer->Add(m_browserTilesetFilterButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
+	m_browserBrushesViewBtn = nullptr;
+	m_browserPalettesViewBtn = nullptr;
+
 	// Search control
-	m_browserSearchCtrl = new wxSearchCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(280, -1));
-	m_browserSearchCtrl->SetDescriptiveText("Search...");
+	m_browserSearchCtrl = new wxSearchCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(240, -1));
+	m_browserSearchCtrl->SetDescriptiveText("Search brushes...");
 	m_browserSearchCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &BorderEditorPanel::OnBrowserSearch, this);
 	m_browserSearchCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnBrowserSearch, this);
 	browserSizer->Add(m_browserSearchCtrl, 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
+
+	wxStaticBoxSizer* selectionSummarySizer = new wxStaticBoxSizer(wxVERTICAL, this, "Current Selection");
+	m_browserLabel = new wxStaticText(selectionSummarySizer->GetStaticBox(), wxID_ANY, "No brush selected");
+	wxFont titleFont = m_browserLabel->GetFont();
+	titleFont.MakeBold();
+	m_browserLabel->SetFont(titleFont);
+	selectionSummarySizer->Add(m_browserLabel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
+	m_browserMetaLabel = new wxStaticText(selectionSummarySizer->GetStaticBox(), wxID_ANY, "Select a brush in the browser to see its details.");
+	m_browserMetaLabel->Wrap(200);
+	selectionSummarySizer->Add(m_browserMetaLabel, 0, wxEXPAND | wxALL, 5);
+	browserSizer->Add(selectionSummarySizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
+
+	wxGridSizer* browserActionSizer = new wxGridSizer(2, 3, 4, 4);
+	m_browserNewEntityButton = new wxButton(this, wxID_ANY, "New");
+	m_browserNewEntityButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserNewEntity, this);
+	browserActionSizer->Add(m_browserNewEntityButton, 1, wxEXPAND);
+	m_browserDuplicateButton = new wxButton(this, wxID_ANY, "Duplicate");
+	m_browserDuplicateButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserDuplicateEntity, this);
+	browserActionSizer->Add(m_browserDuplicateButton, 1, wxEXPAND);
+	m_browserDeleteButton = new wxButton(this, wxID_ANY, "Delete");
+	m_browserDeleteButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserDeleteEntity, this);
+	browserActionSizer->Add(m_browserDeleteButton, 1, wxEXPAND);
+	m_browserSaveButton = new wxButton(this, wxID_ANY, "Save");
+	m_browserSaveButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnSave, this);
+	browserActionSizer->Add(m_browserSaveButton, 1, wxEXPAND);
+	m_browserReloadButton = new wxButton(this, wxID_ANY, "Reload");
+	m_browserReloadButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserReloadEntity, this);
+	browserActionSizer->Add(m_browserReloadButton, 1, wxEXPAND);
+	browserSizer->Add(browserActionSizer, 0, wxEXPAND | wxALL, 5);
+
+	wxStaticBoxSizer* paletteSummarySizer = new wxStaticBoxSizer(wxVERTICAL, this, "Palette Navigation");
+	m_browserPaletteList = new wxListBox(paletteSummarySizer->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(220, 100), 0, nullptr, wxLB_SINGLE);
+	m_browserPaletteList->Bind(wxEVT_LISTBOX, &BorderEditorPanel::OnBrowserPaletteSelection, this);
+	paletteSummarySizer->Add(m_browserPaletteList, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 5);
+	wxGridSizer* paletteButtonSizer = new wxGridSizer(3, 2, 4, 4);
+	m_browserNewPaletteButton = new wxButton(paletteSummarySizer->GetStaticBox(), wxID_ANY, "New Palette");
+	m_browserNewPaletteButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserNewPalette, this);
+	paletteButtonSizer->Add(m_browserNewPaletteButton, 1, wxEXPAND);
+	m_browserDeletePaletteButton = new wxButton(paletteSummarySizer->GetStaticBox(), wxID_ANY, "Delete Palette");
+	m_browserDeletePaletteButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserDeletePalette, this);
+	paletteButtonSizer->Add(m_browserDeletePaletteButton, 1, wxEXPAND);
+	m_browserAttachPaletteButton = new wxButton(paletteSummarySizer->GetStaticBox(), wxID_ANY, "Attach");
+	m_browserAttachPaletteButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserAttachPalette, this);
+	paletteButtonSizer->Add(m_browserAttachPaletteButton, 1, wxEXPAND);
+	m_browserDetachPaletteButton = new wxButton(paletteSummarySizer->GetStaticBox(), wxID_ANY, "Detach");
+	m_browserDetachPaletteButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserDetachPalette, this);
+	paletteButtonSizer->Add(m_browserDetachPaletteButton, 1, wxEXPAND);
+	m_browserApplyPaletteFilterButton = new wxButton(paletteSummarySizer->GetStaticBox(), wxID_ANY, "Filter Brushes");
+	m_browserApplyPaletteFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserApplyPaletteFilter, this);
+	paletteButtonSizer->Add(m_browserApplyPaletteFilterButton, 1, wxEXPAND);
+	m_browserClearPaletteFilterButton = new wxButton(paletteSummarySizer->GetStaticBox(), wxID_ANY, "Clear Tileset");
+	m_browserClearPaletteFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserClearPaletteFilter, this);
+	paletteButtonSizer->Add(m_browserClearPaletteFilterButton, 1, wxEXPAND);
+	paletteSummarySizer->Add(paletteButtonSizer, 0, wxEXPAND | wxALL, 5);
+	browserSizer->Add(paletteSummarySizer, 1, wxEXPAND | wxLEFT | wxRIGHT, 5);
 
 	m_borderBrowserList = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxSize(280, -1), 0, nullptr, wxLB_SINGLE | wxBORDER_NONE);
 	m_borderBrowserList->Hide();
@@ -1243,55 +1562,23 @@ void BorderEditorPanel::CreateGUIControls() {
 	topSizer->Add(mainHorizSizer, 1, wxEXPAND);
 
 	SetSizer(topSizer);
+	UpdateInspectorHeader();
 	Layout();
 
-	// Initialize Category Combo (Select Borders if available)
-	// Initialize Category Button (Select Borders if available)
+	// Delay palette/browser loading until the panel is shown.
 	if (!m_rawCategoryNames.IsEmpty()) {
 		int defaults = m_rawCategoryNames.Index("Borders");
-		if (defaults != wxNOT_FOUND) {
-			m_rawCategorySelection = defaults;
-		} else {
-			m_rawCategorySelection = 0;
-		}
-
+		m_rawCategorySelection = (defaults != wxNOT_FOUND) ? defaults : 0;
 		if (m_rawCategoryButton) {
 			m_rawCategoryButton->SetLabel(m_rawCategoryNames[m_rawCategorySelection] + " \u25BC");
 		}
-
-		// Trigger load
-		if (m_itemPalettePanel) {
-			m_itemPalettePanel->LoadTileset(m_rawCategoryNames[m_rawCategorySelection]);
-		}
 	}
-
-	// Initialize Tileset Choice (Ground Tab)
-	LoadTilesets(); // Ensure m_tilesetListData is populated
-
-	// Select first tileset if any
-	if (!m_tilesetListData.IsEmpty()) {
-		m_groundTilesetSelection = 0;
-		if (m_groundTilesetButton) {
-			m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
-		}
-
-		// Trigger load for ground
-		if (m_groundPalette) {
-			m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
-		}
+	if (m_groundTilesetButton) {
+		m_groundTilesetButton->SetLabel("Select Tileset ▼");
 	}
-
-	{
-		const auto options = GetBrowserTilesetOptions();
-		if (!options.empty() && m_browserTilesetFilter.IsEmpty()) {
-			m_browserTilesetFilter = options.front().second;
-			if (m_browserTilesetFilterButton) {
-				m_browserTilesetFilterButton->SetLabel("Tileset: " + options.front().first + " ▼");
-			}
-		}
+	if (m_wallTilesetButton) {
+		m_wallTilesetButton->SetLabel("Select Tileset ▼");
 	}
-
-	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
 void BorderEditorPanel::OnRawCategoryButtonClick(wxCommandEvent &event) {
@@ -1587,15 +1874,20 @@ void TilesetFilterDialog::OnSelectNone(wxCommandEvent &event) {
 void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
 	if (name.IsEmpty()) {
 		ClearWallItems();
+		UpdateBrowserLabel();
+		return;
+	}
+	if (RestoreDraft(2, name)) {
 		return;
 	}
 
-	// Find the walls.xml file
+	EnsureBrushCatalogUpToDate();
+	const BrushEditorBrushDefinition* brushDef = m_catalog.FindBrushByName(name);
+	const BrushEditorStorageLocation* storage = brushDef ? brushDef->GetPrimaryStorage() : nullptr;
 	wxString dataDir = g_gui.GetDataDirectory();
-
-	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
-
-	// Load XML
+	wxString wallsFile = storage && !storage->filePath.IsEmpty()
+		? storage->filePath
+		: dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 	pugi::xml_document doc;
 	if (!LoadXmlWithCache(wallsFile, doc)) {
 		return;
@@ -1611,8 +1903,8 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
 		pugi::xml_attribute nameAttr = brushNode.attribute("name");
 		if (nameAttr && wxString(nameAttr.as_string()) == name) {
 			ClearWallItems(false);
-			if (m_groundNameCtrl) {
-				m_groundNameCtrl->SetValue(name);
+			if (m_wallNameCtrl) {
+				m_wallNameCtrl->SetValue(name);
 			}
 			m_wallTypes.clear();
 
@@ -1655,6 +1947,7 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
 			m_wallGridPanel->SetSelectedType("vertical"); // Default
 			UpdateWallItemsList();
 			m_wallVisualPanel->SetWallItems(m_wallTypes);
+			UpdateBrowserLabel();
 
 			break;
 		}
@@ -1662,7 +1955,7 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
 }
 
 void BorderEditorPanel::SaveWallBrush() {
-	wxString name = m_groundNameCtrl ? m_groundNameCtrl->GetValue().Trim() : wxString();
+	wxString name = m_wallNameCtrl ? m_wallNameCtrl->GetValue().Trim() : wxString();
 
 	if (name.IsEmpty()) {
 		ShowErrorDialog("Please enter a name for the wall brush.", ErrorSeverity::Warning);
@@ -1679,23 +1972,24 @@ void BorderEditorPanel::SaveWallBrush() {
 		return;
 	}
 
-	uint16_t mainTileId = m_selectedBrowserTileId;
-	if (mainTileId == 0) {
-		for (const auto &pair : m_wallTypes) {
-			const WallTypeData &typeData = pair.second;
-			if (!typeData.items.empty()) {
-				mainTileId = typeData.items.front().itemId;
-				break;
-			}
+	uint16_t mainTileId = 0;
+	for (const auto &pair : m_wallTypes) {
+		const WallTypeData &typeData = pair.second;
+		if (!typeData.items.empty()) {
+			mainTileId = typeData.items.front().itemId;
+			break;
 		}
 	}
 
 	const int serverLookId = static_cast<int>(mainTileId);
 
-	// Find walls.xml
 	wxString dataDir = g_gui.GetDataDirectory();
-
-	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+	EnsureBrushCatalogUpToDate();
+	const BrushEditorBrushDefinition* existingBrush = m_catalog.FindBrushByName(name);
+	const BrushEditorStorageLocation* existingStorage = existingBrush ? existingBrush->GetPrimaryStorage() : nullptr;
+	wxString wallsFile = existingStorage && !existingStorage->filePath.IsEmpty()
+		? existingStorage->filePath
+		: dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 
 	pugi::xml_document doc;
 	bool loaded = doc.load_file(nstr(wallsFile).c_str());
@@ -1772,10 +2066,10 @@ void BorderEditorPanel::SaveWallBrush() {
 	}
 	InvalidateXmlCache(wallsFile);
 
-	DiscardDraft(2, mainTileId);
+	DiscardDraft(2, name);
 
 	TriggerReloadDataFiles();
-	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+	ReloadCurrentBrushEditorXml(name);
 }
 
 void BorderEditorPanel::LoadExistingWallBrushes() {
@@ -1802,14 +2096,15 @@ void BorderEditorPanel::ClearWallItems(bool clearBrowser) {
 	m_wallTypes.clear();
 	m_currentWallItemId = 0;
 
-	if (m_groundNameCtrl) {
-		m_groundNameCtrl->SetValue("");
+	if (m_wallNameCtrl) {
+		m_wallNameCtrl->SetValue("");
 	}
 
 	if (clearBrowser && m_borderBrowserList) {
 		m_borderBrowserList->SetSelection(wxNOT_FOUND);
-		m_selectedBrowserTileId = 0;
+		ClearSelectionForTab(2);
 	}
+	UpdateBrowserLabel();
 }
 
 void BorderEditorPanel::UpdateWallItemsList() {
@@ -1945,6 +2240,10 @@ void BorderEditorPanel::LoadExistingBorders() {
 
 // Helper method to load a border by ID
 void BorderEditorPanel::LoadBorderById(int borderId) {
+	if (RestoreDraft(0, static_cast<uint16_t>(borderId))) {
+		return;
+	}
+
 	wxString dataDir = g_gui.GetDataDirectory();
 	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
 
@@ -2002,6 +2301,7 @@ void BorderEditorPanel::LoadBorderById(int borderId) {
 		break;
 	}
 	UpdatePreview();
+	UpdateBrowserLabel();
 }
 
 // Browser sidebar selection handler - dispatches based on active tab
@@ -2022,24 +2322,15 @@ void BorderEditorPanel::OnBorderBrowserSelection(wxCommandEvent &event) {
 		return;
 	}
 
-	const uint16_t tileId = static_cast<uint16_t>(wxAtoi(data->GetData()));
-	if (tileId == 0) {
+	const wxString key = data->GetData();
+	if (m_activeTab != 0 && m_browserViewMode == 1) {
+		UpdateBrowserLabel();
+		UpdateBrowserActionButtons();
 		return;
 	}
 
-	m_selectedBrowserTileId = tileId;
-
-	switch (m_activeTab) {
-		case 0:
-			LoadBorderByMainTileId(tileId);
-			break;
-		case 1:
-			LoadGroundBrushByMainTileId(tileId);
-			break;
-		case 2:
-			LoadWallBrushByMainTileId(tileId);
-			break;
-	}
+	SetSelectionKeyForTab(m_activeTab, key);
+	LoadSelectionForTab(m_activeTab, key);
 }
 
 void BorderEditorPanel::OnBrowserGridSelection(wxCommandEvent &event) {
@@ -2050,26 +2341,16 @@ void BorderEditorPanel::OnBrowserGridSelection(wxCommandEvent &event) {
 		return;
 	}
 
-	RestoreBrowserSelection(key);
-
-	const uint16_t tileId = static_cast<uint16_t>(wxAtoi(key));
-	if (tileId == 0) {
+	if (m_activeTab != 0 && m_browserViewMode == 1) {
+		RestoreBrowserSelection(key);
+		UpdateBrowserLabel();
+		UpdateBrowserActionButtons();
 		return;
 	}
 
-	m_selectedBrowserTileId = tileId;
-
-	switch (m_activeTab) {
-		case 0:
-			LoadBorderByMainTileId(tileId);
-			break;
-		case 1:
-			LoadGroundBrushByMainTileId(tileId);
-			break;
-		case 2:
-			LoadWallBrushByMainTileId(tileId);
-			break;
-	}
+	RestoreBrowserSelection(key);
+	SetSelectionKeyForTab(m_activeTab, key);
+	LoadSelectionForTab(m_activeTab, key);
 }
 
 void BorderEditorPanel::OnLoadBorder(wxCommandEvent &event) {
@@ -2290,11 +2571,11 @@ void BorderEditorPanel::OnClear(wxCommandEvent &event) {
 	DiscardCurrentDraft();
 
 	if (m_activeTab == 0) {
-		// Border tab
 		ClearItems();
-	} else {
-		// Ground tab
+	} else if (m_activeTab == 1) {
 		ClearGroundItems();
+	} else {
+		ClearWallItems();
 	}
 }
 
@@ -2319,8 +2600,9 @@ void BorderEditorPanel::ClearItems(bool clearBrowser) {
 	// Deselect browser list
 	if (clearBrowser && m_borderBrowserList) {
 		m_borderBrowserList->SetSelection(wxNOT_FOUND);
-		m_selectedBrowserTileId = 0;
+		ClearSelectionForTab(0);
 	}
+	UpdateBrowserLabel();
 }
 
 void BorderEditorPanel::UpdatePreview() {
@@ -2494,11 +2776,11 @@ void BorderEditorPanel::SaveBorder() {
 
 void BorderEditorPanel::OnSave(wxCommandEvent &event) {
 	if (m_activeTab == 0) {
-		// Border tab
 		SaveBorder();
 	} else if (m_activeTab == 1) {
-		// Ground tab
 		SaveGroundBrush();
+	} else {
+		SaveWallBrush();
 	}
 }
 
@@ -2605,7 +2887,15 @@ void SimpleRawPalettePanel::SetItemIds(const std::vector<uint16_t> &ids) {
 }
 
 void SimpleRawPalettePanel::LoadTileset(const wxString &categoryName, PaletteFilterMode filterMode) {
+	if (m_loadedCategoryName == categoryName && m_loadedFilterMode == filterMode) {
+		return;
+	}
+	m_loadedCategoryName = categoryName;
+	m_loadedFilterMode = filterMode;
+	wxWindowUpdateLocker locker(this);
 	m_itemIds.clear();
+	m_hoverIndex = -1;
+	Scroll(0, 0);
 
 	// Find the specific tileset by name
 	auto it = g_materials.tilesets.find(nstr(categoryName).c_str());
@@ -2640,11 +2930,8 @@ void SimpleRawPalettePanel::LoadTileset(const wxString &categoryName, PaletteFil
 	std::sort(m_itemIds.begin(), m_itemIds.end());
 	m_itemIds.erase(std::unique(m_itemIds.begin(), m_itemIds.end()), m_itemIds.end());
 
-	// Reset hover to avoid stuck highlighting
-	m_hoverIndex = -1;
-
 	RecalculateLayout();
-	Refresh();
+	Refresh(false);
 }
 
 SimpleRawPalettePanel::~SimpleRawPalettePanel() { }
@@ -3530,62 +3817,796 @@ void BorderEditorPanel::ClearGroundItems(bool clearBrowser) {
 	// Deselect browser list
 	if (clearBrowser && m_borderBrowserList) {
 		m_borderBrowserList->SetSelection(wxNOT_FOUND);
-		m_selectedBrowserTileId = 0;
+		ClearSelectionForTab(1);
 	}
+	UpdateBrowserLabel();
 }
 
 void BorderEditorPanel::OnPageChanged(wxBookCtrlEvent &event) {
-	SaveCurrentDraft(false);
-
-	m_activeTab = event.GetSelection();
-
-	LoadTilesets();
-
-	if (m_browserSearchCtrl) {
-		m_browserSearchCtrl->Clear();
-	}
-
-	UpdateBrowserLabel();
-
+	const int newTab = event.GetSelection();
+	m_activeTab = newTab;
+	if (m_borderModeBtn) m_borderModeBtn->SetValue(newTab == 0);
+	if (m_groundModeBtn) m_groundModeBtn->SetValue(newTab == 1);
+	if (m_wallModeBtn) m_wallModeBtn->SetValue(newTab == 2);
 	if (m_newButton) {
 		switch (m_activeTab) {
-			case 0:
-				m_newButton->SetLabel("New Border");
-				break;
-			case 1:
-				m_newButton->SetLabel("New Ground");
-				break;
-			case 2:
-				m_newButton->SetLabel("New Wall");
-				break;
+			case 0: m_newButton->SetLabel("New Border"); break;
+			case 1: m_newButton->SetLabel("New Ground"); break;
+			case 2: m_newButton->SetLabel("New Wall"); break;
 		}
 	}
-
-	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
-
-	if (m_selectedBrowserTileId != 0) {
-		RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
-		switch (m_activeTab) {
-			case 0:
-				LoadBorderByMainTileId(m_selectedBrowserTileId);
-				break;
-			case 1:
-				LoadGroundBrushByMainTileId(m_selectedBrowserTileId);
-				break;
-			case 2:
-				LoadWallBrushByMainTileId(m_selectedBrowserTileId);
-				break;
-		}
-	}
-
+	UpdateBrowserActionButtons();
 	event.Skip();
 }
 
+wxString BorderEditorPanel::GetSelectedPaletteKey() const {
+	if (m_browserPaletteList && m_browserPaletteList->IsEnabled()) {
+		const int sel = m_browserPaletteList->GetSelection();
+		if (sel != wxNOT_FOUND) {
+			return m_browserPaletteList->GetString(sel);
+		}
+	}
+	if (m_browserViewMode == 1 && m_borderBrowserList) {
+		const int sel = m_borderBrowserList->GetSelection();
+		if (sel != wxNOT_FOUND) {
+			if (wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(sel))) {
+				return data->GetData();
+			}
+		}
+	}
+	return wxString();
+}
+
+void BorderEditorPanel::UpdateBrowserActionButtons() {
+	if (!m_browserNewEntityButton || !m_browserDuplicateButton || !m_browserDeleteButton || !m_browserSaveButton || !m_browserReloadButton) {
+		return;
+	}
+	const bool hasSelection = !GetSelectionKeyForTab(m_activeTab).IsEmpty();
+	const wxString selectedPaletteKey = GetSelectedPaletteKey();
+	const bool hasPaletteSelection = !selectedPaletteKey.IsEmpty() && selectedPaletteKey != "No palettes available";
+	m_browserNewEntityButton->SetLabel(m_activeTab == 0 ? "New Border" : "New Brush");
+	m_browserDuplicateButton->Enable(m_activeTab != 0 && hasSelection && m_browserViewMode == 0);
+	m_browserDeleteButton->Enable(hasSelection && m_browserViewMode == 0);
+	m_browserSaveButton->Enable(m_browserViewMode == 0);
+	m_browserReloadButton->Enable(hasSelection && m_browserViewMode == 0);
+	if (m_browserNewPaletteButton) {
+		m_browserNewPaletteButton->SetLabel(m_activeTab == 0 ? "New Palette" : "New Palette");
+		m_browserNewPaletteButton->Enable(m_activeTab != 0);
+	}
+	if (m_browserDeletePaletteButton) {
+		m_browserDeletePaletteButton->SetLabel("Delete Palette");
+		m_browserDeletePaletteButton->Enable(m_activeTab != 0 && hasPaletteSelection);
+	}
+	if (m_browserAttachPaletteButton) {
+		m_browserAttachPaletteButton->SetLabel(m_activeTab == 0 ? "Attach" : "Attach Brush");
+		m_browserAttachPaletteButton->Enable(m_activeTab != 0 && hasSelection);
+	}
+	if (m_browserDetachPaletteButton) {
+		m_browserDetachPaletteButton->SetLabel(m_activeTab == 0 ? "Detach" : "Detach Brush");
+		m_browserDetachPaletteButton->Enable(m_activeTab != 0 && hasPaletteSelection);
+	}
+	if (m_browserApplyPaletteFilterButton) {
+		m_browserApplyPaletteFilterButton->SetLabel(m_activeTab == 0 ? "Filter Borders" : "Filter Brushes");
+		m_browserApplyPaletteFilterButton->Enable(hasPaletteSelection);
+	}
+	if (m_browserClearPaletteFilterButton) {
+		m_browserClearPaletteFilterButton->SetLabel(m_activeTab == 0 ? "Clear Filter" : "Clear Tileset");
+		m_browserClearPaletteFilterButton->Enable(!m_browserTilesetFilter.IsEmpty());
+	}
+}
+
+const BrushEditorPaletteDefinition* BorderEditorPanel::FindPaletteDefinitionForLabel(const wxString &paletteLabel) const {
+	if (paletteLabel.IsEmpty()) {
+		return nullptr;
+	}
+	if (const BrushEditorPaletteDefinition* exact = m_catalog.FindPaletteByName(paletteLabel)) {
+		return exact;
+	}
+	const wxString tilesetName = ExtractTilesetNameFromPaletteLabel(paletteLabel);
+	const int sep = paletteLabel.Find("[");
+	const wxString categoryLabel = (sep == wxNOT_FOUND) ? wxString() : paletteLabel.Mid(sep + 1).BeforeLast(']').Trim(false).Trim(true);
+	const TilesetCategoryType expectedType = GetPaletteCategoryTypeFromLabel(categoryLabel);
+	for (const BrushEditorPaletteDefinition &palette : m_catalog.palettes) {
+		if (ExtractTilesetNameFromPaletteLabel(palette.name) == tilesetName && (expectedType == TILESET_UNKNOWN || palette.categoryType == expectedType)) {
+			return &palette;
+		}
+	}
+	return nullptr;
+}
+
+wxString BorderEditorPanel::FindTilesetSourceFile(const wxString &tilesetName) const {
+	const wxString dirPath = g_gui.GetDataDirectory() + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "tilesets";
+	wxDir dir(dirPath);
+	if (!dir.IsOpened()) {
+		return wxString();
+	}
+	wxString fileName;
+	bool cont = dir.GetFirst(&fileName, "*.xml", wxDIR_FILES);
+	while (cont) {
+		const wxString filePath = dirPath + wxFileName::GetPathSeparator() + fileName;
+		pugi::xml_document doc;
+		if (doc.load_file(nstr(filePath).c_str())) {
+			for (pugi::xml_node tilesetNode = doc.child("materials").child("tileset"); tilesetNode; tilesetNode = tilesetNode.next_sibling("tileset")) {
+				if (wxString(tilesetNode.attribute("name").as_string()) == tilesetName) {
+					return filePath;
+				}
+			}
+		}
+		cont = dir.GetNext(&fileName);
+	}
+	return wxString();
+}
+
+wxString BorderEditorPanel::GetCustomPaletteFilePath() const {
+	return g_gui.GetDataDirectory() + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "tilesets" + wxFileName::GetPathSeparator() + "brush_editor_palettes.xml";
+}
+
+bool BorderEditorPanel::PersistPaletteDefinition(const wxString &tilesetName, TilesetCategoryType categoryType, bool create) {
+	if (tilesetName.IsEmpty() || categoryType == TILESET_UNKNOWN) {
+		return false;
+	}
+	const char* categoryNodeName = GetPaletteCategoryXmlNodeName(categoryType);
+	if (!categoryNodeName) {
+		return false;
+	}
+	wxString filePath = create ? GetCustomPaletteFilePath() : FindTilesetSourceFile(tilesetName);
+	if (filePath.IsEmpty()) {
+		filePath = GetCustomPaletteFilePath();
+	}
+	pugi::xml_document doc;
+	if (!wxFileExists(filePath)) {
+		if (!create) {
+			return false;
+		}
+		doc.append_child("materials");
+	} else if (!doc.load_file(nstr(filePath).c_str())) {
+		return false;
+	}
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		materials = doc.append_child("materials");
+	}
+	pugi::xml_node tilesetNode;
+	for (pugi::xml_node node = materials.child("tileset"); node; node = node.next_sibling("tileset")) {
+		if (wxString(node.attribute("name").as_string()) == tilesetName) {
+			tilesetNode = node;
+			break;
+		}
+	}
+	if (create) {
+		if (tilesetNode) {
+			return false;
+		}
+		tilesetNode = materials.append_child("tileset");
+		tilesetNode.append_attribute("name").set_value(nstr(tilesetName).c_str());
+		tilesetNode.append_child(categoryNodeName);
+	} else {
+		if (!tilesetNode) {
+			return false;
+		}
+		pugi::xml_node categoryNode = tilesetNode.child(categoryNodeName);
+		if (!categoryNode) {
+			return false;
+		}
+		if (categoryNode.child("brush")) {
+			return false;
+		}
+		tilesetNode.remove_child(categoryNode);
+		if (!tilesetNode.first_child()) {
+			materials.remove_child(tilesetNode);
+		}
+	}
+	if (!doc.save_file(nstr(filePath).c_str(), PUGIXML_TEXT("\t"))) {
+		return false;
+	}
+	InvalidateXmlCache(filePath);
+	TriggerReloadDataFiles();
+	MarkBrushCatalogDirty();
+	return true;
+}
+
+bool BorderEditorPanel::PersistBrushPaletteMembership(const wxString &brushName, const wxString &paletteLabel, bool attach) {
+	const BrushEditorPaletteDefinition* palette = FindPaletteDefinitionForLabel(paletteLabel);
+	if (!palette) {
+		return false;
+	}
+	const wxString tilesetName = ExtractTilesetNameFromPaletteLabel(palette->name);
+	const wxString filePath = FindTilesetSourceFile(tilesetName);
+	if (filePath.IsEmpty()) {
+		return false;
+	}
+	const char* categoryNodeName = GetPaletteCategoryXmlNodeName(palette->categoryType);
+	if (!categoryNodeName) {
+		return false;
+	}
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(filePath).c_str())) {
+		return false;
+	}
+	pugi::xml_node tilesetNode;
+	for (pugi::xml_node node = doc.child("materials").child("tileset"); node; node = node.next_sibling("tileset")) {
+		if (wxString(node.attribute("name").as_string()) == tilesetName) {
+			tilesetNode = node;
+			break;
+		}
+	}
+	if (!tilesetNode) {
+		return false;
+	}
+	pugi::xml_node categoryNode = tilesetNode.child(categoryNodeName);
+	if (!categoryNode && attach) {
+		categoryNode = tilesetNode.append_child(categoryNodeName);
+		categoryNode.append_attribute("name").set_value("");
+		categoryNode.remove_attribute("name");
+	}
+	if (!categoryNode) {
+		return false;
+	}
+	if (attach) {
+		for (pugi::xml_node brushNode = categoryNode.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+			if (wxString(brushNode.attribute("name").as_string()) == brushName) {
+				return true;
+			}
+		}
+		pugi::xml_node brushNode = categoryNode.append_child("brush");
+		brushNode.append_attribute("name").set_value(nstr(brushName).c_str());
+	} else {
+		bool removed = false;
+		for (pugi::xml_node brushNode = categoryNode.child("brush"); brushNode; ) {
+			pugi::xml_node next = brushNode.next_sibling("brush");
+			if (wxString(brushNode.attribute("name").as_string()) == brushName) {
+				categoryNode.remove_child(brushNode);
+				removed = true;
+			}
+			brushNode = next;
+		}
+		if (!removed) {
+			return false;
+		}
+	}
+	if (!doc.save_file(nstr(filePath).c_str(), PUGIXML_TEXT("\t"))) {
+		return false;
+	}
+	TriggerReloadDataFiles();
+	MarkBrushCatalogDirty();
+	return true;
+}
+
+void BorderEditorPanel::RefreshBrowserPaletteList() {
+	if (!m_browserPaletteList) {
+		return;
+	}
+	wxWindowUpdateLocker locker(m_browserPaletteList);
+	const wxString previousSelection = GetSelectedPaletteKey();
+	const auto restoreSelection = [this, &previousSelection]() {
+		if (!m_browserPaletteList->IsEnabled() || m_browserPaletteList->GetCount() == 0) {
+			return;
+		}
+		int selectionIndex = wxNOT_FOUND;
+		for (unsigned int i = 0; i < m_browserPaletteList->GetCount(); ++i) {
+			const wxString item = m_browserPaletteList->GetString(i);
+			if (item == previousSelection || (!m_browserTilesetFilter.IsEmpty() && ExtractTilesetNameFromPaletteLabel(item) == m_browserTilesetFilter)) {
+				selectionIndex = static_cast<int>(i);
+				break;
+			}
+		}
+		m_browserPaletteList->SetSelection(selectionIndex == wxNOT_FOUND ? 0 : selectionIndex);
+	};
+	if (!m_browserPaletteListDirty && m_browserPaletteListBuiltForTab == m_activeTab && m_browserPaletteListBuiltForCategory == m_browserPaletteCategoryFilter && m_browserPaletteList->GetCount() > 0) {
+		m_browserPaletteList->Enable(true);
+		if (m_browserPaletteCategoryButton) {
+			m_browserPaletteCategoryButton->Enable(true);
+			m_browserPaletteCategoryButton->SetLabel(m_browserPaletteCategoryFilter.IsEmpty() ? "Category: All ▼" : "Category: " + m_browserPaletteCategoryFilter + " ▼");
+		}
+		restoreSelection();
+		UpdateBrowserActionButtons();
+		return;
+	}
+
+	m_browserPaletteList->Clear();
+	m_browserPaletteList->Enable(true);
+	if (m_browserPaletteCategoryButton) {
+		m_browserPaletteCategoryButton->Enable(true);
+		m_browserPaletteCategoryButton->SetLabel(m_browserPaletteCategoryFilter.IsEmpty() ? "Category: All ▼" : "Category: " + m_browserPaletteCategoryFilter + " ▼");
+	}
+	const BrushEditorBrushKind wantedKind = (m_activeTab == 2) ? BrushEditorBrushKind::Wall : BrushEditorBrushKind::Ground;
+	const TilesetCategoryType activeCategoryType = GetPaletteCategoryTypeFromLabel(m_browserPaletteCategoryFilter);
+	for (const BrushEditorPaletteDefinition &palette : m_catalog.palettes) {
+		int count = 0;
+		for (const wxString &brushName : palette.brushNames) {
+			const BrushEditorBrushDefinition* brush = m_catalog.FindBrushByName(brushName);
+			if (brush && brush->kind == wantedKind) {
+				++count;
+			}
+		}
+		if (count == 0) {
+			continue;
+		}
+		if (activeCategoryType != TILESET_UNKNOWN && palette.categoryType != activeCategoryType) {
+			continue;
+		}
+		if (m_activeTab == 2 && palette.name.Lower().Contains("tiny borders")) {
+			continue;
+		}
+		m_browserPaletteList->Append(palette.name);
+	}
+	if (m_browserPaletteList->GetCount() == 0) {
+		m_browserPaletteList->Append("No palettes available");
+		m_browserPaletteList->Enable(false);
+		m_browserPaletteList->SetSelection(wxNOT_FOUND);
+		m_browserPaletteListDirty = false;
+		m_browserPaletteListBuiltForTab = m_activeTab;
+		m_browserPaletteListBuiltForCategory = m_browserPaletteCategoryFilter;
+		UpdateBrowserActionButtons();
+		return;
+	}
+	m_browserPaletteListDirty = false;
+	m_browserPaletteListBuiltForTab = m_activeTab;
+	m_browserPaletteListBuiltForCategory = m_browserPaletteCategoryFilter;
+	restoreSelection();
+	UpdateBrowserActionButtons();
+}
+
+void BorderEditorPanel::ApplyBrowserPaletteFilter(const wxString &paletteName) {
+	const wxString newTilesetFilter = paletteName.IsEmpty() ? wxString() : ExtractTilesetNameFromPaletteLabel(paletteName);
+	if (newTilesetFilter == m_browserTilesetFilter) {
+		UpdateBrowserActionButtons();
+		return;
+	}
+	m_browserTilesetFilter = newTilesetFilter;
+	m_browserTilesetFiltersByTab[m_activeTab] = m_browserTilesetFilter;
+	if (m_browserTilesetFilterButton) {
+		m_browserTilesetFilterButton->SetLabel(m_browserTilesetFilter.IsEmpty() ? "Tileset: Select ▼" : "Tileset: " + m_browserTilesetFilter + " ▼");
+	}
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	if (!selectionKey.IsEmpty() && RestoreBrowserSelection(selectionKey)) {
+		LoadSelectionForTab(m_activeTab, selectionKey);
+	} else if (!selectionKey.IsEmpty()) {
+		ClearSelectionForTab(m_activeTab);
+		switch (m_activeTab) {
+			case 0: ClearItems(false); break;
+			case 1: ClearGroundItems(false); break;
+			case 2: ClearWallItems(false); break;
+		}
+	}
+	UpdateBrowserLabel();
+	UpdateBrowserActionButtons();
+}
+
 void BorderEditorPanel::UpdateBrowserLabel() {
-	// No longer needed - mode is indicated by toggle buttons
+	if (!m_browserLabel || !m_browserMetaLabel) {
+		return;
+	}
+
+	wxString title = "No brush selected";
+	wxString meta = "Select a brush in the browser to see its details.";
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	const wxString selectedPaletteKey = GetSelectedPaletteKey();
+
+	if (selectionKey.IsEmpty() && !selectedPaletteKey.IsEmpty()) {
+		title = selectedPaletteKey;
+		if (const BrushEditorPaletteDefinition* palette = FindPaletteDefinitionForLabel(selectedPaletteKey)) {
+			meta = (m_activeTab == 0)
+				? "Palette filter active | Select a border from the filtered list to edit it."
+				: wxString::Format("Palette filter active | brushes: %zu", palette->brushNames.size());
+			if (!palette->sourceFile.IsEmpty()) {
+				meta += " | source: " + wxFileName(palette->sourceFile).GetFullName();
+			}
+		} else {
+			meta = (m_activeTab == 0) ? "Select a border from the filtered list to edit it." : "Select a brush from the filtered list to edit it.";
+		}
+		m_browserLabel->SetLabel(title);
+		m_browserMetaLabel->SetLabel(meta);
+		m_browserMetaLabel->Wrap(250);
+		UpdateBrowserActionButtons();
+		UpdateInspectorHeader();
+		return;
+	}
+
+	if (m_activeTab == 0) {
+		if (!selectionKey.IsEmpty() || !m_loadedBorderName.IsEmpty() || m_currentBorderId > 0) {
+			title = m_loadedBorderName.IsEmpty() ? wxString::Format("Border #%d", m_currentBorderId) : m_loadedBorderName;
+			meta = wxString::Format("Border brush | ID: %d", m_currentBorderId);
+		}
+	} else {
+		const BrushEditorBrushDefinition* brush = selectionKey.IsEmpty() ? nullptr : m_catalog.FindBrushByName(selectionKey);
+		if (brush) {
+			title = brush->name;
+			meta = "type: " + BrushEditorBrushKindToString(brush->kind);
+			std::set<wxString> seenTilesets;
+			wxString tilesets;
+			for (const BrushEditorPaletteMembership &membership : brush->memberships) {
+				if (membership.tilesetName.IsEmpty() || !seenTilesets.insert(membership.tilesetName).second) {
+					continue;
+				}
+				if (!tilesets.IsEmpty()) {
+					tilesets += ", ";
+				}
+				tilesets += membership.tilesetName;
+			}
+			if (!tilesets.IsEmpty()) {
+				meta += " | palettes: " + tilesets;
+			}
+			if (!brush->storageLocations.empty()) {
+				meta += " | source: " + wxFileName(brush->storageLocations.front().filePath).GetFullName();
+			}
+		} else if (!selectionKey.IsEmpty()) {
+			title = selectionKey;
+			meta = wxString::Format("mode: %s", m_activeTab == 1 ? "variation" : "structure");
+		}
+	}
+
+	m_browserLabel->SetLabel(title);
+	m_browserMetaLabel->SetLabel(meta);
+	m_browserMetaLabel->Wrap(250);
+	UpdateBrowserActionButtons();
+	UpdateInspectorHeader();
+}
+
+void BorderEditorPanel::UpdateInspectorHeader() {
+	if (!m_inspectorTitleLabel || !m_inspectorMetaLabel) {
+		return;
+	}
+
+	wxString title = "No brush selected";
+	wxString meta = "Select a brush or palette to see summary, flags, and source info.";
+	wxString generalState = "No brush selected";
+	wxString palettesState = "No palette data";
+	wxString flagsState = "No flags available";
+	wxString advancedState = "No source loaded";
+	const bool hasSelection = HasSelectionForTab(m_activeTab);
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	const wxString selectedPaletteKey = GetSelectedPaletteKey();
+	const BrushEditorBrushDefinition* brush = (m_activeTab == 0 || selectionKey.IsEmpty()) ? nullptr : m_catalog.FindBrushByName(selectionKey);
+	const BrushEditorPaletteDefinition* palette = (!selectionKey.IsEmpty() || selectedPaletteKey.IsEmpty()) ? nullptr : FindPaletteDefinitionForLabel(selectedPaletteKey);
+
+	if (palette) {
+		title = palette->name;
+		meta = "Palette summary · Use the navigation list to filter brushes and manage palette membership.";
+		generalState = wxString::Format("Palette: %s | Brushes: %zu", palette->name, palette->brushNames.size());
+		palettesState = "Palette view is active";
+		flagsState = "Attach, detach, create, delete, and filter actions are available.";
+		advancedState = palette->sourceFile.IsEmpty() ? "Source: custom palette storage" : "Source: " + wxFileName(palette->sourceFile).GetFullName();
+	} else if (hasSelection) {
+		title = m_browserLabel ? m_browserLabel->GetLabel() : selectionKey;
+		if (m_activeTab == 0) {
+			meta = "Border brush summary · Shows ID, flags, source status, and palette-driven filter context for the current border.";
+			generalState = wxString::Format("Border ID %d", m_currentBorderId);
+			flagsState = wxString::Format("Optional: %s | Ground: %s", m_isOptionalCheck && m_isOptionalCheck->GetValue() ? "Yes" : "No", m_isGroundCheck && m_isGroundCheck->GetValue() ? "Yes" : "No");
+			advancedState = m_loadedBorderName.IsEmpty() ? "Source: borders.xml" : "Source: borders.xml | Name: " + m_loadedBorderName;
+			palettesState = m_browserTilesetFilter.IsEmpty() ? "Palette navigation is available" : "Filtered by tileset: " + m_browserTilesetFilter;
+		} else if (m_activeTab == 1) {
+			meta = "Ground brush summary · Shows palette links, variation state, flags, and source info.";
+			generalState = wxString::Format("Name: %s | Z-Order: %d", m_groundNameCtrl ? m_groundNameCtrl->GetValue() : selectionKey, m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0);
+			flagsState = wxString::Format("To None: %s | Inner Border: %s", m_includeToNoneCheck && m_includeToNoneCheck->GetValue() ? "Yes" : "No", m_includeInnerCheck && m_includeInnerCheck->GetValue() ? "Yes" : "No");
+		} else {
+			meta = "Wall brush summary · Shows palette links, structure state, flags, and source info.";
+			generalState = "Name: " + (m_wallNameCtrl ? m_wallNameCtrl->GetValue() : selectionKey);
+			flagsState = "Wall flags will move here in a later step";
+		}
+
+		if (brush) {
+			palettesState = wxString::Format("Linked palettes: %zu", brush->memberships.size());
+			if (!brush->storageLocations.empty()) {
+				advancedState = "Source: " + wxFileName(brush->storageLocations.front().filePath).GetFullName();
+			}
+		}
+	}
+
+	m_inspectorTitleLabel->SetLabel(title);
+	m_inspectorMetaLabel->SetLabel(meta);
+	if (m_inspectorGeneralStateLabel) {
+		m_inspectorGeneralStateLabel->SetLabel("General: " + generalState);
+		m_inspectorGeneralStateLabel->Wrap(320);
+	}
+	if (m_inspectorPalettesStateLabel) {
+		m_inspectorPalettesStateLabel->SetLabel("Palettes: " + palettesState);
+		m_inspectorPalettesStateLabel->Wrap(320);
+	}
+	if (m_inspectorFlagsStateLabel) {
+		m_inspectorFlagsStateLabel->SetLabel("Flags: " + flagsState);
+		m_inspectorFlagsStateLabel->Wrap(320);
+	}
+	if (m_inspectorAdvancedStateLabel) {
+		m_inspectorAdvancedStateLabel->SetLabel("Advanced: " + advancedState);
+		m_inspectorAdvancedStateLabel->Wrap(320);
+	}
+
+	if (m_inspectorGeneralButton) {
+		m_inspectorGeneralButton->Enable(hasSelection || palette != nullptr);
+	}
+	if (m_inspectorPaletteButton) {
+		m_inspectorPaletteButton->Enable(hasSelection || palette != nullptr);
+	}
+	if (m_inspectorEditorButton) {
+		m_inspectorEditorButton->Enable(hasSelection && palette == nullptr);
+	}
+	if (m_inspectorPreviewButton) {
+		m_inspectorPreviewButton->Enable(hasSelection && palette == nullptr);
+	}
+	UpdateInspectorSectionButtons();
+}
+
+void BorderEditorPanel::OnBrowserNewEntity(wxCommandEvent &event) {
+	OnClear(event);
+}
+
+void BorderEditorPanel::OnBrowserDuplicateEntity(wxCommandEvent &event) {
+	if (m_activeTab == 0) {
+		return;
+	}
+	wxTextCtrl* activeNameCtrl = (m_activeTab == 2) ? m_wallNameCtrl : m_groundNameCtrl;
+	const wxString currentName = activeNameCtrl ? activeNameCtrl->GetValue().Trim() : wxString();
+	if (currentName.IsEmpty()) {
+		ShowErrorDialog("Select or name a brush before duplicating it.", ErrorSeverity::Warning);
+		return;
+	}
+	const wxString duplicatedName = currentName + " Copy";
+	if (activeNameCtrl) {
+		activeNameCtrl->SetValue(duplicatedName);
+	}
+	SetSelectionKeyForTab(m_activeTab, duplicatedName);
+	if (m_borderBrowserList) {
+		m_borderBrowserList->SetSelection(wxNOT_FOUND);
+	}
+	UpdateBrowserLabel();
+}
+
+void BorderEditorPanel::OnBrowserReloadEntity(wxCommandEvent &event) {
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	if (selectionKey.IsEmpty()) {
+		return;
+	}
+	ReloadCurrentBrushEditorXml(selectionKey);
+}
+
+void BorderEditorPanel::OnBrowserDeleteEntity(wxCommandEvent &event) {
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	if (selectionKey.IsEmpty()) {
+		ShowErrorDialog("Select a brush before deleting it.", ErrorSeverity::Warning);
+		return;
+	}
+	wxString dataDir = g_gui.GetDataDirectory();
+	if (m_activeTab == 0) {
+		wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+		if (wxFileExists(groundsFile)) {
+			pugi::xml_document doc; if (doc.load_file(nstr(groundsFile).c_str())) {
+				int refs = 0; for (pugi::xml_node b = doc.child("materials").child("brush"); b; b = b.next_sibling("brush")) for (pugi::xml_node n = b.child("border"); n; n = n.next_sibling("border")) if (n.attribute("id").as_int() == m_currentBorderId) ++refs;
+				if (refs > 0) { ShowErrorDialog(wxString::Format("Cannot delete this border because it is still referenced by %d ground brush(es).", refs), ErrorSeverity::Warning); return; }
+			}
+		}
+		if (wxMessageBox(wxString::Format("Delete border '%s' (id %d)?", m_loadedBorderName, m_currentBorderId), "Confirm Delete", wxYES_NO | wxICON_WARNING | wxSTAY_ON_TOP, this) != wxYES) return;
+		wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+		pugi::xml_document doc; if (!doc.load_file(nstr(bordersFile).c_str())) { ShowErrorDialog("Failed to load borders.xml", ErrorSeverity::Error); return; }
+		for (pugi::xml_node n = doc.child("materials").child("border"); n; n = n.next_sibling("border")) if (n.attribute("id").as_int() == m_currentBorderId) { doc.child("materials").remove_child(n); break; }
+		if (!doc.save_file(nstr(bordersFile).c_str(), PUGIXML_TEXT("\t"))) { ShowErrorDialog("Failed to save borders.xml", ErrorSeverity::Error); return; }
+		InvalidateXmlCache(bordersFile); TriggerReloadDataFiles(); MarkBrushCatalogDirty(); ClearItems(); PopulateUnifiedList(); return;
+	}
+	const BrushEditorBrushDefinition* brush = m_catalog.FindBrushByName(selectionKey);
+	if (brush && !brush->memberships.empty()) {
+		wxString palettes; for (const BrushEditorPaletteMembership &m : brush->memberships) { if (!palettes.IsEmpty()) palettes += ", "; palettes += m.tilesetName; }
+		ShowErrorDialog("Cannot delete this brush yet because it still belongs to palettes: " + palettes, ErrorSeverity::Warning);
+		return;
+	}
+	wxString filePath = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + (m_activeTab == 1 ? "grounds.xml" : "walls.xml");
+	if (m_activeTab == 2) {
+		if (const BrushEditorBrushDefinition* selectedBrush = m_catalog.FindBrushByName(selectionKey)) {
+			if (const BrushEditorStorageLocation* storage = selectedBrush->GetPrimaryStorage()) {
+				if (!storage->filePath.IsEmpty()) filePath = storage->filePath;
+			}
+		}
+	}
+	if (wxMessageBox("Delete brush '" + selectionKey + "'?", "Confirm Delete", wxYES_NO | wxICON_WARNING | wxSTAY_ON_TOP, this) != wxYES) return;
+	pugi::xml_document doc; if (!doc.load_file(nstr(filePath).c_str())) { ShowErrorDialog("Failed to load source XML for deletion.", ErrorSeverity::Error); return; }
+	bool removed = false; for (pugi::xml_node n = doc.child("materials").child("brush"); n; n = n.next_sibling("brush")) if (wxString(n.attribute("name").as_string()) == selectionKey) { doc.child("materials").remove_child(n); removed = true; break; }
+	if (!removed) { ShowErrorDialog("The selected brush was not found in its source XML.", ErrorSeverity::Warning); return; }
+	if (!doc.save_file(nstr(filePath).c_str(), PUGIXML_TEXT("\t"))) { ShowErrorDialog("Failed to save source XML after deletion.", ErrorSeverity::Error); return; }
+	InvalidateXmlCache(filePath); DiscardDraft(m_activeTab, selectionKey); TriggerReloadDataFiles(); MarkBrushCatalogDirty(); if (m_activeTab == 1) ClearGroundItems(); else ClearWallItems(); PopulateUnifiedList();
+}
+
+void BorderEditorPanel::OnBrowserViewModeChanged(wxCommandEvent &event) {
+	m_browserViewMode = 0;
+	UpdateBrowserActionButtons();
+	event.Skip();
+}
+
+void BorderEditorPanel::OnBrowserPaletteSelection(wxCommandEvent &event) {
+	const wxString paletteName = GetSelectedPaletteKey();
+	m_browserPaletteSelections[m_activeTab] = (paletteName == "No palettes available") ? wxString() : paletteName;
+	if (!paletteName.IsEmpty() && paletteName != "No palettes available") {
+		ApplyBrowserPaletteFilter(paletteName);
+	}
+	UpdateBrowserLabel();
+	UpdateBrowserActionButtons();
+	event.Skip();
+}
+
+void BorderEditorPanel::OnBrowserApplyPaletteFilter(wxCommandEvent &event) {
+	const wxString paletteName = GetSelectedPaletteKey();
+	if (paletteName.IsEmpty() || paletteName == "No palettes available") {
+		return;
+	}
+	ApplyBrowserPaletteFilter(paletteName);
+}
+
+void BorderEditorPanel::OnBrowserClearPaletteFilter(wxCommandEvent &event) {
+	ApplyBrowserPaletteFilter(wxString());
+}
+
+void BorderEditorPanel::OnBrowserAttachPalette(wxCommandEvent &event) {
+	const wxString brushName = GetSelectionKeyForTab(m_activeTab);
+	if (m_activeTab == 0 || brushName.IsEmpty()) {
+		return;
+	}
+	const BrushEditorBrushDefinition* brush = m_catalog.FindBrushByName(brushName);
+	if (!brush) {
+		ShowErrorDialog("Select a valid brush before attaching it to a palette.", ErrorSeverity::Warning);
+		return;
+	}
+	const TilesetCategoryType activeCategoryType = GetPaletteCategoryTypeFromLabel(m_browserPaletteCategoryFilter);
+	wxMenu menu;
+	int idBase = 50000;
+	int added = 0;
+	for (const BrushEditorPaletteDefinition &palette : m_catalog.palettes) {
+		if (palette.name.IsEmpty()) {
+			continue;
+		}
+		if (activeCategoryType != TILESET_UNKNOWN && palette.categoryType != activeCategoryType) {
+			continue;
+		}
+		if (!m_browserTilesetFilter.IsEmpty() && ExtractTilesetNameFromPaletteLabel(palette.name) != m_browserTilesetFilter) {
+			continue;
+		}
+		if (BrushHasPaletteMembership(*brush, palette.name)) {
+			continue;
+		}
+		menu.Append(idBase, palette.name);
+		menu.Bind(wxEVT_MENU, [this, brushName, paletteName = palette.name](wxCommandEvent &) {
+			if (PersistBrushPaletteMembership(brushName, paletteName, true)) {
+				MarkBrushCatalogDirty();
+				PopulateUnifiedList();
+				RestoreBrowserSelection(brushName);
+				UpdateBrowserLabel();
+			} else {
+				ShowErrorDialog("Failed to attach the brush to the selected palette.", ErrorSeverity::Error);
+			}
+		}, idBase);
+		++idBase;
+		++added;
+	}
+	if (added == 0) {
+		ShowErrorDialog("No palettes are available for the current category or tileset.", ErrorSeverity::Info);
+		return;
+	}
+	PopupMenu(&menu);
+}
+
+void BorderEditorPanel::OnBrowserNewPalette(wxCommandEvent &event) {
+	if (m_activeTab == 0) {
+		return;
+	}
+	wxTextEntryDialog dialog(this, "Enter a new palette name:", "New Palette");
+	if (dialog.ShowModal() != wxID_OK) {
+		return;
+	}
+	const wxString paletteName = dialog.GetValue().Trim();
+	if (paletteName.IsEmpty()) {
+		ShowErrorDialog("Palette name cannot be empty.", ErrorSeverity::Warning);
+		return;
+	}
+	const TilesetCategoryType categoryType = GetPaletteCategoryTypeFromLabel(m_browserPaletteCategoryFilter);
+	if (categoryType == TILESET_UNKNOWN) {
+		ShowErrorDialog("Select a palette category before creating a palette.", ErrorSeverity::Warning);
+		return;
+	}
+	if (!PersistPaletteDefinition(paletteName, categoryType, true)) {
+		ShowErrorDialog("Failed to create the palette. It may already exist.", ErrorSeverity::Error);
+		return;
+	}
+	PopulateUnifiedList();
+	UpdateBrowserLabel();
+}
+
+void BorderEditorPanel::OnBrowserDeletePalette(wxCommandEvent &event) {
+	if (!m_browserPaletteList || m_activeTab == 0) {
+		return;
+	}
+	const int sel = m_browserPaletteList->GetSelection();
+	if (sel == wxNOT_FOUND) {
+		return;
+	}
+	const wxString paletteLabel = m_browserPaletteList->GetString(sel);
+	if (paletteLabel == "No palettes linked" || paletteLabel == "No palettes available") {
+		return;
+	}
+	const BrushEditorPaletteDefinition* palette = FindPaletteDefinitionForLabel(paletteLabel);
+	if (!palette) {
+		ShowErrorDialog("Could not resolve the selected palette.", ErrorSeverity::Error);
+		return;
+	}
+	if (!palette->brushNames.empty()) {
+		ShowErrorDialog("Only empty palettes can be deleted right now.", ErrorSeverity::Warning);
+		return;
+	}
+	const wxString tilesetName = ExtractTilesetNameFromPaletteLabel(palette->name);
+	if (wxMessageBox("Delete palette '" + palette->name + "'?", "Confirm Delete", wxYES_NO | wxICON_WARNING | wxSTAY_ON_TOP, this) != wxYES) {
+		return;
+	}
+	if (!PersistPaletteDefinition(tilesetName, palette->categoryType, false)) {
+		ShowErrorDialog("Failed to delete the selected palette.", ErrorSeverity::Error);
+		return;
+	}
+	PopulateUnifiedList();
+	UpdateBrowserLabel();
+}
+
+void BorderEditorPanel::OnBrowserDetachPalette(wxCommandEvent &event) {
+	const wxString brushName = GetSelectionKeyForTab(m_activeTab);
+	if (!m_browserPaletteList || m_activeTab == 0 || brushName.IsEmpty()) {
+		return;
+	}
+	const int sel = m_browserPaletteList->GetSelection();
+	if (sel == wxNOT_FOUND) {
+		return;
+	}
+	const wxString paletteName = m_browserPaletteList->GetString(sel);
+	if (paletteName == "No palettes linked" || paletteName == "No palettes available") {
+		return;
+	}
+	if (PersistBrushPaletteMembership(brushName, paletteName, false)) {
+		MarkBrushCatalogDirty();
+		PopulateUnifiedList();
+		RestoreBrowserSelection(brushName);
+		UpdateBrowserLabel();
+	} else {
+		ShowErrorDialog("Failed to detach the brush from the selected palette.", ErrorSeverity::Error);
+	}
+}
+
+void BorderEditorPanel::UpdateInspectorSectionButtons() {
+	return;
+}
+
+void BorderEditorPanel::SetActiveInspectorSection(int section) {
+	m_activeInspectorSection = section;
+	m_browserViewMode = 0;
+	UpdateInspectorSectionButtons();
+	if (section == 0) {
+		if (m_activeTab == 0 && m_groupCheck) m_groupCheck->SetFocus();
+		else if (m_activeTab == 2 && m_wallNameCtrl) m_wallNameCtrl->SetFocus();
+		else if (m_groundNameCtrl) m_groundNameCtrl->SetFocus();
+	} else if (section == 1) {
+		if (m_activeTab != 0 && m_browserGrid) m_browserGrid->SetFocus();
+		else if (m_browserPaletteList) m_browserPaletteList->SetFocus();
+	} else if (section == 2) {
+		if (m_activeTab == 0 && m_gridPanel) m_gridPanel->SetFocus();
+		else if (m_activeTab == 1 && m_groundGridContainer) m_groundGridContainer->SetFocus();
+		else if (m_activeTab == 2 && m_wallGridPanel) m_wallGridPanel->SetFocus();
+	} else if (section == 3) {
+		if (m_activeTab == 0 && m_previewPanel) m_previewPanel->SetFocus();
+		else if (m_activeTab == 1 && m_groundPreviewPanel) m_groundPreviewPanel->SetFocus();
+		else if (m_activeTab == 2 && m_wallVisualPanel) m_wallVisualPanel->SetFocus();
+	}
+	UpdateBrowserActionButtons();
+	UpdateBrowserLabel();
+}
+
+void BorderEditorPanel::OnInspectorSectionClick(wxCommandEvent &event) {
+	const int id = event.GetId();
+	if (id == wxID_HIGHEST + 401) SetActiveInspectorSection(0);
+	else if (id == wxID_HIGHEST + 402) SetActiveInspectorSection(1);
+	else if (id == wxID_HIGHEST + 403) SetActiveInspectorSection(2);
+	else if (id == wxID_HIGHEST + 404) SetActiveInspectorSection(3);
 }
 
 void BorderEditorPanel::OnModeSwitch(wxCommandEvent &event) {
+	m_browserPaletteSelections[m_activeTab] = GetSelectedPaletteKey() == "No palettes available" ? wxString() : GetSelectedPaletteKey();
+	m_browserTilesetFiltersByTab[m_activeTab] = m_browserTilesetFilter;
+	m_browserPaletteCategoriesByTab[m_activeTab] = m_browserPaletteCategoryFilter;
+	if (m_browserSearchCtrl) {
+		m_browserSearchQueriesByTab[m_activeTab] = m_browserSearchCtrl->GetValue();
+	}
 	SaveCurrentDraft(false);
 
 	wxToggleButton* clickedBtn = dynamic_cast<wxToggleButton*>(event.GetEventObject());
@@ -3603,91 +4624,70 @@ void BorderEditorPanel::OnModeSwitch(wxCommandEvent &event) {
 		newTab = 2;
 	}
 
+	if (newTab == m_activeTab) {
+		m_borderModeBtn->SetValue(newTab == 0);
+		m_groundModeBtn->SetValue(newTab == 1);
+		m_wallModeBtn->SetValue(newTab == 2);
+		return;
+	}
+
 	// Update toggle button states (only clicked one should be depressed)
 	m_borderModeBtn->SetValue(newTab == 0);
 	m_groundModeBtn->SetValue(newTab == 1);
 	m_wallModeBtn->SetValue(newTab == 2);
 
-	// Switch the notebook page to show the correct editor panel for this mode
+	m_activeTab = newTab;
 	if (m_notebook) {
 		m_notebook->ChangeSelection(newTab);
 	}
-	m_activeTab = newTab;
 
-	// Refresh tileset list (and apply filters) for the new mode
-	LoadTilesets();
-
-	{
-		const auto options = GetBrowserTilesetOptions();
-		if (!options.empty()) {
-			bool filterExists = false;
-			for (const auto &opt : options) {
-				if (opt.second == m_browserTilesetFilter) {
-					filterExists = true;
-					break;
-				}
-			}
-
-			if (m_browserTilesetFilter.IsEmpty() || !filterExists) {
-				m_browserTilesetFilter = options.front().second;
-			}
-
-			wxString shown = options.front().first;
-			for (const auto &opt : options) {
-				if (opt.second == m_browserTilesetFilter) {
-					shown = opt.first;
-					break;
-				}
-			}
-
-			if (m_browserTilesetFilterButton) {
-				m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
-			}
-		} else {
-			m_browserTilesetFilter.clear();
-			if (m_browserTilesetFilterButton) {
-				m_browserTilesetFilterButton->SetLabel("Tileset: Select ▼");
-			}
-		}
+	m_browserPaletteCategoryFilter = m_browserPaletteCategoriesByTab[m_activeTab].IsEmpty() ? "Terrain" : m_browserPaletteCategoriesByTab[m_activeTab];
+	m_browserPaletteListDirty = true;
+	m_browserTilesetFilter = m_browserTilesetFiltersByTab[m_activeTab];
+	if (m_browserTilesetFilterButton) {
+		m_browserTilesetFilterButton->SetLabel(m_browserTilesetFilter.IsEmpty() ? "Tileset: Select ▼" : "Tileset: " + m_browserTilesetFilter + " ▼");
 	}
-
-	// Clear search and repopulate sidebar
 	if (m_browserSearchCtrl) {
-		m_browserSearchCtrl->Clear();
+		m_browserSearchCtrl->ChangeValue(m_browserSearchQueriesByTab[m_activeTab]);
 	}
-
-	// Keep browser list unified; just re-apply search/filter
-	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	LoadTilesets();
+	if (!RestoreCachedBrowserDataForTab(m_activeTab)) {
+		PopulateUnifiedList();
+	}
+	RefreshBrowserPaletteList();
 
 	bool restored = false;
-	if (m_selectedBrowserTileId != 0) {
-		restored = RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
+	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
+	if (!selectionKey.IsEmpty()) {
+		restored = RestoreBrowserSelection(selectionKey);
 	}
 
-	if (!restored) {
-		switch (m_activeTab) {
-			case 0:
-				ClearItems(false);
-				break;
-			case 1:
-				ClearGroundItems(false);
-				break;
-			case 2:
-				ClearWallItems(false);
-				break;
-		}
+	if (restored) {
+		LoadSelectionForTab(m_activeTab, selectionKey);
 		return;
+	}
+
+	const wxString paletteSelection = m_browserPaletteSelections[m_activeTab];
+	if (!paletteSelection.IsEmpty() && m_browserPaletteList) {
+		for (unsigned int i = 0; i < m_browserPaletteList->GetCount(); ++i) {
+			if (m_browserPaletteList->GetString(i) == paletteSelection) {
+				m_browserPaletteList->SetSelection(i);
+				ApplyBrowserPaletteFilter(paletteSelection);
+				UpdateBrowserLabel();
+				return;
+			}
+		}
 	}
 
 	switch (m_activeTab) {
 		case 0:
-			LoadBorderByMainTileId(m_selectedBrowserTileId);
+			ClearItems(false);
 			break;
 		case 1:
-			LoadGroundBrushByMainTileId(m_selectedBrowserTileId);
+			ClearGroundItems(false);
 			break;
 		case 2:
-			LoadWallBrushByMainTileId(m_selectedBrowserTileId);
+			ClearWallItems(false);
 			break;
 	}
 }
@@ -3698,153 +4698,34 @@ void BorderEditorPanel::PopulateBorderList() {
 	m_fullBrowserPreviewIds.clear();
 	m_borderBrowserList->Clear();
 
-	wxString dataDir = g_gui.GetDataDirectory();
+	EnsureBrushCatalogUpToDate();
 
-	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
-
-	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
-
-	if (!wxFileExists(bordersFile) || !wxFileExists(groundsFile)) {
-		return;
-	}
-
-	std::map<int, wxString> borderNames;
 	int maxId = 0;
-
-	{
-		pugi::xml_document doc;
-		if (!LoadXmlWithCache(bordersFile, doc)) {
-			return;
+	for (const BrushEditorBrushDefinition &brush : m_catalog.brushes) {
+		if (brush.kind != BrushEditorBrushKind::Border) {
+			continue;
 		}
 
-		pugi::xml_node materials = doc.child("materials");
-		if (!materials) {
-			return;
+		const BrushEditorStorageLocation* storage = brush.GetPrimaryStorage();
+		if (!storage) {
+			continue;
 		}
 
-		for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-			pugi::xml_attribute idAttr = borderNode.attribute("id");
-			if (!idAttr) {
-				continue;
-			}
-
-			const int id = idAttr.as_int();
-			if (id > maxId) {
-				maxId = id;
-			}
-
-			wxString name;
-			pugi::xml_attribute nameAttr = borderNode.attribute("name");
-			if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
-				name = wxString(nameAttr.as_string());
-			} else {
-				const char* nodeText = borderNode.child_value();
-				if (nodeText && strlen(nodeText) > 0) {
-					wxString textContent = wxString(nodeText).Trim(true).Trim(false);
-					while (textContent.StartsWith("-") || textContent.StartsWith(" ")) {
-						textContent = textContent.Mid(1);
-					}
-					while (textContent.EndsWith("-") || textContent.EndsWith(" ")) {
-						textContent = textContent.RemoveLast();
-					}
-					textContent = textContent.Trim(true).Trim(false);
-					if (!textContent.IsEmpty()) {
-						name = textContent;
-					}
-				}
-
-				if (name.IsEmpty()) {
-					name = "(no name)";
-				}
-			}
-
-			borderNames[id] = name;
-		}
-	}
-
-	std::map<int, std::pair<uint16_t, wxString>> borderToMainTile;
-
-	{
-		pugi::xml_document doc;
-		if (!LoadXmlWithCache(groundsFile, doc)) {
-			return;
+		const int borderId = wxAtoi(storage->logicalId);
+		if (borderId <= 0) {
+			continue;
 		}
 
-		pugi::xml_node materials = doc.child("materials");
-		if (!materials) {
-			return;
-		}
-
-		for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-			pugi::xml_attribute typeAttr = brushNode.attribute("type");
-			if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
-				continue;
-			}
-
-			pugi::xml_attribute nameAttr = brushNode.attribute("name");
-			if (!nameAttr) {
-				continue;
-			}
-
-			uint16_t mainTileId = 0;
-			if (pugi::xml_attribute serverLookIdAttr = brushNode.attribute("server_lookid")) {
-				mainTileId = serverLookIdAttr.as_uint();
-			} else if (pugi::xml_attribute lookIdAttr = brushNode.attribute("lookid")) {
-				mainTileId = lookIdAttr.as_uint();
-			}
-
-			if (mainTileId == 0) {
-				continue;
-			}
-
-			int outerBorderId = 0;
-			for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-				pugi::xml_attribute idAttr = borderNode.attribute("id");
-				if (!idAttr) {
-					continue;
-				}
-
-				wxString align = wxString(borderNode.attribute("align").as_string());
-				if (align.IsEmpty() || align == "outer") {
-					outerBorderId = idAttr.as_int();
-					break;
-				}
-			}
-
-			if (outerBorderId <= 0) {
-				continue;
-			}
-
-			if (borderToMainTile.find(outerBorderId) == borderToMainTile.end()) {
-				borderToMainTile[outerBorderId] = { mainTileId, wxString(nameAttr.as_string()) };
-			}
-		}
-	}
-
-	for (const auto &pair : borderToMainTile) {
-		const int borderId = pair.first;
-		const uint16_t tileId = pair.second.first;
-		const wxString brushName = pair.second.second;
-
-		wxString borderName;
-		auto itName = borderNames.find(borderId);
-		if (itName != borderNames.end()) {
-			borderName = itName->second;
-		} else {
-			borderName = wxString::Format("border %d", borderId);
-		}
-
-		wxString label = wxString::Format("%d - %s [%s]", (int)tileId, brushName, borderName);
+		maxId = std::max(maxId, borderId);
+		const uint16_t previewId = brush.previewItemId != 0 ? brush.previewItemId : brush.serverLookId;
+		const wxString label = wxString::Format("%d - %s", borderId, BuildCatalogBrowserLabel(brush));
 
 		m_fullBrowserList.Add(label);
 		m_fullBrowserIds.Add(wxString::Format("%d", borderId));
-		m_fullBrowserPreviewIds.push_back(tileId);
-
-		m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", borderId)));
+		m_fullBrowserPreviewIds.push_back(previewId);
 	}
 
 	m_nextBorderId = maxId + 1;
-
 	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
@@ -3892,8 +4773,6 @@ void BorderEditorPanel::PopulateGroundList() {
 			previewId = itemNode.attribute("id").as_uint();
 		}
 		m_fullBrowserPreviewIds.push_back(previewId);
-
-		m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
 	}
 
 	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
@@ -3941,108 +4820,97 @@ void BorderEditorPanel::PopulateWallList() {
 			}
 		}
 		m_fullBrowserPreviewIds.push_back(previewId);
-
-		m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
 	}
 
 	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::PopulateUnifiedList() {
+bool BorderEditorPanel::PopulateUnifiedListFromCatalog() {
+	if (!m_borderBrowserList || m_activeTab == 0) {
+		return false;
+	}
+
 	m_fullBrowserList.Clear();
 	m_fullBrowserIds.Clear();
 	m_fullBrowserPreviewIds.clear();
 	m_borderBrowserList->Clear();
 
-	wxString dataDir = g_gui.GetDataDirectory();
-	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
-
-	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
-
-	std::set<uint16_t> seen;
-
-	if (wxFileExists(groundsFile)) {
-		pugi::xml_document doc;
-		if (LoadXmlWithCache(groundsFile, doc)) {
-			pugi::xml_node materials = doc.child("materials");
-			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-				pugi::xml_attribute typeAttr = brushNode.attribute("type");
-				if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
-					continue;
-				}
-
-				pugi::xml_attribute nameAttr = brushNode.attribute("name");
-				if (!nameAttr) {
-					continue;
-				}
-
-				uint16_t tileId = 0;
-				if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
-					tileId = a.as_uint();
-				} else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
-					tileId = a.as_uint();
-				} else if (pugi::xml_node itemNode = brushNode.child("item")) {
-					tileId = itemNode.attribute("id").as_uint();
-				}
-
-				if (tileId == 0) {
-					continue;
-				}
-
-				if (seen.find(tileId) != seen.end()) {
-					continue;
-				}
-				seen.insert(tileId);
-
-				wxString brushName = wxString(nameAttr.as_string());
-				wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
-
-				m_fullBrowserList.Add(label);
-				m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
-				m_fullBrowserPreviewIds.push_back(tileId);
-
-				m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
-			}
-		}
-	}
-
-	if (wxFileExists(wallsFile)) {
-		pugi::xml_document doc;
-		if (LoadXmlWithCache(wallsFile, doc)) {
-			pugi::xml_node materials = doc.child("materials");
-			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-				pugi::xml_attribute nameAttr = brushNode.attribute("name");
-				if (!nameAttr) {
-					continue;
-				}
-
-				uint16_t tileId = 0;
-				if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
-					tileId = a.as_uint();
-				}
-
-				if (tileId == 0) {
-					continue;
-				}
-
-				if (seen.find(tileId) != seen.end()) {
-					continue;
-				}
-				seen.insert(tileId);
-
-				wxString brushName = wxString(nameAttr.as_string());
-				wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
-
-				m_fullBrowserList.Add(label);
-				m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
-				m_fullBrowserPreviewIds.push_back(tileId);
-
-				m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
-			}
-		}
+	const BrushEditorBrushKind wantedKind = (m_activeTab == 1) ? BrushEditorBrushKind::Ground : BrushEditorBrushKind::Wall;
+	for (const BrushEditorBrushDefinition &brush : m_catalog.brushes) {
+		if (brush.kind != wantedKind) continue;
+		if (m_activeTab == 2 && (brush.name.Lower().Contains("(tiny)") || BuildCatalogTilesetLabel(brush).Lower().Contains("tiny borders"))) continue;
+		const uint16_t previewId = brush.previewItemId != 0 ? brush.previewItemId : brush.serverLookId;
+		if (previewId == 0 || brush.name.IsEmpty()) continue;
+		const wxString label = BuildCatalogBrowserLabel(brush);
+		m_fullBrowserList.Add(label);
+		m_fullBrowserIds.Add(brush.name);
+		m_fullBrowserPreviewIds.push_back(previewId);
 	}
 
 	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	return m_fullBrowserList.GetCount() > 0;
+}
+
+bool BorderEditorPanel::PopulatePaletteBrowserListFromCatalog() {
+	if (!m_borderBrowserList || m_activeTab == 0) {
+		return false;
+	}
+	m_fullBrowserList.Clear();
+	m_fullBrowserIds.Clear();
+	m_fullBrowserPreviewIds.clear();
+	m_borderBrowserList->Clear();
+
+	const BrushEditorBrushKind wantedKind = (m_activeTab == 1) ? BrushEditorBrushKind::Ground : BrushEditorBrushKind::Wall;
+	for (const BrushEditorPaletteDefinition &palette : m_catalog.palettes) {
+		int count = 0;
+		for (const wxString &brushName : palette.brushNames) {
+			const BrushEditorBrushDefinition* brush = m_catalog.FindBrushByName(brushName);
+			if (brush && brush->kind == wantedKind) {
+				++count;
+			}
+		}
+		if (count == 0) {
+			continue;
+		}
+		const wxString sourceName = palette.sourceFile.IsEmpty() ? "custom" : wxFileName(palette.sourceFile).GetName();
+		const wxString label = wxString::Format("%s | %d brushes | %s", palette.name, count, sourceName);
+		m_fullBrowserList.Add(label);
+		m_fullBrowserIds.Add(palette.name);
+		m_fullBrowserPreviewIds.push_back(0);
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	return m_fullBrowserList.GetCount() > 0;
+}
+
+void BorderEditorPanel::UpdateBrowserViewButtons() {
+	m_browserViewMode = 0;
+	if (m_browserBrushesViewBtn) {
+		m_browserBrushesViewBtn->Hide();
+		m_browserBrushesViewBtn->SetValue(true);
+	}
+	if (m_browserPalettesViewBtn) {
+		m_browserPalettesViewBtn->Hide();
+		m_browserPalettesViewBtn->SetValue(false);
+	}
+	if (m_browserTilesetFilterButton) {
+		m_browserTilesetFilterButton->Hide();
+		m_browserTilesetFilterButton->Enable(false);
+	}
+}
+
+void BorderEditorPanel::PopulateUnifiedList() {
+	if (m_activeTab == 0) {
+		PopulateBorderList();
+		UpdateBrowserViewButtons();
+		CacheBrowserDataForActiveTab();
+		return;
+	}
+	m_browserViewMode = 0;
+	UpdateBrowserViewButtons();
+	EnsureBrushCatalogUpToDate();
+	PopulateUnifiedListFromCatalog();
+	CacheBrowserDataForActiveTab();
 }
 
 void BorderEditorPanel::OnBrowserSearch(wxCommandEvent &event) {
@@ -4067,8 +4935,26 @@ static wxString FindTilesetByPreferredOrContains(const wxString &preferred, cons
 	return wxString();
 }
 
-static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions() {
+static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions(int activeTab, const BrushEditorCatalog* catalog) {
 	std::vector<std::pair<wxString, wxString>> options;
+
+	if (catalog) {
+		const BrushEditorBrushKind wantedKind = (activeTab == 2) ? BrushEditorBrushKind::Wall : BrushEditorBrushKind::Ground;
+		std::set<wxString> seen;
+		for (const BrushEditorBrushDefinition &brush : catalog->brushes) {
+			if (brush.kind != wantedKind) {
+				continue;
+			}
+			for (const BrushEditorPaletteMembership &membership : brush.memberships) {
+				if (membership.categoryType != TILESET_TERRAIN || membership.tilesetName.IsEmpty()) continue;
+				if (activeTab == 2 && membership.tilesetName.Lower().Contains("tiny borders")) continue;
+				if (!seen.insert(membership.tilesetName).second) continue;
+				options.push_back({ membership.tilesetName, membership.tilesetName });
+			}
+		}
+		std::sort(options.begin(), options.end(), [](const auto &a, const auto &b) { return a.first < b.first; });
+		return options;
+	}
 
 	// Load saved brushes from grounds.xml and walls.xml to check which tilesets have brushes
 	std::set<wxString> tilesetsWithSavedBrushes;
@@ -4160,10 +5046,32 @@ static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions() {
 	return options;
 }
 
+void BorderEditorPanel::OnBrowserPaletteCategoryButtonClick(wxCommandEvent &event) {
+	wxMenu menu;
+	wxMenuItem* allItem = menu.Append(wxID_ANY, "All");
+	allItem->Enable(false);
+	wxMenuItem* terrainItem = menu.AppendRadioItem(wxID_ANY, "Terrain");
+	terrainItem->Check(true);
+	menu.Bind(wxEVT_MENU, [this](wxCommandEvent &) {
+		m_browserPaletteCategoryFilter = "Terrain";
+		m_browserPaletteListDirty = true;
+		RefreshBrowserPaletteList();
+		ApplyBrowserPaletteFilter(GetSelectedPaletteKey());
+		UpdateBrowserLabel();
+	}, terrainItem->GetId());
+	wxMenuItem* itemItem = menu.Append(wxID_ANY, "Item");
+	itemItem->Enable(false);
+	wxMenuItem* doodadItem = menu.Append(wxID_ANY, "Doodad");
+	doodadItem->Enable(false);
+	wxMenuItem* rawItem = menu.Append(wxID_ANY, "Raw");
+	rawItem->Enable(false);
+	PopupMenu(&menu);
+}
+
 void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event) {
 	wxMenu menu;
 
-	const auto options = GetBrowserTilesetOptions();
+	const auto options = GetBrowserTilesetOptions(m_activeTab, m_activeTab == 0 ? nullptr : &m_catalog);
 	if (options.empty()) {
 		return;
 	}
@@ -4174,7 +5082,10 @@ void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event)
 			item->Check(true);
 		}
 		menu.Bind(wxEVT_MENU, [this, shown, value](wxCommandEvent &) {
-            const uint16_t keepTileId = m_selectedBrowserTileId;
+            const wxString keepSelectionKey = GetSelectionKeyForTab(m_activeTab);
+            if (value == m_browserTilesetFilter) {
+                return;
+            }
 
             m_browserTilesetFilter = value;
             if (m_browserTilesetFilterButton) {
@@ -4184,16 +5095,12 @@ void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event)
             FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 
             bool restored = false;
-            if (keepTileId != 0) {
-                restored = RestoreBrowserSelection(wxString::Format("%u", (unsigned)keepTileId));
+            if (!keepSelectionKey.IsEmpty()) {
+                restored = RestoreBrowserSelection(keepSelectionKey);
             }
 
             if (restored) {
-                switch (m_activeTab) {
-                    case 0: LoadBorderByMainTileId(keepTileId); break;
-                    case 1: LoadGroundBrushByMainTileId(keepTileId); break;
-                    case 2: LoadWallBrushByMainTileId(keepTileId); break;
-                }
+                LoadSelectionForTab(m_activeTab, keepSelectionKey);
             } else {
                 switch (m_activeTab) {
                     case 0: ClearItems(false); break;
@@ -4211,13 +5118,24 @@ void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event)
 }
 
 void BorderEditorPanel::FilterBrowserList(const wxString &query) {
+	if (!m_borderBrowserList) {
+		return;
+	}
+	wxWindowUpdateLocker locker(m_borderBrowserList);
 	m_borderBrowserList->Clear();
 	wxString lowerQuery = query.Lower();
 
-	const auto filterOptions = GetBrowserTilesetOptions();
-
 	const bool useTilesetFilter = !m_browserTilesetFilter.IsEmpty();
-	const std::string tilesetName = useTilesetFilter ? nstr(m_browserTilesetFilter) : std::string();
+	const auto filterOptions = useTilesetFilter ? GetBrowserTilesetOptions(m_activeTab, &m_catalog) : std::vector<std::pair<wxString, wxString>>();
+	wxString selectedTilesetShown;
+	if (useTilesetFilter) {
+		for (const auto &opt : filterOptions) {
+			if (opt.second == m_browserTilesetFilter) {
+				selectedTilesetShown = opt.first;
+				break;
+			}
+		}
+	}
 
 	std::vector<BrushBrowserGridPanel::Entry> entries;
 	entries.reserve(m_fullBrowserList.GetCount());
@@ -4231,98 +5149,24 @@ void BorderEditorPanel::FilterBrowserList(const wxString &query) {
 		if (i < m_fullBrowserPreviewIds.size()) {
 			previewId = m_fullBrowserPreviewIds[i];
 		}
+		const BrushEditorBrushDefinition* catalogBrush = (m_activeTab != 0) ? m_catalog.FindBrushByName(m_fullBrowserIds[i]) : nullptr;
 
 		if (useTilesetFilter) {
-			if (previewId == 0) {
-				continue;
-			}
-
-			const ItemType &type = g_items.getItemType(previewId);
-			if (type.id == 0) {
-				continue;
-			}
-
-			auto inTilesetFor = [&](const wxString &tilesetWx) -> bool {
-				const std::string ts = nstr(tilesetWx);
-				return g_materials.isInTileset(type.brush, ts) || g_materials.isInTileset(type.doodad_brush, ts) || g_materials.isInTileset(type.raw_brush, ts);
-			};
-
-			if (!inTilesetFor(m_browserTilesetFilter)) {
-				continue;
-			}
-
-			if (filterOptions.size() > 1) {
-				size_t selectedIndex = filterOptions.size();
-				for (size_t idx = 0; idx < filterOptions.size(); ++idx) {
-					if (filterOptions[idx].second == m_browserTilesetFilter) {
-						selectedIndex = idx;
-						break;
-					}
+			if (catalogBrush) {
+				if (!CatalogBrushHasTileset(*catalogBrush, m_browserTilesetFilter)) {
+					continue;
 				}
-
-				if (selectedIndex != filterOptions.size()) {
-					bool belongsToHigher = false;
-					for (size_t idx = 0; idx < selectedIndex; ++idx) {
-						const wxString &higherTs = filterOptions[idx].second;
-						if (higherTs.IsEmpty()) {
-							continue;
-						}
-						if (inTilesetFor(higherTs)) {
-							belongsToHigher = true;
-							break;
-						}
-					}
-					if (belongsToHigher) {
-						continue;
-					}
+			} else {
+				const int borderId = wxAtoi(m_fullBrowserIds[i]);
+				if (borderId <= 0 || !CatalogBorderHasTileset(m_catalog, borderId, m_browserTilesetFilter)) {
+					continue;
 				}
 			}
 		}
 
 		wxString displayLabel = m_fullBrowserList[i];
-		if (previewId != 0 && !filterOptions.empty()) {
-			if (useTilesetFilter) {
-				wxString selectedShown;
-				for (const auto &opt : filterOptions) {
-					if (opt.second == m_browserTilesetFilter) {
-						selectedShown = opt.first;
-						break;
-					}
-				}
-
-				if (!selectedShown.IsEmpty()) {
-					displayLabel += " [" + selectedShown + "]";
-				}
-			} else {
-				const ItemType &type = g_items.getItemType(previewId);
-				if (type.id != 0) {
-					wxString tagList;
-					bool first = true;
-
-					for (const auto &opt : filterOptions) {
-						const wxString &shown = opt.first;
-						const wxString &tsNameWx = opt.second;
-						if (tsNameWx.IsEmpty()) {
-							continue;
-						}
-
-						const std::string tsName = nstr(tsNameWx);
-						const bool inTileset = g_materials.isInTileset(type.brush, tsName) || g_materials.isInTileset(type.doodad_brush, tsName) || g_materials.isInTileset(type.raw_brush, tsName);
-
-						if (inTileset) {
-							if (!first) {
-								tagList += ", ";
-							}
-							tagList += shown;
-							first = false;
-						}
-					}
-
-					if (!tagList.IsEmpty()) {
-						displayLabel += " [" + tagList + "]";
-					}
-				}
-			}
+		if (useTilesetFilter && !catalogBrush && previewId != 0 && !selectedTilesetShown.IsEmpty()) {
+			displayLabel += " [" + selectedTilesetShown + "]";
 		}
 
 		m_borderBrowserList->Append(displayLabel, new wxStringClientData(m_fullBrowserIds[i]));
@@ -4345,7 +5189,7 @@ void BorderEditorPanel::OnGroundGridSelect(wxCommandEvent &event) {
 }
 
 void BorderEditorPanel::LoadTilesets() {
-	// Clear the choice control
+	wxWindowUpdateLocker locker(this);
 	m_tilesetListData.Clear();
 	m_tilesets.clear();
 
@@ -4380,11 +5224,13 @@ void BorderEditorPanel::LoadTilesets() {
 		m_rawCategoryNames = m_tilesetListData;
 
 		if (!m_tilesetListData.IsEmpty()) {
-			m_rawCategorySelection = 0;
-			m_rawCategoryButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+			int selection = (m_rawCategorySelection >= 0 && m_rawCategorySelection < (int)m_tilesetListData.GetCount()) ? m_rawCategorySelection : m_tilesetListData.Index("Borders");
+			if (selection == wxNOT_FOUND) selection = 0;
+			m_rawCategorySelection = selection;
+			m_rawCategoryButton->SetLabel(m_tilesetListData[selection] + " \u25BC");
 
 			if (m_itemPalettePanel) {
-				m_itemPalettePanel->LoadTileset(m_tilesetListData[0]);
+				m_itemPalettePanel->LoadTileset(m_tilesetListData[selection]);
 			}
 		} else {
 			m_rawCategoryButton->SetLabel("Select \u25BC");
@@ -4395,11 +5241,11 @@ void BorderEditorPanel::LoadTilesets() {
 	} else if (m_activeTab == 1 && m_groundTilesetButton) {
 		// Ground tab
 		if (!m_tilesetListData.IsEmpty()) {
-			m_groundTilesetSelection = 0;
-			m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+			if (m_groundTilesetSelection < 0 || m_groundTilesetSelection >= (int)m_tilesetListData.GetCount()) m_groundTilesetSelection = 0;
+			m_groundTilesetButton->SetLabel(m_tilesetListData[m_groundTilesetSelection] + " \u25BC");
 
 			if (m_groundPalette) {
-				m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
+				m_groundPalette->LoadTileset(m_tilesetListData[m_groundTilesetSelection], FILTER_GROUND);
 			}
 		} else {
 			m_groundTilesetButton->SetLabel("Select \u25BC");
@@ -4407,11 +5253,11 @@ void BorderEditorPanel::LoadTilesets() {
 	} else if (m_activeTab == 2 && m_wallTilesetButton) {
 		// Wall tab
 		if (!m_tilesetListData.IsEmpty()) {
-			m_wallTilesetSelection = 0;
-			m_wallTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+			if (m_wallTilesetSelection < 0 || m_wallTilesetSelection >= (int)m_tilesetListData.GetCount()) m_wallTilesetSelection = 0;
+			m_wallTilesetButton->SetLabel(m_tilesetListData[m_wallTilesetSelection] + " \u25BC");
 
 			if (m_wallPalette) {
-				m_wallPalette->LoadTileset(m_tilesetListData[0], FILTER_WALL);
+				m_wallPalette->LoadTileset(m_tilesetListData[m_wallTilesetSelection], FILTER_WALL);
 			}
 		} else {
 			m_wallTilesetButton->SetLabel("Select \u25BC");
@@ -5594,9 +6440,7 @@ void BorderEditorPanel::SaveGroundBrush() {
 	}
 
 	// Get form values
-	const uint16_t mainTileId = (m_selectedBrowserTileId != 0)
-		? m_selectedBrowserTileId
-		: (!items.empty() ? items.front().first : 0);
+	const uint16_t mainTileId = !items.empty() ? items.front().first : 0;
 	int zOrder = m_zOrderCtrl->GetValue();
 	wxString alignment = (m_borderAlignmentSelection == 1) ? "inner" : "outer";
 	bool includeToNone = m_includeToNoneCheck->GetValue();
@@ -5724,10 +6568,10 @@ void BorderEditorPanel::SaveGroundBrush() {
 	}
 	InvalidateXmlCache(groundsFile);
 
-	DiscardDraft(1, mainTileId);
+	DiscardDraft(1, name);
 
 	TriggerReloadDataFiles();
-	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+	ReloadCurrentBrushEditorXml(name);
 }
 
 void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {
@@ -5853,32 +6697,14 @@ void BorderEditorPanel::LoadWallBrushByMainTileId(uint16_t tileId) {
 		return;
 	}
 
-	wxString dataDir = g_gui.GetDataDirectory();
-	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
-
-	if (!wxFileExists(wallsFile)) {
-		return;
-	}
-
-	pugi::xml_document doc;
-	if (!doc.load_file(nstr(wallsFile).c_str())) {
-		return;
-	}
-
-	pugi::xml_node materials = doc.child("materials");
-	if (!materials) {
-		return;
-	}
-
-	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-		pugi::xml_attribute nameAttr = brushNode.attribute("name");
-		if (!nameAttr) {
+	EnsureBrushCatalogUpToDate();
+	for (const BrushEditorBrushDefinition &brush : m_catalog.brushes) {
+		if (brush.kind != BrushEditorBrushKind::Wall) {
 			continue;
 		}
-
-		pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
-		if (lookIdAttr && lookIdAttr.as_uint() == tileId) {
-			LoadWallBrushByName(wxString(nameAttr.as_string()));
+		const uint16_t lookId = brush.serverLookId != 0 ? brush.serverLookId : brush.previewItemId;
+		if (lookId == tileId) {
+			LoadWallBrushByName(brush.name);
 			return;
 		}
 	}
@@ -5886,6 +6712,9 @@ void BorderEditorPanel::LoadWallBrushByMainTileId(uint16_t tileId) {
 
 void BorderEditorPanel::LoadGroundBrushByName(const wxString &name) {
 	if (name.IsEmpty()) {
+		return;
+	}
+	if (RestoreDraft(1, name)) {
 		return;
 	}
 
@@ -5967,6 +6796,7 @@ void BorderEditorPanel::LoadGroundBrushByName(const wxString &name) {
 		if (m_groundPreviewPanel && m_groundGridContainer) {
 			m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
 		}
+		UpdateBrowserLabel();
 		break;
 	}
 }

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -2302,7 +2302,7 @@ void BorderEditorPanel::UpdatePreview() {
 
 bool BorderEditorPanel::ValidateBorder() {
 	if (m_borderItems.empty()) {
-		wxMessageBox("The border must have at least one item.", "Validation Error", wxICON_ERROR);
+		ShowErrorDialog("The border must have at least one item.", ErrorSeverity::Error);
 		return false;
 	}
 
@@ -2310,7 +2310,7 @@ bool BorderEditorPanel::ValidateBorder() {
 	std::set<BorderEdgePosition> positions;
 	for (const BorderItem &item : m_borderItems) {
 		if (positions.find(item.position) != positions.end()) {
-			wxMessageBox("The border contains duplicate positions.", "Validation Error", wxICON_ERROR);
+			ShowErrorDialog("The border contains duplicate positions.", ErrorSeverity::Error);
 			return false;
 		}
 		positions.insert(item.position);
@@ -2319,7 +2319,7 @@ bool BorderEditorPanel::ValidateBorder() {
 	// Check for ID validity (using m_currentBorderId)
 	int id = m_currentBorderId; // Use m_currentBorderId
 	if (id <= 0) {
-		wxMessageBox("Border ID must be greater than 0.", "Validation Error", wxICON_ERROR);
+		ShowErrorDialog("Border ID must be greater than 0.", ErrorSeverity::Error);
 		return false;
 	}
 

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -4070,48 +4070,86 @@ static wxString FindTilesetByPreferredOrContains(const wxString &preferred, cons
 static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions() {
 	std::vector<std::pair<wxString, wxString>> options;
 
-	// Iterate over all tilesets and find those with terrain or doodad category
-	// that have at least one brush with variation, wall, or border support
-	for (const auto &pair : g_materials.tilesets) {
-		wxString tilesetName = wxString(pair.first);
-		Tileset* tileset = pair.second;
-		if (!tileset) {
-			continue;
-		}
+	// Load saved brushes from grounds.xml and walls.xml to check which tilesets have brushes
+	std::set<wxString> tilesetsWithSavedBrushes;
 
-		bool hasValidBrush = false;
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 
-		// Check terrain category
-		const TilesetCategory* terrainCat = tileset->getCategory(TILESET_TERRAIN);
-		if (terrainCat && !terrainCat->brushlist.empty()) {
-			for (Brush* brush : terrainCat->brushlist) {
-				if (!brush) {
+	// Check grounds.xml
+	if (wxFileExists(groundsFile)) {
+		pugi::xml_document doc;
+		if (doc.load_file(nstr(groundsFile).c_str())) {
+			pugi::xml_node materials = doc.child("materials");
+			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+				pugi::xml_attribute typeAttr = brushNode.attribute("type");
+				if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
 					continue;
 				}
-				if (brush->getMaxVariation() > 0 || brush->isWall() || brush->needBorders()) {
-					hasValidBrush = true;
-					break;
+
+				uint16_t tileId = 0;
+				if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+					tileId = a.as_uint();
+				} else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+					tileId = a.as_uint();
+				} else if (pugi::xml_node itemNode = brushNode.child("item")) {
+					tileId = itemNode.attribute("id").as_uint();
+				}
+
+				if (tileId == 0) {
+					continue;
+				}
+
+				// Find which tileset this item belongs to
+				const ItemType &type = g_items.getItemType(tileId);
+				if (type.id != 0) {
+					for (const auto &pair : g_materials.tilesets) {
+						const std::string tsName = pair.first;
+						if (g_materials.isInTileset(type.brush, tsName) || g_materials.isInTileset(type.doodad_brush, tsName) || g_materials.isInTileset(type.raw_brush, tsName)) {
+							tilesetsWithSavedBrushes.insert(wxString(pair.first));
+							break;
+						}
+					}
 				}
 			}
 		}
+	}
 
-		// Check doodad category
-		if (!hasValidBrush) {
-			const TilesetCategory* doodadCat = tileset->getCategory(TILESET_DOODAD);
-			if (doodadCat && !doodadCat->brushlist.empty()) {
-				for (Brush* brush : doodadCat->brushlist) {
-					if (!brush) {
-						continue;
-					}
-					if (brush->getMaxVariation() > 0 || brush->isWall() || brush->needBorders()) {
-						hasValidBrush = true;
-						break;
+	// Check walls.xml
+	if (wxFileExists(wallsFile)) {
+		pugi::xml_document doc;
+		if (doc.load_file(nstr(wallsFile).c_str())) {
+			pugi::xml_node materials = doc.child("materials");
+			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+				uint16_t tileId = 0;
+				if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+					tileId = a.as_uint();
+				}
+
+				if (tileId == 0) {
+					continue;
+				}
+
+				// Find which tileset this item belongs to
+				const ItemType &type = g_items.getItemType(tileId);
+				if (type.id != 0) {
+					for (const auto &pair : g_materials.tilesets) {
+						const std::string tsName = pair.first;
+						if (g_materials.isInTileset(type.brush, tsName) || g_materials.isInTileset(type.doodad_brush, tsName) || g_materials.isInTileset(type.raw_brush, tsName)) {
+							tilesetsWithSavedBrushes.insert(wxString(pair.first));
+							break;
+						}
 					}
 				}
 			}
 		}
+	}
 
-		if (hasValidBrush) {
+	// Now filter tilesets to only show those that have saved brushes
+	for (const auto &pair : g_materials.tilesets) {
+		wxString tilesetName = wxString(pair.first);
+		if (tilesetsWithSavedBrushes.find(tilesetName) != tilesetsWithSavedBrushes.end()) {
 			options.push_back({ tilesetName, tilesetName });
 		}
 	}

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -151,20 +151,24 @@ void BorderEditorPanel::ShowErrorDialog(const wxString &message, ErrorSeverity s
 	long style;
 	switch (severity) {
 		case ErrorSeverity::Info:
-			style = wxOK | wxICON_INFORMATION;
+			style = wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP;
 			break;
 		case ErrorSeverity::Warning:
-			style = wxOK | wxICON_WARNING;
+			style = wxOK | wxICON_WARNING | wxSTAY_ON_TOP;
 			break;
 		case ErrorSeverity::Error:
-			style = wxOK | wxICON_ERROR;
+			style = wxOK | wxICON_ERROR | wxSTAY_ON_TOP;
 			break;
 		case ErrorSeverity::Critical:
-			style = wxOK | wxICON_ERROR;
+			style = wxOK | wxICON_ERROR | wxSTAY_ON_TOP;
 			break;
 	}
 
-	wxMessageBox(message, "Brush Editor", style, this);
+	if (GetParent()) {
+		GetParent()->Raise();
+	}
+	wxSafeYield();
+	wxMessageBox(message, "Brush Editor", style, nullptr);
 }
 
 bool BorderEditorPanel::LoadXmlWithCache(const wxString &path, pugi::xml_document &doc) {
@@ -1772,11 +1776,6 @@ void BorderEditorPanel::SaveWallBrush() {
 
 	TriggerReloadDataFiles();
 	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
-
-	ShowErrorDialog(
-		wxString::Format("Wall brush '%s' saved successfully.", name),
-		ErrorSeverity::Info
-	);
 }
 
 void BorderEditorPanel::LoadExistingWallBrushes() {
@@ -2491,8 +2490,6 @@ void BorderEditorPanel::SaveBorder() {
 
 	TriggerReloadDataFiles();
 	ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
-
-	ShowErrorDialog("Border saved successfully.", ErrorSeverity::Info);
 }
 
 void BorderEditorPanel::OnSave(wxCommandEvent &event) {
@@ -5664,11 +5661,6 @@ void BorderEditorPanel::SaveGroundBrush() {
 
 	TriggerReloadDataFiles();
 	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
-
-	ShowErrorDialog(
-		wxString::Format("Ground brush '%s' saved successfully.", name),
-		ErrorSeverity::Info
-	);
 }
 
 void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -2355,7 +2355,7 @@ void BorderEditorPanel::SaveBorder() {
 	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
 
 	if (!wxFileExists(bordersFile)) {
-		wxMessageBox("Cannot find borders.xml file in the data directory.", "Error", wxICON_ERROR);
+		ShowErrorDialog("Cannot find borders.xml file in the data directory.", ErrorSeverity::Error);
 		return;
 	}
 
@@ -2364,13 +2364,13 @@ void BorderEditorPanel::SaveBorder() {
 	pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
 
 	if (!result) {
-		wxMessageBox("Failed to load borders.xml: " + wxString(result.description()), "Error", wxICON_ERROR);
+		ShowErrorDialog("Failed to load borders.xml: " + wxString(result.description()), ErrorSeverity::Error);
 		return;
 	}
 
 	pugi::xml_node materials = doc.child("materials");
 	if (!materials) {
-		wxMessageBox("Invalid borders.xml file: missing 'materials' node", "Error", wxICON_ERROR);
+		ShowErrorDialog("Invalid borders.xml file: missing 'materials' node", ErrorSeverity::Error);
 		return;
 	}
 
@@ -2439,7 +2439,7 @@ void BorderEditorPanel::SaveBorder() {
 
 	wxString xmlText;
 	if (!ReadAllText(bordersFile, xmlText) || xmlText.IsEmpty()) {
-		wxMessageBox("Failed to read borders.xml", "Error", wxICON_ERROR);
+		ShowErrorDialog("Failed to read borders.xml", ErrorSeverity::Error);
 		return;
 	}
 
@@ -2455,7 +2455,7 @@ void BorderEditorPanel::SaveBorder() {
 	}
 
 	if (xmlText != oldText && !WriteAllText(bordersFile, xmlText)) {
-		wxMessageBox("Failed to save changes to borders.xml", "Error", wxICON_ERROR);
+		ShowErrorDialog("Failed to save changes to borders.xml", ErrorSeverity::Error);
 		return;
 	}
 

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -47,6 +47,7 @@
 #include <pugixml.hpp>
 #include <wx/file.h>
 #include <wx/stdpaths.h>
+#include <sstream>
 
 #define BorderEditorPanel BrushEditorPanel
 
@@ -103,6 +104,171 @@ struct GridMetrics {
 #define ID_GROUND_ITEM_LIST wxID_HIGHEST + 2
 
 static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions();
+
+static bool ReadAllText(const wxString& path, wxString& out) {
+    wxFile file(path, wxFile::read);
+    if (!file.IsOpened()) {
+        return false;
+    }
+    file.ReadAll(&out);
+    file.Close();
+    return true;
+}
+
+static bool WriteAllText(const wxString& path, const wxString& content) {
+    wxFile file;
+    if (!file.Create(path, true)) {
+        return false;
+    }
+    file.Write(content);
+    file.Close();
+    return true;
+}
+
+static wxString DetectNewline(const wxString& text) {
+    return (text.Find("\r\n") != wxNOT_FOUND) ? "\r\n" : "\n";
+}
+
+static wxString IndentBeforePos(const wxString& text, size_t pos) {
+    if (pos > text.length()) {
+        pos = text.length();
+    }
+    size_t lineStart = text.rfind('\n', pos);
+    if (lineStart == wxString::npos) {
+        lineStart = 0;
+    } else {
+        lineStart += 1;
+    }
+    size_t i = lineStart;
+    while (i < pos && (text[i] == ' ' || text[i] == '\t')) {
+        ++i;
+    }
+    return text.Mid(lineStart, i - lineStart);
+}
+
+static wxString DetectChildIndent(const wxString& text, const wxString& elementName) {
+    const wxString open = "<" + elementName;
+    const size_t pos = text.find(open);
+    if (pos == wxString::npos) {
+        return "    ";
+    }
+    return IndentBeforePos(text, pos);
+}
+
+static bool FindXmlElementRangeSimple(const wxString& text, const wxString& elementName, const wxString& attrNeedle, size_t& outStart, size_t& outEnd) {
+    const wxString open = "<" + elementName;
+    const wxString close = "</" + elementName + ">";
+
+    size_t pos = 0;
+    while ((pos = text.find(open, pos)) != wxString::npos) {
+        const size_t tagEnd = text.find('>', pos);
+        if (tagEnd == wxString::npos) {
+            return false;
+        }
+
+        const wxString startTag = text.Mid(pos, tagEnd - pos + 1);
+        if (startTag.find(attrNeedle) == wxString::npos) {
+            pos = tagEnd + 1;
+            continue;
+        }
+
+        const size_t closePos = text.find(close, tagEnd + 1);
+        if (closePos == wxString::npos) {
+            return false;
+        }
+
+        size_t end = closePos + close.length();
+        if (end < text.length() && text[end] == '\r') {
+            if (end + 1 < text.length() && text[end + 1] == '\n') {
+                end += 2;
+            } else {
+                end += 1;
+            }
+        } else if (end < text.length() && text[end] == '\n') {
+            end += 1;
+        }
+
+        outStart = pos;
+        outEnd = end;
+        return true;
+    }
+
+    return false;
+}
+
+static void ExpandStartToIncludePrevSingleLineComment(const wxString& text, size_t& start) {
+    if (start == 0) {
+        return;
+    }
+
+    size_t lineStart = text.rfind('\n', start - 1);
+    if (lineStart == wxString::npos) {
+        lineStart = 0;
+    } else {
+        lineStart += 1;
+    }
+
+    wxString line = text.Mid(lineStart, start - lineStart);
+    line.Trim(true);
+    line.Trim(false);
+
+    if (line.StartsWith("<!--") && line.EndsWith("-->")) {
+        start = lineStart;
+    }
+}
+
+static wxString PrintNodeIndented(const pugi::xml_node& node, const wxString& baseIndent, const wxString& nl) {
+    std::ostringstream oss;
+    node.print(oss, "  ", pugi::format_default, pugi::encoding_utf8);
+
+    const std::string s = oss.str();
+    wxString out = wxString::FromUTF8(s.c_str());
+
+    if (out.EndsWith("\n")) {
+        out.RemoveLast();
+    }
+
+    out.Replace("\n", "\n" + baseIndent);
+    out = baseIndent + out;
+
+    if (nl != "\n") {
+        out.Replace("\n", nl);
+    }
+
+    if (!out.EndsWith(nl)) {
+        out += nl;
+    }
+
+    return out;
+}
+
+static bool ReplaceOrInsertChildSimple(wxString& text, const wxString& elementName, const wxString& attrNeedle, const wxString& newBlock, bool includePrevSingleLineComment) {
+    size_t start = 0;
+    size_t end = 0;
+
+    if (FindXmlElementRangeSimple(text, elementName, attrNeedle, start, end)) {
+        if (includePrevSingleLineComment) {
+            ExpandStartToIncludePrevSingleLineComment(text, start);
+        }
+        text = text.Mid(0, start) + newBlock + text.Mid(end);
+        return true;
+    }
+
+    const size_t insertPos = text.rfind("</materials>");
+    if (insertPos == wxString::npos) {
+        return false;
+    }
+
+    const wxString nl = DetectNewline(text);
+    wxString insertion = newBlock;
+    const wxString before = text.Mid(0, insertPos);
+    if (!before.EndsWith(nl)) {
+        insertion = nl + insertion;
+    }
+
+    text = before + insertion + text.Mid(insertPos);
+    return true;
+}
 
 // Utility functions for edge string/position conversion
 BorderEdgePosition edgeStringToPosition(const std::string& edgeStr) {
@@ -1436,17 +1602,33 @@ void BorderEditorPanel::SaveWallBrush() {
         }
     }
     
-    // Save
-    if (doc.save_file(nstr(wallsFile).c_str())) {
-        DiscardDraft(2, mainTileId);
-
-        TriggerReloadDataFiles();
-        ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
-
-        wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
-    } else {
-        wxMessageBox("Failed to save walls.xml", "Error", wxICON_ERROR);
+    wxString xmlText;
+    if (!ReadAllText(wallsFile, xmlText) || xmlText.IsEmpty()) {
+        xmlText = "<materials>\n</materials>\n";
     }
+
+    const wxString nl = DetectNewline(xmlText);
+    const wxString baseIndent = DetectChildIndent(xmlText, "brush");
+    const wxString newBlock = PrintNodeIndented(brushNode, baseIndent, nl);
+    const wxString attrNeedle = "name=\"" + name + "\"";
+
+    wxString oldText = xmlText;
+    if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
+        wxMessageBox("Invalid walls.xml file: missing '</materials>'", "Error", wxICON_ERROR);
+        return;
+    }
+
+    if (xmlText != oldText && !WriteAllText(wallsFile, xmlText)) {
+        wxMessageBox("Failed to save walls.xml", "Error", wxICON_ERROR);
+        return;
+    }
+
+    DiscardDraft(2, mainTileId);
+
+    TriggerReloadDataFiles();
+    ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+
+    wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
 }
 
 void BorderEditorPanel::LoadExistingWallBrushes() {
@@ -2094,8 +2276,24 @@ void BorderEditorPanel::SaveBorder() {
         itemNode.append_attribute("item").set_value(item.itemId);
     }
     
-    // Save the file
-    if (!doc.save_file(nstr(bordersFile).c_str())) {
+    wxString xmlText;
+    if (!ReadAllText(bordersFile, xmlText) || xmlText.IsEmpty()) {
+        wxMessageBox("Failed to read borders.xml", "Error", wxICON_ERROR);
+        return;
+    }
+
+    const wxString nl = DetectNewline(xmlText);
+    const wxString baseIndent = DetectChildIndent(xmlText, "border");
+    const wxString newBlock = PrintNodeIndented(borderNode, baseIndent, nl);
+    const wxString attrNeedle = wxString::Format("id=\"%d\"", id);
+
+    wxString oldText = xmlText;
+    if (!ReplaceOrInsertChildSimple(xmlText, "border", attrNeedle, newBlock, true)) {
+        wxMessageBox("Invalid borders.xml file: missing '</materials>'", "Error", wxICON_ERROR);
+        return;
+    }
+
+    if (xmlText != oldText && !WriteAllText(bordersFile, xmlText)) {
         wxMessageBox("Failed to save changes to borders.xml", "Error", wxICON_ERROR);
         return;
     }
@@ -5077,22 +5275,41 @@ void BorderEditorPanel::SaveGroundBrush() {
         }
     }
     
-    // Save the file
-    if (doc.save_file(nstr(groundsFile).c_str())) {
-        DiscardDraft(1, mainTileId);
-
-        TriggerReloadDataFiles();
-        ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
-
-        wxMessageBox(
-            wxString::Format("Ground brush '%s' saved successfully.", name),
-            "Success",
-            wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP,
-            this
-        );
-    } else {
-        wxMessageBox("Failed to save ground brush file.", "Error", wxOK | wxICON_ERROR);
+    wxString xmlText;
+    if (wxFileExists(groundsFile)) {
+        ReadAllText(groundsFile, xmlText);
     }
+    if (xmlText.IsEmpty()) {
+        xmlText = "<materials>\n</materials>\n";
+    }
+
+    const wxString nl = DetectNewline(xmlText);
+    const wxString baseIndent = DetectChildIndent(xmlText, "brush");
+    const wxString newBlock = PrintNodeIndented(brushNode, baseIndent, nl);
+    const wxString attrNeedle = "name=\"" + name + "\"";
+
+    wxString oldText = xmlText;
+    if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
+        wxMessageBox("Invalid grounds.xml file: missing '</materials>'", "Error", wxOK | wxICON_ERROR);
+        return;
+    }
+
+    if (xmlText != oldText && !WriteAllText(groundsFile, xmlText)) {
+        wxMessageBox("Failed to save ground brush file.", "Error", wxOK | wxICON_ERROR);
+        return;
+    }
+
+    DiscardDraft(1, mainTileId);
+
+    TriggerReloadDataFiles();
+    ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+
+    wxMessageBox(
+        wxString::Format("Ground brush '%s' saved successfully.", name),
+        "Success",
+        wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP,
+        this
+    );
 }
 
 void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -3716,7 +3716,6 @@ void BorderEditorPanel::PopulateBorderList() {
 
 	{
 		pugi::xml_document doc;
-		pugi::xml_document doc;
 		if (!LoadXmlWithCache(bordersFile, doc)) {
 			return;
 		}

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -1635,7 +1635,7 @@ void BorderEditorPanel::SaveWallBrush() {
 	wxString name = m_groundNameCtrl ? m_groundNameCtrl->GetValue().Trim() : wxString();
 
 	if (name.IsEmpty()) {
-		wxMessageBox("Please enter a name for the wall brush.", "Error", wxICON_ERROR);
+		ShowErrorDialog("Please enter a name for the wall brush.", ErrorSeverity::Warning);
 		return;
 	}
 
@@ -1732,12 +1732,12 @@ void BorderEditorPanel::SaveWallBrush() {
 
 	wxString oldText = xmlText;
 	if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
-		wxMessageBox("Invalid walls.xml file: missing '</materials>'", "Error", wxICON_ERROR);
+		ShowErrorDialog("Invalid walls.xml file: missing '</materials>'", ErrorSeverity::Error);
 		return;
 	}
 
 	if (xmlText != oldText && !WriteAllText(wallsFile, xmlText)) {
-		wxMessageBox("Failed to save walls.xml", "Error", wxICON_ERROR);
+		ShowErrorDialog("Failed to save wall brush file.", ErrorSeverity::Error);
 		return;
 	}
 
@@ -1746,7 +1746,10 @@ void BorderEditorPanel::SaveWallBrush() {
 	TriggerReloadDataFiles();
 	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
 
-	wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
+	ShowErrorDialog(
+		wxString::Format("Wall brush '%s' saved successfully.", name),
+		ErrorSeverity::Info
+	);
 }
 
 void BorderEditorPanel::LoadExistingWallBrushes() {

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -57,44 +57,45 @@
 
 // Helper to calculate grid metrics (Shared between BorderGridPanel and WallGridPanel)
 struct GridMetrics {
-    int cellSize;
-    int spacing;
-    int startX;
-    int startY;
-    int normalX, normalY;
-    int cornerX, cornerY;
-    int diagX, diagY;
-    
-    GridMetrics(const wxSize& size) {
-        int w = size.GetWidth();
-        int h = size.GetHeight();
-        int margin = 5;
-        
-        // We have 3 blocks of 2x2. 
-        // Width = 6 * cell + 2 * spacing. 
-        // Let spacing = cell / 2.
-        // Total width units = 7.
-        // Height = 2 * cell.
-        
-        cellSize = std::min((w - 2 * margin) / 7, (h - 2 * margin) / 2);
-        if (cellSize < 16) cellSize = 16; // Minimum size
-        
-        spacing = cellSize / 2;
-        int totalWidth = (2 * cellSize) * 3 + 2 * spacing;
-        
-        startX = (w - totalWidth) / 2;
-        startY = (h - 2 * cellSize) / 2;
-        
-        normalX = startX;
-        normalY = startY;
-        
-        cornerX = normalX + 2 * cellSize + spacing;
-        cornerY = startY;
-        
-        diagX = cornerX + 2 * cellSize + spacing;
-        diagY = startY;
-    }
+	int cellSize;
+	int spacing;
+	int startX;
+	int startY;
+	int normalX, normalY;
+	int cornerX, cornerY;
+	int diagX, diagY;
 
+	GridMetrics(const wxSize &size) {
+		int w = size.GetWidth();
+		int h = size.GetHeight();
+		int margin = 5;
+
+		// We have 3 blocks of 2x2.
+		// Width = 6 * cell + 2 * spacing.
+		// Let spacing = cell / 2.
+		// Total width units = 7.
+		// Height = 2 * cell.
+
+		cellSize = std::min((w - 2 * margin) / 7, (h - 2 * margin) / 2);
+		if (cellSize < 16) {
+			cellSize = 16; // Minimum size
+		}
+
+		spacing = cellSize / 2;
+		int totalWidth = (2 * cellSize) * 3 + 2 * spacing;
+
+		startX = (w - totalWidth) / 2;
+		startY = (h - 2 * cellSize) / 2;
+
+		normalX = startX;
+		normalY = startY;
+
+		cornerX = normalX + 2 * cellSize + spacing;
+		cornerY = startY;
+
+		diagX = cornerX + 2 * cellSize + spacing;
+		diagY = startY;
+	}
 };
 
 #define BORDER_GRID_SIZE 32
@@ -105,2496 +106,2666 @@ struct GridMetrics {
 
 static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions();
 
-static bool ReadAllText(const wxString& path, wxString& out) {
-    wxFile file(path, wxFile::read);
-    if (!file.IsOpened()) {
-        return false;
-    }
-    file.ReadAll(&out);
-    file.Close();
-    return true;
+static bool ReadAllText(const wxString &path, wxString &out) {
+	wxFile file(path, wxFile::read);
+	if (!file.IsOpened()) {
+		return false;
+	}
+	file.ReadAll(&out);
+	file.Close();
+	return true;
 }
 
-static bool WriteAllText(const wxString& path, const wxString& content) {
-    wxFile file;
-    if (!file.Create(path, true)) {
-        return false;
-    }
-    file.Write(content);
-    file.Close();
-    return true;
+static bool WriteAllText(const wxString &path, const wxString &content) {
+	wxFile file;
+	if (!file.Create(path, true)) {
+		return false;
+	}
+	file.Write(content);
+	file.Close();
+	return true;
 }
 
-static wxString DetectNewline(const wxString& text) {
-    return (text.Find("\r\n") != wxNOT_FOUND) ? "\r\n" : "\n";
+void BorderEditorPanel::LogError(const wxString &message, ErrorSeverity severity) {
+	wxString severityStr;
+	switch (severity) {
+		case ErrorSeverity::Info:
+			severityStr = "INFO";
+			break;
+		case ErrorSeverity::Warning:
+			severityStr = "WARNING";
+			break;
+		case ErrorSeverity::Error:
+			severityStr = "ERROR";
+			break;
+		case ErrorSeverity::Critical:
+			severityStr = "CRITICAL";
+			break;
+	}
+	wxLogMessage("[BrushEditor] [%s] %s", severityStr, message);
 }
 
-static wxString IndentBeforePos(const wxString& text, size_t pos) {
-    if (pos > text.length()) {
-        pos = text.length();
-    }
-    size_t lineStart = text.rfind('\n', pos);
-    if (lineStart == wxString::npos) {
-        lineStart = 0;
-    } else {
-        lineStart += 1;
-    }
-    size_t i = lineStart;
-    while (i < pos && (text[i] == ' ' || text[i] == '\t')) {
-        ++i;
-    }
-    return text.Mid(lineStart, i - lineStart);
+void BorderEditorPanel::ShowErrorDialog(const wxString &message, ErrorSeverity severity) {
+	LogError(message, severity);
+
+	long style;
+	switch (severity) {
+		case ErrorSeverity::Info:
+			style = wxOK | wxICON_INFORMATION;
+			break;
+		case ErrorSeverity::Warning:
+			style = wxOK | wxICON_WARNING;
+			break;
+		case ErrorSeverity::Error:
+			style = wxOK | wxICON_ERROR;
+			break;
+		case ErrorSeverity::Critical:
+			style = wxOK | wxICON_ERROR;
+			break;
+	}
+
+	wxMessageBox(message, "Brush Editor", style, this);
 }
 
-static wxString DetectChildIndent(const wxString& text, const wxString& elementName) {
-    const wxString open = "<" + elementName;
-    const size_t pos = text.find(open);
-    if (pos == wxString::npos) {
-        return "    ";
-    }
-    return IndentBeforePos(text, pos);
+static wxString DetectNewline(const wxString &text) {
+	return (text.Find("\r\n") != wxNOT_FOUND) ? "\r\n" : "\n";
 }
 
-static bool FindXmlElementRangeSimple(const wxString& text, const wxString& elementName, const wxString& attrNeedle, size_t& outStart, size_t& outEnd) {
-    const wxString open = "<" + elementName;
-    const wxString close = "</" + elementName + ">";
-
-    size_t pos = 0;
-    while ((pos = text.find(open, pos)) != wxString::npos) {
-        const size_t tagEnd = text.find('>', pos);
-        if (tagEnd == wxString::npos) {
-            return false;
-        }
-
-        const wxString startTag = text.Mid(pos, tagEnd - pos + 1);
-        if (startTag.find(attrNeedle) == wxString::npos) {
-            pos = tagEnd + 1;
-            continue;
-        }
-
-        const size_t closePos = text.find(close, tagEnd + 1);
-        if (closePos == wxString::npos) {
-            return false;
-        }
-
-        size_t end = closePos + close.length();
-        if (end < text.length() && text[end] == '\r') {
-            if (end + 1 < text.length() && text[end + 1] == '\n') {
-                end += 2;
-            } else {
-                end += 1;
-            }
-        } else if (end < text.length() && text[end] == '\n') {
-            end += 1;
-        }
-
-        outStart = pos;
-        outEnd = end;
-        return true;
-    }
-
-    return false;
+static wxString IndentBeforePos(const wxString &text, size_t pos) {
+	if (pos > text.length()) {
+		pos = text.length();
+	}
+	size_t lineStart = text.rfind('\n', pos);
+	if (lineStart == wxString::npos) {
+		lineStart = 0;
+	} else {
+		lineStart += 1;
+	}
+	size_t i = lineStart;
+	while (i < pos && (text[i] == ' ' || text[i] == '\t')) {
+		++i;
+	}
+	return text.Mid(lineStart, i - lineStart);
 }
 
-static void ExpandStartToIncludePrevSingleLineComment(const wxString& text, size_t& start) {
-    if (start == 0) {
-        return;
-    }
-
-    size_t lineStart = text.rfind('\n', start - 1);
-    if (lineStart == wxString::npos) {
-        lineStart = 0;
-    } else {
-        lineStart += 1;
-    }
-
-    wxString line = text.Mid(lineStart, start - lineStart);
-    line.Trim(true);
-    line.Trim(false);
-
-    if (line.StartsWith("<!--") && line.EndsWith("-->")) {
-        start = lineStart;
-    }
+static wxString DetectChildIndent(const wxString &text, const wxString &elementName) {
+	const wxString open = "<" + elementName;
+	const size_t pos = text.find(open);
+	if (pos == wxString::npos) {
+		return "    ";
+	}
+	return IndentBeforePos(text, pos);
 }
 
-static wxString PrintNodeIndented(const pugi::xml_node& node, const wxString& baseIndent, const wxString& nl) {
-    std::ostringstream oss;
-    node.print(oss, "  ", pugi::format_default, pugi::encoding_utf8);
+static bool FindXmlElementRangeSimple(const wxString &text, const wxString &elementName, const wxString &attrNeedle, size_t &outStart, size_t &outEnd) {
+	const wxString open = "<" + elementName;
+	const wxString close = "</" + elementName + ">";
 
-    const std::string s = oss.str();
-    wxString out = wxString::FromUTF8(s.c_str());
+	size_t pos = 0;
+	while ((pos = text.find(open, pos)) != wxString::npos) {
+		const size_t tagEnd = text.find('>', pos);
+		if (tagEnd == wxString::npos) {
+			return false;
+		}
 
-    if (out.EndsWith("\n")) {
-        out.RemoveLast();
-    }
+		const wxString startTag = text.Mid(pos, tagEnd - pos + 1);
+		if (startTag.find(attrNeedle) == wxString::npos) {
+			pos = tagEnd + 1;
+			continue;
+		}
 
-    out.Replace("\n", "\n" + baseIndent);
-    out = baseIndent + out;
+		const size_t closePos = text.find(close, tagEnd + 1);
+		if (closePos == wxString::npos) {
+			return false;
+		}
 
-    if (nl != "\n") {
-        out.Replace("\n", nl);
-    }
+		size_t end = closePos + close.length();
+		if (end < text.length() && text[end] == '\r') {
+			if (end + 1 < text.length() && text[end + 1] == '\n') {
+				end += 2;
+			} else {
+				end += 1;
+			}
+		} else if (end < text.length() && text[end] == '\n') {
+			end += 1;
+		}
 
-    if (!out.EndsWith(nl)) {
-        out += nl;
-    }
+		outStart = pos;
+		outEnd = end;
+		return true;
+	}
 
-    return out;
+	return false;
 }
 
-static bool ReplaceOrInsertChildSimple(wxString& text, const wxString& elementName, const wxString& attrNeedle, const wxString& newBlock, bool includePrevSingleLineComment) {
-    size_t start = 0;
-    size_t end = 0;
+static void ExpandStartToIncludePrevSingleLineComment(const wxString &text, size_t &start) {
+	if (start == 0) {
+		return;
+	}
 
-    if (FindXmlElementRangeSimple(text, elementName, attrNeedle, start, end)) {
-        if (includePrevSingleLineComment) {
-            ExpandStartToIncludePrevSingleLineComment(text, start);
-        }
-        text = text.Mid(0, start) + newBlock + text.Mid(end);
-        return true;
-    }
+	size_t lineStart = text.rfind('\n', start - 1);
+	if (lineStart == wxString::npos) {
+		lineStart = 0;
+	} else {
+		lineStart += 1;
+	}
 
-    const size_t insertPos = text.rfind("</materials>");
-    if (insertPos == wxString::npos) {
-        return false;
-    }
+	wxString line = text.Mid(lineStart, start - lineStart);
+	line.Trim(true);
+	line.Trim(false);
 
-    const wxString nl = DetectNewline(text);
-    wxString insertion = newBlock;
-    const wxString before = text.Mid(0, insertPos);
-    if (!before.EndsWith(nl)) {
-        insertion = nl + insertion;
-    }
+	if (line.StartsWith("<!--") && line.EndsWith("-->")) {
+		start = lineStart;
+	}
+}
 
-    text = before + insertion + text.Mid(insertPos);
-    return true;
+static wxString PrintNodeIndented(const pugi::xml_node &node, const wxString &baseIndent, const wxString &nl) {
+	std::ostringstream oss;
+	node.print(oss, "  ", pugi::format_default, pugi::encoding_utf8);
+
+	const std::string s = oss.str();
+	wxString out = wxString::FromUTF8(s.c_str());
+
+	if (out.EndsWith("\n")) {
+		out.RemoveLast();
+	}
+
+	out.Replace("\n", "\n" + baseIndent);
+	out = baseIndent + out;
+
+	if (nl != "\n") {
+		out.Replace("\n", nl);
+	}
+
+	if (!out.EndsWith(nl)) {
+		out += nl;
+	}
+
+	return out;
+}
+
+static bool ReplaceOrInsertChildSimple(wxString &text, const wxString &elementName, const wxString &attrNeedle, const wxString &newBlock, bool includePrevSingleLineComment) {
+	size_t start = 0;
+	size_t end = 0;
+
+	if (FindXmlElementRangeSimple(text, elementName, attrNeedle, start, end)) {
+		if (includePrevSingleLineComment) {
+			ExpandStartToIncludePrevSingleLineComment(text, start);
+		}
+		text = text.Mid(0, start) + newBlock + text.Mid(end);
+		return true;
+	}
+
+	const size_t insertPos = text.rfind("</materials>");
+	if (insertPos == wxString::npos) {
+		return false;
+	}
+
+	const wxString nl = DetectNewline(text);
+	wxString insertion = newBlock;
+	const wxString before = text.Mid(0, insertPos);
+	if (!before.EndsWith(nl)) {
+		insertion = nl + insertion;
+	}
+
+	text = before + insertion + text.Mid(insertPos);
+	return true;
 }
 
 // Utility functions for edge string/position conversion
-BorderEdgePosition edgeStringToPosition(const std::string& edgeStr) {
-    if (edgeStr == "n") return EDGE_N;
-    if (edgeStr == "e") return EDGE_E;
-    if (edgeStr == "s") return EDGE_S;
-    if (edgeStr == "w") return EDGE_W;
-    if (edgeStr == "cnw") return EDGE_CNW;
-    if (edgeStr == "cne") return EDGE_CNE;
-    if (edgeStr == "cse") return EDGE_CSE;
-    if (edgeStr == "csw") return EDGE_CSW;
-    if (edgeStr == "dnw") return EDGE_DNW;
-    if (edgeStr == "dne") return EDGE_DNE;
-    if (edgeStr == "dse") return EDGE_DSE;
-    if (edgeStr == "dsw") return EDGE_DSW;
-    return EDGE_NONE;
+BorderEdgePosition edgeStringToPosition(const std::string &edgeStr) {
+	if (edgeStr == "n") {
+		return EDGE_N;
+	}
+	if (edgeStr == "e") {
+		return EDGE_E;
+	}
+	if (edgeStr == "s") {
+		return EDGE_S;
+	}
+	if (edgeStr == "w") {
+		return EDGE_W;
+	}
+	if (edgeStr == "cnw") {
+		return EDGE_CNW;
+	}
+	if (edgeStr == "cne") {
+		return EDGE_CNE;
+	}
+	if (edgeStr == "cse") {
+		return EDGE_CSE;
+	}
+	if (edgeStr == "csw") {
+		return EDGE_CSW;
+	}
+	if (edgeStr == "dnw") {
+		return EDGE_DNW;
+	}
+	if (edgeStr == "dne") {
+		return EDGE_DNE;
+	}
+	if (edgeStr == "dse") {
+		return EDGE_DSE;
+	}
+	if (edgeStr == "dsw") {
+		return EDGE_DSW;
+	}
+	return EDGE_NONE;
 }
 
 std::string edgePositionToString(BorderEdgePosition pos) {
-    switch (pos) {
-        case EDGE_N: return "n";
-        case EDGE_E: return "e";
-        case EDGE_S: return "s";
-        case EDGE_W: return "w";
-        case EDGE_CNW: return "cnw";
-        case EDGE_CNE: return "cne";
-        case EDGE_CSE: return "cse";
-        case EDGE_CSW: return "csw";
-        case EDGE_DNW: return "dnw";
-        case EDGE_DNE: return "dne";
-        case EDGE_DSE: return "dse";
-        case EDGE_DSW: return "dsw";
-        default: return "";
-    }
+	switch (pos) {
+		case EDGE_N:
+			return "n";
+		case EDGE_E:
+			return "e";
+		case EDGE_S:
+			return "s";
+		case EDGE_W:
+			return "w";
+		case EDGE_CNW:
+			return "cnw";
+		case EDGE_CNE:
+			return "cne";
+		case EDGE_CSE:
+			return "cse";
+		case EDGE_CSW:
+			return "csw";
+		case EDGE_DNW:
+			return "dnw";
+		case EDGE_DNE:
+			return "dne";
+		case EDGE_DSE:
+			return "dse";
+		case EDGE_DSW:
+			return "dsw";
+		default:
+			return "";
+	}
 }
 
 // Add a helper function at the top of the file to get item ID from brush
 uint16_t GetItemIDFromBrush(Brush* brush) {
-    if (!brush) {
-        wxLogDebug("GetItemIDFromBrush: Brush is null");
+	if (!brush) {
+		wxLogDebug("GetItemIDFromBrush: Brush is null");
 
-        return 0;
-    }
-    
-    uint16_t id = 0;
-    
-    wxLogDebug("GetItemIDFromBrush: Checking brush type: %s", wxString(brush->getName()).c_str());
+		return 0;
+	}
 
-    
-    // First prioritize RAW brush - this is the most direct approach
-    if (brush->isRaw()) {
-        RAWBrush* rawBrush = brush->asRaw();
-        if (rawBrush) {
-            id = rawBrush->getItemID();
-            wxLogDebug("GetItemIDFromBrush: Found RAW brush ID: %d", id);
+	uint16_t id = 0;
 
-            if (id > 0) {
-                return id;
-            }
-        }
-    } 
-    
-    // Then try getID which sometimes works directly
-    id = brush->getID();
-    if (id > 0) {
-        wxLogDebug("GetItemIDFromBrush: Got ID from brush->getID(): %d", id);
+	wxLogDebug("GetItemIDFromBrush: Checking brush type: %s", wxString(brush->getName()).c_str());
 
-        return id;
-    }
-    
-    // Try getLookID which works for most other brush types
-    id = brush->getLookID();
-    if (id > 0) {
-        wxLogDebug("GetItemIDFromBrush: Got ID from getLookID(): %d", id);
+	// First prioritize RAW brush - this is the most direct approach
+	if (brush->isRaw()) {
+		RAWBrush* rawBrush = brush->asRaw();
+		if (rawBrush) {
+			id = rawBrush->getItemID();
+			wxLogDebug("GetItemIDFromBrush: Found RAW brush ID: %d", id);
 
-        return id;
-    }
-    
-    // Try specific brush type methods - when all else fails
-    if (brush->isGround()) {
-        wxLogDebug("GetItemIDFromBrush: Detected Ground brush");
+			if (id > 0) {
+				return id;
+			}
+		}
+	}
 
-        GroundBrush* groundBrush = brush->asGround();
-        if (groundBrush) {
-            // For ground brush, id is usually the server_lookid from grounds.xml
-            // Try to find something else
-            wxLogDebug("GetItemIDFromBrush: Failed to get ID for Ground brush");
+	// Then try getID which sometimes works directly
+	id = brush->getID();
+	if (id > 0) {
+		wxLogDebug("GetItemIDFromBrush: Got ID from brush->getID(): %d", id);
 
-        }
-    }
-    else if (brush->isWall()) {
-        wxLogDebug("GetItemIDFromBrush: Detected Wall brush");
+		return id;
+	}
 
-        WallBrush* wallBrush = brush->asWall();
-        if (wallBrush) {
-            wxLogDebug("GetItemIDFromBrush: Failed to get ID for Wall brush");
+	// Try getLookID which works for most other brush types
+	id = brush->getLookID();
+	if (id > 0) {
+		wxLogDebug("GetItemIDFromBrush: Got ID from getLookID(): %d", id);
 
-        }
-    }
-    else if (brush->isDoodad()) {
-        wxLogDebug("GetItemIDFromBrush: Detected Doodad brush");
+		return id;
+	}
 
-        DoodadBrush* doodadBrush = brush->asDoodad();
-        if (doodadBrush) {
-            wxLogDebug("GetItemIDFromBrush: Failed to get ID for Doodad brush");
+	// Try specific brush type methods - when all else fails
+	if (brush->isGround()) {
+		wxLogDebug("GetItemIDFromBrush: Detected Ground brush");
 
-        }
-    }
-    
-    if (id == 0) {
-        wxLogDebug("GetItemIDFromBrush: Failed to get item ID from brush %s", wxString(brush->getName()).c_str());
+		GroundBrush* groundBrush = brush->asGround();
+		if (groundBrush) {
+			// For ground brush, id is usually the server_lookid from grounds.xml
+			// Try to find something else
+			wxLogDebug("GetItemIDFromBrush: Failed to get ID for Ground brush");
+		}
+	} else if (brush->isWall()) {
+		wxLogDebug("GetItemIDFromBrush: Detected Wall brush");
 
-    }
-    
-    return id;
+		WallBrush* wallBrush = brush->asWall();
+		if (wallBrush) {
+			wxLogDebug("GetItemIDFromBrush: Failed to get ID for Wall brush");
+		}
+	} else if (brush->isDoodad()) {
+		wxLogDebug("GetItemIDFromBrush: Detected Doodad brush");
+
+		DoodadBrush* doodadBrush = brush->asDoodad();
+		if (doodadBrush) {
+			wxLogDebug("GetItemIDFromBrush: Failed to get ID for Doodad brush");
+		}
+	}
+
+	if (id == 0) {
+		wxLogDebug("GetItemIDFromBrush: Failed to get item ID from brush %s", wxString(brush->getName()).c_str());
+	}
+
+	return id;
 }
 
 // Event table for BorderEditorPanel
 wxDEFINE_EVENT(wxEVT_GROUND_CONTAINER_CHANGE, wxCommandEvent);
 
 static void TriggerReloadDataFiles() {
-    if (!g_gui.root) {
-        return;
-    }
+	if (!g_gui.root) {
+		return;
+	}
 
-    wxCommandEvent reloadEvent(
-        wxEVT_COMMAND_MENU_SELECTED,
-        MAIN_FRAME_MENU + MenuBar::RELOAD_DATA
-    );
-    g_gui.root->GetEventHandler()->ProcessEvent(reloadEvent);
+	wxCommandEvent reloadEvent(
+		wxEVT_COMMAND_MENU_SELECTED,
+		MAIN_FRAME_MENU + MenuBar::RELOAD_DATA
+	);
+	g_gui.root->GetEventHandler()->ProcessEvent(reloadEvent);
 }
 
-bool BorderEditorPanel::RestoreBrowserSelection(const wxString& selectionKey) {
-    if (!m_borderBrowserList) {
-        return false;
-    }
+bool BorderEditorPanel::RestoreBrowserSelection(const wxString &selectionKey) {
+	if (!m_borderBrowserList) {
+		return false;
+	}
 
-    if (selectionKey.IsEmpty()) {
-        m_borderBrowserList->SetSelection(wxNOT_FOUND);
-        if (m_browserGrid) {
-            m_browserGrid->SetSelectionByKey(wxString());
-        }
-        return false;
-    }
+	if (selectionKey.IsEmpty()) {
+		m_borderBrowserList->SetSelection(wxNOT_FOUND);
+		if (m_browserGrid) {
+			m_browserGrid->SetSelectionByKey(wxString());
+		}
+		return false;
+	}
 
-    const int wanted = wxAtoi(selectionKey);
+	const int wanted = wxAtoi(selectionKey);
 
-    for (unsigned int i = 0; i < m_borderBrowserList->GetCount(); ++i) {
-        wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(i));
-        if (!data) {
-            continue;
-        }
+	for (unsigned int i = 0; i < m_borderBrowserList->GetCount(); ++i) {
+		wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(i));
+		if (!data) {
+			continue;
+		}
 
-        if (wxAtoi(data->GetData()) == wanted) {
-            m_borderBrowserList->SetSelection(i);
-            if (m_browserGrid) {
-                m_browserGrid->SetSelectionByKey(selectionKey);
-            }
-            return true;
-        }
-    }
+		if (wxAtoi(data->GetData()) == wanted) {
+			m_borderBrowserList->SetSelection(i);
+			if (m_browserGrid) {
+				m_browserGrid->SetSelectionByKey(selectionKey);
+			}
+			return true;
+		}
+	}
 
-    m_borderBrowserList->SetSelection(wxNOT_FOUND);
-    if (m_browserGrid) {
-        m_browserGrid->SetSelectionByKey(wxString());
-    }
-    return false;
+	m_borderBrowserList->SetSelection(wxNOT_FOUND);
+	if (m_browserGrid) {
+		m_browserGrid->SetSelectionByKey(wxString());
+	}
+	return false;
 }
 
-void BorderEditorPanel::ReloadCurrentBrushEditorXml(const wxString& selectionKey) {
-    if (m_browserSearchCtrl) {
-        m_browserSearchCtrl->Clear();
-    }
+void BorderEditorPanel::ReloadCurrentBrushEditorXml(const wxString &selectionKey) {
+	if (m_browserSearchCtrl) {
+		m_browserSearchCtrl->Clear();
+	}
 
-    LoadTilesets();
-    PopulateUnifiedList();
+	LoadTilesets();
+	PopulateUnifiedList();
 
-    RestoreBrowserSelection(selectionKey);
+	RestoreBrowserSelection(selectionKey);
 
-    const uint16_t tileId = static_cast<uint16_t>(wxAtoi(selectionKey));
-    switch (m_activeTab) {
-        case 0: LoadBorderByMainTileId(tileId); break;
-        case 1: LoadGroundBrushByMainTileId(tileId); break;
-        case 2: LoadWallBrushByMainTileId(tileId); break;
-    }
+	const uint16_t tileId = static_cast<uint16_t>(wxAtoi(selectionKey));
+	switch (m_activeTab) {
+		case 0:
+			LoadBorderByMainTileId(tileId);
+			break;
+		case 1:
+			LoadGroundBrushByMainTileId(tileId);
+			break;
+		case 2:
+			LoadWallBrushByMainTileId(tileId);
+			break;
+	}
 
-    Layout();
-    Refresh();
-    Update();
+	Layout();
+	Refresh();
+	Update();
 }
 
 BEGIN_EVENT_TABLE(BorderEditorPanel, wxPanel)
-    EVT_BUTTON(wxID_ADD, BorderEditorPanel::OnAddItem)
-    EVT_BUTTON(wxID_CLEAR, BorderEditorPanel::OnClear)
-    EVT_BUTTON(wxID_SAVE, BorderEditorPanel::OnSave)
-    EVT_BUTTON(wxID_CLOSE, BorderEditorPanel::OnClose)
-    EVT_BUTTON(wxID_FIND, BorderEditorPanel::OnBrowse)
-    EVT_COMBOBOX(wxID_ANY, BorderEditorPanel::OnLoadBorder)
-    EVT_NOTEBOOK_PAGE_CHANGED(wxID_ANY, BorderEditorPanel::OnPageChanged)
+EVT_BUTTON(wxID_ADD, BorderEditorPanel::OnAddItem)
+EVT_BUTTON(wxID_CLEAR, BorderEditorPanel::OnClear)
+EVT_BUTTON(wxID_SAVE, BorderEditorPanel::OnSave)
+EVT_BUTTON(wxID_CLOSE, BorderEditorPanel::OnClose)
+EVT_BUTTON(wxID_FIND, BorderEditorPanel::OnBrowse)
+EVT_COMBOBOX(wxID_ANY, BorderEditorPanel::OnLoadBorder)
+EVT_NOTEBOOK_PAGE_CHANGED(wxID_ANY, BorderEditorPanel::OnPageChanged)
 END_EVENT_TABLE()
 
 // Event table for BorderItemButton
 BEGIN_EVENT_TABLE(BorderItemButton, wxButton)
-    EVT_PAINT(BorderItemButton::OnPaint)
+EVT_PAINT(BorderItemButton::OnPaint)
 END_EVENT_TABLE()
 
 // Event table for BorderGridPanel
 BEGIN_EVENT_TABLE(BorderGridPanel, wxPanel)
-    EVT_PAINT(BorderGridPanel::OnPaint)
-    EVT_LEFT_UP(BorderGridPanel::OnMouseClick)
-    EVT_LEFT_DOWN(BorderGridPanel::OnMouseDown)
+EVT_PAINT(BorderGridPanel::OnPaint)
+EVT_LEFT_UP(BorderGridPanel::OnMouseClick)
+EVT_LEFT_DOWN(BorderGridPanel::OnMouseDown)
 END_EVENT_TABLE()
 
 // Event table for BorderPreviewPanel
 BEGIN_EVENT_TABLE(BorderPreviewPanel, wxPanel)
-    EVT_PAINT(BorderPreviewPanel::OnPaint)
+EVT_PAINT(BorderPreviewPanel::OnPaint)
 END_EVENT_TABLE()
 
 BorderEditorPanel::BorderEditorPanel(wxWindow* parent) :
-    wxPanel(parent, wxID_ANY),
-    m_nextBorderId(1),
-    m_activeTab(1),
-    m_selectedBrowserTileId(0),
-    m_lastInteractionTime(0) {
-    
-    // Load saved filter configuration (before creating UI)
-    LoadFilterConfig();
-    
-    CreateGUIControls();
-    
-    // Default to Ground tab
-    m_notebook->SetSelection(1);
-    if (m_borderModeBtn) m_borderModeBtn->SetValue(false);
-    if (m_groundModeBtn) m_groundModeBtn->SetValue(true);
-    if (m_wallModeBtn) m_wallModeBtn->SetValue(false);
-    
-    // Explicitly populate the sidebar (unified list) for the initial tab
-    // (OnPageChanged may not fire for the initial selection on all platforms)
-    PopulateUnifiedList();
-    UpdateBrowserLabel();
-    
-    // Set initial border ID
-    m_currentBorderId = m_nextBorderId;
-    
-    Layout();
+	wxPanel(parent, wxID_ANY),
+	m_nextBorderId(1),
+	m_activeTab(1),
+	m_selectedBrowserTileId(0),
+	m_lastInteractionTime(0) {
+
+	// Load saved filter configuration (before creating UI)
+	LoadFilterConfig();
+
+	CreateGUIControls();
+
+	// Default to Ground tab
+	m_notebook->SetSelection(1);
+	if (m_borderModeBtn) {
+		m_borderModeBtn->SetValue(false);
+	}
+	if (m_groundModeBtn) {
+		m_groundModeBtn->SetValue(true);
+	}
+	if (m_wallModeBtn) {
+		m_wallModeBtn->SetValue(false);
+	}
+
+	// Explicitly populate the sidebar (unified list) for the initial tab
+	// (OnPageChanged may not fire for the initial selection on all platforms)
+	PopulateUnifiedList();
+	UpdateBrowserLabel();
+
+	// Set initial border ID
+	m_currentBorderId = m_nextBorderId;
+
+	Layout();
 }
 
 BorderEditorPanel::~BorderEditorPanel() {
-    // Nothing to destroy manually
+	// Nothing to destroy manually
 }
 
 void BorderEditorPanel::SaveDraft(int tab, uint16_t tileId, bool markDirty) {
-    if (m_isRestoringDraft) {
-        return;
-    }
-    if (tileId == 0) {
-        return;
-    }
+	if (m_isRestoringDraft) {
+		return;
+	}
+	if (tileId == 0) {
+		return;
+	}
 
-    switch (tab) {
-        case 0: {
-            BorderDraftState& d = m_borderDrafts[tileId];
-            d.currentBorderId = m_currentBorderId;
-            d.borderName = m_loadedBorderName;
-            d.group = m_groupCheck ? m_groupCheck->GetValue() : false;
-            d.optional = m_isOptionalCheck ? m_isOptionalCheck->GetValue() : false;
-            d.ground = m_isGroundCheck ? m_isGroundCheck->GetValue() : false;
-            d.items = m_borderItems;
-            d.dirty = d.dirty || markDirty;
-            break;
-        }
-        case 1: {
-            GroundDraftState& d = m_groundDrafts[tileId];
-            d.name = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
-            d.zOrder = m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0;
-            d.borderAlignmentSelection = m_borderAlignmentSelection;
-            d.includeToNone = m_includeToNoneCheck ? m_includeToNoneCheck->GetValue() : true;
-            d.includeInner = m_includeInnerCheck ? m_includeInnerCheck->GetValue() : false;
-            d.items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
-            d.dirty = d.dirty || markDirty;
-            break;
-        }
-        case 2: {
-            WallDraftState& d = m_wallDrafts[tileId];
-            d.brushName = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
-            d.wallTypes = m_wallTypes;
-            d.selectedType = m_wallGridPanel ? m_wallGridPanel->GetSelectedType() : std::string();
-            d.dirty = d.dirty || markDirty;
-            break;
-        }
-        default:
-            break;
-    }
+	switch (tab) {
+		case 0: {
+			BorderDraftState &d = m_borderDrafts[tileId];
+			d.currentBorderId = m_currentBorderId;
+			d.borderName = m_loadedBorderName;
+			d.group = m_groupCheck ? m_groupCheck->GetValue() : false;
+			d.optional = m_isOptionalCheck ? m_isOptionalCheck->GetValue() : false;
+			d.ground = m_isGroundCheck ? m_isGroundCheck->GetValue() : false;
+			d.items = m_borderItems;
+			d.dirty = d.dirty || markDirty;
+			break;
+		}
+		case 1: {
+			GroundDraftState &d = m_groundDrafts[tileId];
+			d.name = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
+			d.zOrder = m_zOrderCtrl ? m_zOrderCtrl->GetValue() : 0;
+			d.borderAlignmentSelection = m_borderAlignmentSelection;
+			d.includeToNone = m_includeToNoneCheck ? m_includeToNoneCheck->GetValue() : true;
+			d.includeInner = m_includeInnerCheck ? m_includeInnerCheck->GetValue() : false;
+			d.items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
+			d.dirty = d.dirty || markDirty;
+			break;
+		}
+		case 2: {
+			WallDraftState &d = m_wallDrafts[tileId];
+			d.brushName = m_groundNameCtrl ? m_groundNameCtrl->GetValue() : wxString();
+			d.wallTypes = m_wallTypes;
+			d.selectedType = m_wallGridPanel ? m_wallGridPanel->GetSelectedType() : std::string();
+			d.dirty = d.dirty || markDirty;
+			break;
+		}
+		default:
+			break;
+	}
 }
 
 bool BorderEditorPanel::RestoreDraft(int tab, uint16_t tileId) {
-    if (tileId == 0) {
-        return false;
-    }
+	if (tileId == 0) {
+		return false;
+	}
 
-    if (tab == 0) {
-        auto it = m_borderDrafts.find(tileId);
-        if (it == m_borderDrafts.end()) return false;
+	if (tab == 0) {
+		auto it = m_borderDrafts.find(tileId);
+		if (it == m_borderDrafts.end()) {
+			return false;
+		}
 
-        m_isRestoringDraft = true;
-        ClearItems(false);
+		m_isRestoringDraft = true;
+		ClearItems(false);
 
-        const BorderDraftState& d = it->second;
-        m_currentBorderId = d.currentBorderId;
-        m_loadedBorderName = d.borderName;
-        if (m_groupCheck) m_groupCheck->SetValue(d.group);
-        if (m_isOptionalCheck) m_isOptionalCheck->SetValue(d.optional);
-        if (m_isGroundCheck) m_isGroundCheck->SetValue(d.ground);
+		const BorderDraftState &d = it->second;
+		m_currentBorderId = d.currentBorderId;
+		m_loadedBorderName = d.borderName;
+		if (m_groupCheck) {
+			m_groupCheck->SetValue(d.group);
+		}
+		if (m_isOptionalCheck) {
+			m_isOptionalCheck->SetValue(d.optional);
+		}
+		if (m_isGroundCheck) {
+			m_isGroundCheck->SetValue(d.ground);
+		}
 
-        m_borderItems = d.items;
-        if (m_gridPanel) {
-            for (const BorderItem& item : m_borderItems) {
-                m_gridPanel->SetItemId(item.position, item.itemId);
-            }
-        }
-        UpdatePreview();
-        m_isRestoringDraft = false;
-        return true;
-    }
+		m_borderItems = d.items;
+		if (m_gridPanel) {
+			for (const BorderItem &item : m_borderItems) {
+				m_gridPanel->SetItemId(item.position, item.itemId);
+			}
+		}
+		UpdatePreview();
+		m_isRestoringDraft = false;
+		return true;
+	}
 
-    if (tab == 1) {
-        auto it = m_groundDrafts.find(tileId);
-        if (it == m_groundDrafts.end()) return false;
+	if (tab == 1) {
+		auto it = m_groundDrafts.find(tileId);
+		if (it == m_groundDrafts.end()) {
+			return false;
+		}
 
-        m_isRestoringDraft = true;
-        ClearGroundItems(false);
+		m_isRestoringDraft = true;
+		ClearGroundItems(false);
 
-        const GroundDraftState& d = it->second;
-        if (m_groundNameCtrl) m_groundNameCtrl->SetValue(d.name);
-        if (m_zOrderCtrl) m_zOrderCtrl->SetValue(d.zOrder);
-        m_borderAlignmentSelection = d.borderAlignmentSelection;
-        if (m_borderAlignmentButton) {
-            m_borderAlignmentButton->SetLabel((m_borderAlignmentSelection == 1 ? "Inner" : "Outer") + wxString(" \u25BC"));
-        }
-        if (m_includeToNoneCheck) m_includeToNoneCheck->SetValue(d.includeToNone);
-        if (m_includeInnerCheck) m_includeInnerCheck->SetValue(d.includeInner);
+		const GroundDraftState &d = it->second;
+		if (m_groundNameCtrl) {
+			m_groundNameCtrl->SetValue(d.name);
+		}
+		if (m_zOrderCtrl) {
+			m_zOrderCtrl->SetValue(d.zOrder);
+		}
+		m_borderAlignmentSelection = d.borderAlignmentSelection;
+		if (m_borderAlignmentButton) {
+			m_borderAlignmentButton->SetLabel((m_borderAlignmentSelection == 1 ? "Inner" : "Outer") + wxString(" \u25BC"));
+		}
+		if (m_includeToNoneCheck) {
+			m_includeToNoneCheck->SetValue(d.includeToNone);
+		}
+		if (m_includeInnerCheck) {
+			m_includeInnerCheck->SetValue(d.includeInner);
+		}
 
-        if (m_groundGridContainer) {
-            m_groundGridContainer->Clear();
-            for (const auto& item : d.items) {
-                if (item.first > 0) {
-                    m_groundGridContainer->AddItem(item.first, item.second, true);
-                }
-            }
-        }
-        if (m_groundPreviewPanel && m_groundGridContainer) {
-            m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
-        }
+		if (m_groundGridContainer) {
+			m_groundGridContainer->Clear();
+			for (const auto &item : d.items) {
+				if (item.first > 0) {
+					m_groundGridContainer->AddItem(item.first, item.second, true);
+				}
+			}
+		}
+		if (m_groundPreviewPanel && m_groundGridContainer) {
+			m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+		}
 
-        m_isRestoringDraft = false;
-        return true;
-    }
+		m_isRestoringDraft = false;
+		return true;
+	}
 
-    if (tab == 2) {
-        auto it = m_wallDrafts.find(tileId);
-        if (it == m_wallDrafts.end()) return false;
+	if (tab == 2) {
+		auto it = m_wallDrafts.find(tileId);
+		if (it == m_wallDrafts.end()) {
+			return false;
+		}
 
-        m_isRestoringDraft = true;
-        ClearWallItems(false);
+		m_isRestoringDraft = true;
+		ClearWallItems(false);
 
-        const WallDraftState& d = it->second;
-        if (m_groundNameCtrl) m_groundNameCtrl->SetValue(d.brushName);
+		const WallDraftState &d = it->second;
+		if (m_groundNameCtrl) {
+			m_groundNameCtrl->SetValue(d.brushName);
+		}
 
-        m_wallTypes = d.wallTypes;
-        if (m_wallGridPanel) {
-            m_wallGridPanel->SetWallTypes(m_wallTypes);
-            m_wallGridPanel->SetSelectedType(d.selectedType.empty() ? std::string("vertical") : d.selectedType);
-        }
-        if (m_wallVisualPanel) {
-            m_wallVisualPanel->SetWallItems(m_wallTypes);
-        }
-        UpdateWallItemsList();
+		m_wallTypes = d.wallTypes;
+		if (m_wallGridPanel) {
+			m_wallGridPanel->SetWallTypes(m_wallTypes);
+			m_wallGridPanel->SetSelectedType(d.selectedType.empty() ? std::string("vertical") : d.selectedType);
+		}
+		if (m_wallVisualPanel) {
+			m_wallVisualPanel->SetWallItems(m_wallTypes);
+		}
+		UpdateWallItemsList();
 
-        m_isRestoringDraft = false;
-        return true;
-    }
+		m_isRestoringDraft = false;
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 void BorderEditorPanel::DiscardDraft(int tab, uint16_t tileId) {
-    if (tileId == 0) {
-        return;
-    }
+	if (tileId == 0) {
+		return;
+	}
 
-    switch (tab) {
-        case 0: m_borderDrafts.erase(tileId); break;
-        case 1: m_groundDrafts.erase(tileId); break;
-        case 2: m_wallDrafts.erase(tileId); break;
-        default: break;
-    }
+	switch (tab) {
+		case 0:
+			m_borderDrafts.erase(tileId);
+			break;
+		case 1:
+			m_groundDrafts.erase(tileId);
+			break;
+		case 2:
+			m_wallDrafts.erase(tileId);
+			break;
+		default:
+			break;
+	}
 }
 
 void BorderEditorPanel::SaveCurrentDraft(bool markDirty) {
-    if (m_selectedBrowserTileId == 0) {
-        return;
-    }
+	if (m_selectedBrowserTileId == 0) {
+		return;
+	}
 
-    SaveDraft(m_activeTab, m_selectedBrowserTileId, markDirty);
+	SaveDraft(m_activeTab, m_selectedBrowserTileId, markDirty);
 }
 
 void BorderEditorPanel::DiscardCurrentDraft() {
-    if (m_selectedBrowserTileId == 0) {
-        return;
-    }
+	if (m_selectedBrowserTileId == 0) {
+		return;
+	}
 
-    DiscardDraft(m_activeTab, m_selectedBrowserTileId);
+	DiscardDraft(m_activeTab, m_selectedBrowserTileId);
 }
 
-void BorderEditorPanel::OnBorderDraftChange(wxCommandEvent& event) {
-    SaveCurrentDraft(true);
-    event.Skip();
+void BorderEditorPanel::OnBorderDraftChange(wxCommandEvent &event) {
+	SaveCurrentDraft(true);
+	event.Skip();
 }
 
-void BorderEditorPanel::OnGroundDraftChange(wxCommandEvent& event) {
-    SaveCurrentDraft(true);
-    event.Skip();
+void BorderEditorPanel::OnGroundDraftChange(wxCommandEvent &event) {
+	SaveCurrentDraft(true);
+	event.Skip();
 }
 
-void BorderEditorPanel::OnWallDraftChange(wxCommandEvent& event) {
-    SaveCurrentDraft(true);
-    event.Skip();
+void BorderEditorPanel::OnWallDraftChange(wxCommandEvent &event) {
+	SaveCurrentDraft(true);
+	event.Skip();
 }
 
 void BorderEditorPanel::CreateGUIControls() {
-    wxBoxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
-    
-    
-    // Create simplebook (no visible tabs - switching via sidebar buttons)
-    m_notebook = new wxSimplebook(this, wxID_ANY);
-    
-    // ========== BORDER TAB ==========
-    m_borderPanel = new wxPanel(m_notebook);
-    wxBoxSizer* borderSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // --- Top Toolbar: Name + Checkboxes (Merged) ---
-    wxBoxSizer* toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // Checkboxes (Right side of toolbar)
-    m_groupCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Group");
-    m_groupCheck->SetToolTip("Check to assign this border to a group");
-    m_groupCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
-    toolbarSizer->Add(m_groupCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-    
-    m_isOptionalCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Optional");
-    m_isOptionalCheck->SetToolTip("Marks this border as optional");
-    m_isOptionalCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
-    toolbarSizer->Add(m_isOptionalCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-    
-    m_isGroundCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Ground");
-    m_isGroundCheck->SetToolTip("Marks this border as a ground border");
-    m_isGroundCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
-    toolbarSizer->Add(m_isGroundCheck, 0, wxALIGN_CENTER_VERTICAL);
-    
-    borderSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 5);
-    
-    // --- Main Content: Palette (Left) + Editor/Preview (Right) ---
-    wxBoxSizer* borderContentSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // === Left Column: Raw Item Palette (takes full height) ===
-    wxBoxSizer* leftColumnSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Raw Item Palette - shows all raw items for selection    // Raw Item Palette - shows all raw items for selection
-    // Category Selector Row (ComboBox + Filter Button)
-    wxBoxSizer* borderTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    wxArrayString categories;
-    for (const auto& pair : g_materials.tilesets) {
-        categories.Add(wxstr(pair.first));
-    }
-    m_rawCategoryNames = categories; // Store for menu
-    m_rawCategoryButton = new wxButton(m_borderPanel, wxID_ANY, "Category ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
-    m_rawCategoryButton->SetToolTip("Filter by Tileset Category");
-    m_rawCategoryButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnRawCategoryButtonClick, this);
-    borderTilesetRowSizer->Add(m_rawCategoryButton, 1, wxEXPAND | wxRIGHT, 2);
-    
-    // Filter button with Cut icon (scissors)
-    wxBitmapButton* borderFilterBtn = new wxBitmapButton(m_borderPanel, wxID_ANY, 
-        wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
-    borderFilterBtn->SetToolTip("Filter visible tilesets");
-    borderFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
-    borderTilesetRowSizer->Add(borderFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
-    
-    leftColumnSizer->Add(borderTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
-    
-    m_itemPalettePanel = new SimpleRawPalettePanel(m_borderPanel);
-    // m_itemPalettePanel->SetListType(BRUSHLIST_LARGE_ICONS);
-    m_itemPalettePanel->SetMinSize(wxSize(220, 300));
-    leftColumnSizer->Add(m_itemPalettePanel, 1, wxEXPAND | wxALL, 5);
-    
-    borderContentSizer->Add(leftColumnSizer, 0, wxEXPAND);
-    
-    // === Right Column: Editor + Preview ===
-    wxBoxSizer* rightColumnSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Editor inside StaticBoxSizer
-    wxStaticBoxSizer* editorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Editor");
-    m_gridPanel = new BorderGridPanel(editorBoxSizer->GetStaticBox());
-    editorBoxSizer->Add(m_gridPanel, 0, wxALIGN_CENTER | wxALL, 5);
-    rightColumnSizer->Add(editorBoxSizer, 0, wxEXPAND | wxALL, 5);
-    
-    // Preview inside StaticBoxSizer
-    wxStaticBoxSizer* previewBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Preview");
-    m_previewPanel = new BorderPreviewPanel(previewBoxSizer->GetStaticBox());
-    m_previewPanel->SetMinSize(wxSize(200, 200));
-    previewBoxSizer->Add(m_previewPanel, 1, wxEXPAND | wxALL, 5);
-    rightColumnSizer->Add(previewBoxSizer, 1, wxEXPAND | wxALL, 5);
-    
-    borderContentSizer->Add(rightColumnSizer, 1, wxEXPAND | wxLEFT, 5);
-    
-    // Add main content to border sizer (takes most vertical space)
-    borderSizer->Add(borderContentSizer, 1, wxEXPAND | wxALL, 5);
-    
-    // --- Bottom Action Bar ---
-    wxBoxSizer* borderButtonSizer = new wxBoxSizer(wxHORIZONTAL);
-    borderButtonSizer->AddStretchSpacer(1);
-    
-    m_newButton = new wxButton(m_borderPanel, wxID_CLEAR, "New Border");
-    m_newButton->SetToolTip("Start creating a new border (clears current form)");
-    borderButtonSizer->Add(m_newButton, 0, wxRIGHT, 5);
-    
-    borderButtonSizer->Add(new wxButton(m_borderPanel, wxID_SAVE, "Save Changes"), 0, wxRIGHT, 5);
-    borderButtonSizer->Add(new wxButton(m_borderPanel, wxID_CLOSE, "Close"), 0);
-    
-    borderSizer->Add(borderButtonSizer, 0, wxEXPAND | wxALL, 5);
-    
-    m_borderPanel->SetSizer(borderSizer);
-    
-    // ========== GROUND TAB ==========
-    m_groundPanel = new wxPanel(m_notebook);
-    wxBoxSizer* groundSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // === Left Column: Form Controls ===
-    wxBoxSizer* groundLeftSizer = new wxBoxSizer(wxVERTICAL);
-    
-    wxBoxSizer* row1 = new wxBoxSizer(wxHORIZONTAL);
-    row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_groundNameCtrl = new wxTextCtrl(m_groundPanel, wxID_ANY, "");
-    m_groundNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnGroundDraftChange, this);
-    row1->Add(m_groundNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-    groundLeftSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 5);
+	wxBoxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
 
-    wxBoxSizer* row2 = new wxBoxSizer(wxHORIZONTAL);
-    row2->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Z-Order:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_zOrderCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(60, -1));
-    m_zOrderCtrl->SetRange(-100, 100);
-    m_zOrderCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnGroundDraftChange, this);
-    row2->Add(m_zOrderCtrl, 0);
-    groundLeftSizer->Add(row2, 0, wxEXPAND | wxBOTTOM, 5);
-    
-    // Item Palette / Selection
-    wxBoxSizer* row3 = new wxBoxSizer(wxHORIZONTAL);
-    // Chance control removed
-    groundLeftSizer->Add(row3, 0, wxEXPAND | wxBOTTOM, 5);
+	// Create simplebook (no visible tabs - switching via sidebar buttons)
+	m_notebook = new wxSimplebook(this, wxID_ANY);
 
-    // Preview Panel moved to right column
-    wxBoxSizer* tilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
-    tilesetRowSizer->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    
-    // --- Main Body: Palette (Left) + Editor (Right) ---
-    wxBoxSizer* groundContentSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // === Left Column: Raw Item Palette ===
-    // Tileset selector row (ComboBox + Gear button)
-    
-    m_groundTilesetButton = new wxButton(m_groundPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
-    m_groundTilesetButton->SetToolTip("Select Tileset");
-    m_groundTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnGroundTilesetButtonClick, this);
-    tilesetRowSizer->Add(m_groundTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
-    
-    // Filter button with Cut icon (scissors)
-    m_tilesetFilterBtn = new wxBitmapButton(m_groundPanel, wxID_ANY, 
-        wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
-    m_tilesetFilterBtn->SetToolTip("Filter visible tilesets");
-    m_tilesetFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
-    tilesetRowSizer->Add(m_tilesetFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
-    
-    groundLeftSizer->Add(tilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+	// ========== BORDER TAB ==========
+	m_borderPanel = new wxPanel(m_notebook);
+	wxBoxSizer* borderSizer = new wxBoxSizer(wxVERTICAL);
 
-    m_groundPalette = new SimpleRawPalettePanel(m_groundPanel);
-    m_groundPalette->SetMinSize(wxSize(220, 200));
-    m_groundPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundPaletteSelect, this);
-    groundLeftSizer->Add(m_groundPalette, 1, wxEXPAND | wxALL, 5);
-    groundContentSizer->Add(groundLeftSizer, 0, wxEXPAND);
-    
-    // === Right Column: Editor Controls (Scrollable List) ===
-    // === Right Column: Editor Controls (Scrollable List) ===
-    wxBoxSizer* groundRightSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Preview (Directly in sizer for seamless look)
-    m_groundPreviewPanel = new GroundPreviewPanel(m_groundPanel, wxID_ANY);
-    // m_groundPreviewPanel size is set in constructor (96x96)
-    groundRightSizer->Add(m_groundPreviewPanel, 0, wxALIGN_CENTER | wxALL, 10);
+	// --- Top Toolbar: Name + Checkboxes (Merged) ---
+	wxBoxSizer* toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
 
-    wxStaticBoxSizer* groundEditorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Variations");
-    
-    m_groundGridContainer = new GroundGridContainer(groundEditorBoxSizer->GetStaticBox(), wxID_ANY + 1); // Added ID
-    m_groundGridContainer->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundGridSelect, this);
-    // Bind change event to update preview
-    Bind(wxEVT_GROUND_CONTAINER_CHANGE, &BorderEditorPanel::OnGroundContainerChange, this);
-    
-    groundEditorBoxSizer->Add(m_groundGridContainer, 1, wxEXPAND | wxALL, 5);
+	// Checkboxes (Right side of toolbar)
+	m_groupCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Group");
+	m_groupCheck->SetToolTip("Check to assign this border to a group");
+	m_groupCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
+	toolbarSizer->Add(m_groupCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
 
-    wxBoxSizer* addVarSizer = new wxBoxSizer(wxHORIZONTAL);
-    addVarSizer->AddStretchSpacer(1);
-    m_addVariationBtn = new wxButton(groundEditorBoxSizer->GetStaticBox(), wxID_ANY, "Add Variation");
-    m_addVariationBtn->SetToolTip("Add a new empty variation at the end");
-    m_addVariationBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnAddVariation, this);
-    addVarSizer->Add(m_addVariationBtn, 0);
-    groundEditorBoxSizer->Add(addVarSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
-    
-    groundRightSizer->Add(groundEditorBoxSizer, 1, wxEXPAND | wxALL, 5);
-    
-    // Border Options inside StaticBox
-    wxStaticBoxSizer* borderOptionsBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Border Options");
-    
-    wxBoxSizer* borderOptionsRow = new wxBoxSizer(wxHORIZONTAL);
-    
-    borderOptionsRow->Add(new wxStaticText(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Alignment:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    m_borderAlignmentButton = new wxButton(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Outer ▼", wxDefaultPosition, wxSize(80, -1), wxBU_LEFT);
-    m_borderAlignmentButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBorderAlignmentButtonClick, this);
-    borderOptionsRow->Add(m_borderAlignmentButton, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
-    
-    m_includeToNoneCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "To None");
-    m_includeToNoneCheck->SetValue(true);
-    m_includeToNoneCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnGroundDraftChange, this);
-    borderOptionsRow->Add(m_includeToNoneCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
-    
-    m_includeInnerCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Inner Border");
-    m_includeInnerCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnGroundDraftChange, this);
-    borderOptionsRow->Add(m_includeInnerCheck, 0, wxALIGN_CENTER_VERTICAL);
-    
-    borderOptionsBoxSizer->Add(borderOptionsRow, 0, wxEXPAND | wxALL, 5);
-    groundRightSizer->Add(borderOptionsBoxSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
-    
-    groundContentSizer->Add(groundRightSizer, 1, wxEXPAND | wxLEFT, 5);
-    groundSizer->Add(groundContentSizer, 1, wxEXPAND | wxALL, 5);
-    
-    // --- Footer: Right-aligned buttons ---
-    wxBoxSizer* groundButtonSizer = new wxBoxSizer(wxHORIZONTAL);
-    groundButtonSizer->AddStretchSpacer(1);
-    
-    wxButton* groundNewButton = new wxButton(m_groundPanel, wxID_CLEAR, "New Ground");
-    groundNewButton->SetToolTip("Start creating a new ground brush (clears current form)");
-    groundButtonSizer->Add(groundNewButton, 0, wxRIGHT, 5);
-    
-    groundButtonSizer->Add(new wxButton(m_groundPanel, wxID_SAVE, "Save Changes"), 0, wxRIGHT, 5);
-    groundButtonSizer->Add(new wxButton(m_groundPanel, wxID_CLOSE, "Close"), 0);
-    
-    groundSizer->Add(groundButtonSizer, 0, wxEXPAND | wxALL, 5);
-    
-    m_groundPanel->SetSizer(groundSizer);
-    
-    // Add pages to simplebook (no visible tabs)
-    m_notebook->AddPage(m_borderPanel, "Border");
-    m_notebook->AddPage(m_groundPanel, "Ground");
-    
-    // Notebook pages "Border Loop" and "Ground Brush" removed as they were duplicate pointers
+	m_isOptionalCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Optional");
+	m_isOptionalCheck->SetToolTip("Marks this border as optional");
+	m_isOptionalCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
+	toolbarSizer->Add(m_isOptionalCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
 
-    // ========== WALL TAB ==========
-    m_wallPanel = new wxPanel(m_notebook);
-    wxBoxSizer* wallSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // --- Main Body: Palette (Left) + Editor (Right) ---
-    wxBoxSizer* wallContentSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // === Left Column: Raw Item Palette ===
-    // === Left Column: Raw Item Palette ===
-    wxBoxSizer* wallLeftSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Tileset selector row (ComboBox + Filter button)
-    wxBoxSizer* wallTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
-    wallTilesetRowSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    
-    m_wallTilesetButton = new wxButton(m_wallPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
-    m_wallTilesetButton->SetToolTip("Select Tileset");
-    m_wallTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnWallTilesetButtonClick, this);
-    wallTilesetRowSizer->Add(m_wallTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
-    
-    // Filter button
-    wxBitmapButton* wallFilterBtn = new wxBitmapButton(m_wallPanel, wxID_ANY, 
-        wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
-    wallFilterBtn->SetToolTip("Filter visible tilesets");
-    wallFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
-    wallTilesetRowSizer->Add(wallFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
-    
-    wallLeftSizer->Add(wallTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+	m_isGroundCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Ground");
+	m_isGroundCheck->SetToolTip("Marks this border as a ground border");
+	m_isGroundCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnBorderDraftChange, this);
+	toolbarSizer->Add(m_isGroundCheck, 0, wxALIGN_CENTER_VERTICAL);
 
-    m_wallPalette = new SimpleRawPalettePanel(m_wallPanel);
-    m_wallPalette->SetMinSize(wxSize(220, 300));
-    m_wallPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnWallPaletteSelect, this);
-    wallLeftSizer->Add(m_wallPalette, 1, wxEXPAND | wxALL, 5);
-    
-    wallContentSizer->Add(wallLeftSizer, 0, wxEXPAND);
-    
-    // === Right Column: Editor Controls ===
-    wxBoxSizer* wallRightSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Wall Structure inside StaticBox
-    wxStaticBoxSizer* structureSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Wall Structure");
-    
-    // Logic Type Selector (Visual Grid)
-    wxBoxSizer* wallTypeSizer = new wxBoxSizer(wxVERTICAL);
-    // wallTypeSizer->Add(new wxStaticText(structureSizer->GetStaticBox(), wxID_ANY, "Select Type to Edit:"), 0, wxALIGN_LEFT | wxBOTTOM, 5); // Removed to save space
-    
-    m_wallGridPanel = new WallGridPanel(structureSizer->GetStaticBox(), wxID_ANY);
-    m_wallGridPanel->SetMinSize(wxSize(280, 200)); // Increased height for 3x3 grid
-    
-    // Bind click event (reusing BUTTON_CLICKED)
-    m_wallGridPanel->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &BorderEditorPanel::OnWallGridSelect, this);
-    
-    wallTypeSizer->Add(m_wallGridPanel, 0, wxEXPAND | wxBOTTOM, 5);
-    structureSizer->Add(wallTypeSizer, 0, wxEXPAND | wxALL, 5);
-    
-    // List of items for this type (REMOVED per user request)
-    // m_wallItemsList = new wxListBox(structureSizer->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(-1, 80));
-    // structureSizer->Add(m_wallItemsList, 1, wxEXPAND | wxLEFT | wxRIGHT, 5);
-    m_wallItemsList = nullptr;
-    
-    // Add Item Controls row (REMOVED per user request)
-    // wxBoxSizer* wallItemInputSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // wallItemInputSizer->Add(new wxStaticText(structureSizer->GetStaticBox(), wxID_ANY, "Item ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
-    // m_wallItemIdCtrl = new wxSpinCtrl(structureSizer->GetStaticBox(), wxID_ANY, "0", wxDefaultPosition, wxSize(70, -1), wxSP_ARROW_KEYS, 0, 65535);
-    // wallItemInputSizer->Add(m_wallItemIdCtrl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
-    m_wallItemIdCtrl = nullptr;
-    
-    // wxButton* addWallItemBtn = new wxButton(structureSizer->GetStaticBox(), wxID_ANY, "Add", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
-    // addWallItemBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnAddWallItem, this);
-    // wallItemInputSizer->Add(addWallItemBtn, 0, wxRIGHT, 5);
-    
-    // wxButton* remWallItemBtn = new wxButton(structureSizer->GetStaticBox(), wxID_ANY, "Remove", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
-    // remWallItemBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnRemoveWallItem, this);
-    // wallItemInputSizer->Add(remWallItemBtn, 0);
-    
-    // structureSizer->Add(wallItemInputSizer, 0, wxEXPAND | wxALL, 5);
-    wallRightSizer->Add(structureSizer, 1, wxEXPAND | wxALL, 5);
-    
-    // Preview inside StaticBox
-    wxStaticBoxSizer* wallVisualSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Preview");
-    m_wallVisualPanel = new WallVisualPanel(wallVisualSizer->GetStaticBox());
-    m_wallVisualPanel->SetMinSize(wxSize(150, 150));
-    wallVisualSizer->Add(m_wallVisualPanel, 1, wxEXPAND | wxALL, 5);
-    wallRightSizer->Add(wallVisualSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
-    
-    wallContentSizer->Add(wallRightSizer, 1, wxEXPAND | wxLEFT, 5);
-    wallSizer->Add(wallContentSizer, 1, wxEXPAND | wxALL, 5);
-    
-    // --- Footer: Right-aligned buttons ---
-    wxBoxSizer* wallButtonSizer = new wxBoxSizer(wxHORIZONTAL);
-    wallButtonSizer->AddStretchSpacer(1);
-    
-    wxButton* wallNewButton = new wxButton(m_wallPanel, wxID_ANY, "New Wall");
-    wallNewButton->SetToolTip("Start creating a new wall brush (clears current form)");
-    wallNewButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent& ev) { 
-        DiscardCurrentDraft();
-        ClearWallItems();
-        if (m_groundNameCtrl) m_groundNameCtrl->SetValue("");
-        if (m_borderBrowserList) m_borderBrowserList->SetSelection(wxNOT_FOUND);
-    });
-    wallButtonSizer->Add(wallNewButton, 0, wxRIGHT, 5);
-    
-    wxButton* saveWallButton = new wxButton(m_wallPanel, wxID_ANY, "Save Changes");
-    saveWallButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent& ev) { SaveWallBrush(); });
-    wallButtonSizer->Add(saveWallButton, 0, wxRIGHT, 5);
-    wallButtonSizer->Add(new wxButton(m_wallPanel, wxID_CLOSE, "Close"), 0);
-    
-    wallSizer->Add(wallButtonSizer, 0, wxEXPAND | wxALL, 5);
-    
-    m_wallPanel->SetSizer(wallSizer);
-    m_notebook->AddPage(m_wallPanel, "Wall");
-    
-    // ========== HORIZONTAL LAYOUT: Content (Left) + Browser (Right) ==========
-    wxBoxSizer* mainHorizSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    // LEFT: Add notebook (existing content)
-    mainHorizSizer->Add(m_notebook, 1, wxEXPAND | wxALL, 5);
-    
-    // RIGHT: Browser Sidebar
-    wxBoxSizer* browserSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Mode Switcher Buttons (replaces m_browserLabel)
-    wxBoxSizer* modeSwitcherSizer = new wxBoxSizer(wxHORIZONTAL);
-    
-    m_groundModeBtn = new wxToggleButton(this, wxID_ANY, "Variation", wxDefaultPosition, wxDefaultSize);
-    m_groundModeBtn->SetValue(true); // Default to Ground mode
-    m_groundModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
-    modeSwitcherSizer->Add(m_groundModeBtn, 1, wxEXPAND | wxRIGHT, 2);
-    
-    m_wallModeBtn = new wxToggleButton(this, wxID_ANY, "Structure", wxDefaultPosition, wxDefaultSize);
-    m_wallModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
-    modeSwitcherSizer->Add(m_wallModeBtn, 1, wxEXPAND | wxRIGHT, 2);
-    
-    m_borderModeBtn = new wxToggleButton(this, wxID_ANY, "Border", wxDefaultPosition, wxDefaultSize);
-    m_borderModeBtn->SetValue(false);
-    m_borderModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
-    modeSwitcherSizer->Add(m_borderModeBtn, 1, wxEXPAND);
-    
-    browserSizer->Add(modeSwitcherSizer, 0, wxEXPAND | wxALL, 5);
+	borderSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 5);
 
-    m_browserTilesetFilterButton = new wxButton(this, wxID_ANY, "Tileset: Select ▼", wxDefaultPosition, wxSize(280, -1), wxBU_LEFT);
-    m_browserTilesetFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserTilesetFilterButtonClick, this);
-    browserSizer->Add(m_browserTilesetFilterButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
-    
-    // Search control
-    m_browserSearchCtrl = new wxSearchCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(280, -1));
-    m_browserSearchCtrl->SetDescriptiveText("Search...");
-    m_browserSearchCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &BorderEditorPanel::OnBrowserSearch, this);
-    m_browserSearchCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnBrowserSearch, this);
-    browserSizer->Add(m_browserSearchCtrl, 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
-    
-    m_borderBrowserList = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxSize(280, -1), 0, nullptr, wxLB_SINGLE | wxBORDER_NONE);
-    m_borderBrowserList->Hide();
-    m_borderBrowserList->Bind(wxEVT_LISTBOX, &BorderEditorPanel::OnBorderBrowserSelection, this);
+	// --- Main Content: Palette (Left) + Editor/Preview (Right) ---
+	wxBoxSizer* borderContentSizer = new wxBoxSizer(wxHORIZONTAL);
 
-    m_browserGrid = new BrushBrowserGridPanel(this, wxID_ANY);
-    m_browserGrid->SetToolTip("Click an item to load it for editing");
-    Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnBrowserGridSelection, this, m_browserGrid->GetId());
-    browserSizer->Add(m_browserGrid, 1, wxEXPAND | wxALL, 5);
-    
-    mainHorizSizer->Add(browserSizer, 0, wxEXPAND);
-    
-    // Add horizontal layout to top sizer
-    topSizer->Add(mainHorizSizer, 1, wxEXPAND);
-    
-    SetSizer(topSizer);
-    Layout();
-    
-    // Initialize Category Combo (Select Borders if available)
-    // Initialize Category Button (Select Borders if available)
-    if (!m_rawCategoryNames.IsEmpty()) {
-        int defaults = m_rawCategoryNames.Index("Borders");
-        if (defaults != wxNOT_FOUND) {
-            m_rawCategorySelection = defaults;
-        } else {
-            m_rawCategorySelection = 0;
-        }
-        
-        if (m_rawCategoryButton) {
-            m_rawCategoryButton->SetLabel(m_rawCategoryNames[m_rawCategorySelection] + " \u25BC");
-        }
-        
-        // Trigger load
-        if (m_itemPalettePanel) {
-            m_itemPalettePanel->LoadTileset(m_rawCategoryNames[m_rawCategorySelection]);
-        }
-    }
+	// === Left Column: Raw Item Palette (takes full height) ===
+	wxBoxSizer* leftColumnSizer = new wxBoxSizer(wxVERTICAL);
 
-    // Initialize Tileset Choice (Ground Tab)
-    LoadTilesets(); // Ensure m_tilesetListData is populated
-    
-    // Select first tileset if any
-    if (!m_tilesetListData.IsEmpty()) {
-        m_groundTilesetSelection = 0;
-        if (m_groundTilesetButton) {
-            m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
-        }
-        
-        // Trigger load for ground
-        if (m_groundPalette) {
-             m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
-        }
-    }
+	// Raw Item Palette - shows all raw items for selection    // Raw Item Palette - shows all raw items for selection
+	// Category Selector Row (ComboBox + Filter Button)
+	wxBoxSizer* borderTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
 
-    {
-        const auto options = GetBrowserTilesetOptions();
-        if (!options.empty() && m_browserTilesetFilter.IsEmpty()) {
-            m_browserTilesetFilter = options.front().second;
-            if (m_browserTilesetFilterButton) {
-                m_browserTilesetFilterButton->SetLabel("Tileset: " + options.front().first + " ▼");
-            }
-        }
-    }
+	wxArrayString categories;
+	for (const auto &pair : g_materials.tilesets) {
+		categories.Add(wxstr(pair.first));
+	}
+	m_rawCategoryNames = categories; // Store for menu
+	m_rawCategoryButton = new wxButton(m_borderPanel, wxID_ANY, "Category ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+	m_rawCategoryButton->SetToolTip("Filter by Tileset Category");
+	m_rawCategoryButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnRawCategoryButtonClick, this);
+	borderTilesetRowSizer->Add(m_rawCategoryButton, 1, wxEXPAND | wxRIGHT, 2);
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	// Filter button with Cut icon (scissors)
+	wxBitmapButton* borderFilterBtn = new wxBitmapButton(m_borderPanel, wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+	borderFilterBtn->SetToolTip("Filter visible tilesets");
+	borderFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
+	borderTilesetRowSizer->Add(borderFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
+
+	leftColumnSizer->Add(borderTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+
+	m_itemPalettePanel = new SimpleRawPalettePanel(m_borderPanel);
+	// m_itemPalettePanel->SetListType(BRUSHLIST_LARGE_ICONS);
+	m_itemPalettePanel->SetMinSize(wxSize(220, 300));
+	leftColumnSizer->Add(m_itemPalettePanel, 1, wxEXPAND | wxALL, 5);
+
+	borderContentSizer->Add(leftColumnSizer, 0, wxEXPAND);
+
+	// === Right Column: Editor + Preview ===
+	wxBoxSizer* rightColumnSizer = new wxBoxSizer(wxVERTICAL);
+
+	// Editor inside StaticBoxSizer
+	wxStaticBoxSizer* editorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Editor");
+	m_gridPanel = new BorderGridPanel(editorBoxSizer->GetStaticBox());
+	editorBoxSizer->Add(m_gridPanel, 0, wxALIGN_CENTER | wxALL, 5);
+	rightColumnSizer->Add(editorBoxSizer, 0, wxEXPAND | wxALL, 5);
+
+	// Preview inside StaticBoxSizer
+	wxStaticBoxSizer* previewBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Preview");
+	m_previewPanel = new BorderPreviewPanel(previewBoxSizer->GetStaticBox());
+	m_previewPanel->SetMinSize(wxSize(200, 200));
+	previewBoxSizer->Add(m_previewPanel, 1, wxEXPAND | wxALL, 5);
+	rightColumnSizer->Add(previewBoxSizer, 1, wxEXPAND | wxALL, 5);
+
+	borderContentSizer->Add(rightColumnSizer, 1, wxEXPAND | wxLEFT, 5);
+
+	// Add main content to border sizer (takes most vertical space)
+	borderSizer->Add(borderContentSizer, 1, wxEXPAND | wxALL, 5);
+
+	// --- Bottom Action Bar ---
+	wxBoxSizer* borderButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+	borderButtonSizer->AddStretchSpacer(1);
+
+	m_newButton = new wxButton(m_borderPanel, wxID_CLEAR, "New Border");
+	m_newButton->SetToolTip("Start creating a new border (clears current form)");
+	borderButtonSizer->Add(m_newButton, 0, wxRIGHT, 5);
+
+	borderButtonSizer->Add(new wxButton(m_borderPanel, wxID_SAVE, "Save Changes"), 0, wxRIGHT, 5);
+	borderButtonSizer->Add(new wxButton(m_borderPanel, wxID_CLOSE, "Close"), 0);
+
+	borderSizer->Add(borderButtonSizer, 0, wxEXPAND | wxALL, 5);
+
+	m_borderPanel->SetSizer(borderSizer);
+
+	// ========== GROUND TAB ==========
+	m_groundPanel = new wxPanel(m_notebook);
+	wxBoxSizer* groundSizer = new wxBoxSizer(wxVERTICAL);
+
+	// === Left Column: Form Controls ===
+	wxBoxSizer* groundLeftSizer = new wxBoxSizer(wxVERTICAL);
+
+	wxBoxSizer* row1 = new wxBoxSizer(wxHORIZONTAL);
+	row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	m_groundNameCtrl = new wxTextCtrl(m_groundPanel, wxID_ANY, "");
+	m_groundNameCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnGroundDraftChange, this);
+	row1->Add(m_groundNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+	groundLeftSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 5);
+
+	wxBoxSizer* row2 = new wxBoxSizer(wxHORIZONTAL);
+	row2->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Z-Order:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	m_zOrderCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(60, -1));
+	m_zOrderCtrl->SetRange(-100, 100);
+	m_zOrderCtrl->Bind(wxEVT_SPINCTRL, &BorderEditorPanel::OnGroundDraftChange, this);
+	row2->Add(m_zOrderCtrl, 0);
+	groundLeftSizer->Add(row2, 0, wxEXPAND | wxBOTTOM, 5);
+
+	// Item Palette / Selection
+	wxBoxSizer* row3 = new wxBoxSizer(wxHORIZONTAL);
+	// Chance control removed
+	groundLeftSizer->Add(row3, 0, wxEXPAND | wxBOTTOM, 5);
+
+	// Preview Panel moved to right column
+	wxBoxSizer* tilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
+	tilesetRowSizer->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+
+	// --- Main Body: Palette (Left) + Editor (Right) ---
+	wxBoxSizer* groundContentSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	// === Left Column: Raw Item Palette ===
+	// Tileset selector row (ComboBox + Gear button)
+
+	m_groundTilesetButton = new wxButton(m_groundPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+	m_groundTilesetButton->SetToolTip("Select Tileset");
+	m_groundTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnGroundTilesetButtonClick, this);
+	tilesetRowSizer->Add(m_groundTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
+
+	// Filter button with Cut icon (scissors)
+	m_tilesetFilterBtn = new wxBitmapButton(m_groundPanel, wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+	m_tilesetFilterBtn->SetToolTip("Filter visible tilesets");
+	m_tilesetFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
+	tilesetRowSizer->Add(m_tilesetFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
+
+	groundLeftSizer->Add(tilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+
+	m_groundPalette = new SimpleRawPalettePanel(m_groundPanel);
+	m_groundPalette->SetMinSize(wxSize(220, 200));
+	m_groundPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundPaletteSelect, this);
+	groundLeftSizer->Add(m_groundPalette, 1, wxEXPAND | wxALL, 5);
+	groundContentSizer->Add(groundLeftSizer, 0, wxEXPAND);
+
+	// === Right Column: Editor Controls (Scrollable List) ===
+	// === Right Column: Editor Controls (Scrollable List) ===
+	wxBoxSizer* groundRightSizer = new wxBoxSizer(wxVERTICAL);
+
+	// Preview (Directly in sizer for seamless look)
+	m_groundPreviewPanel = new GroundPreviewPanel(m_groundPanel, wxID_ANY);
+	// m_groundPreviewPanel size is set in constructor (96x96)
+	groundRightSizer->Add(m_groundPreviewPanel, 0, wxALIGN_CENTER | wxALL, 10);
+
+	wxStaticBoxSizer* groundEditorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Variations");
+
+	m_groundGridContainer = new GroundGridContainer(groundEditorBoxSizer->GetStaticBox(), wxID_ANY + 1); // Added ID
+	m_groundGridContainer->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundGridSelect, this);
+	// Bind change event to update preview
+	Bind(wxEVT_GROUND_CONTAINER_CHANGE, &BorderEditorPanel::OnGroundContainerChange, this);
+
+	groundEditorBoxSizer->Add(m_groundGridContainer, 1, wxEXPAND | wxALL, 5);
+
+	wxBoxSizer* addVarSizer = new wxBoxSizer(wxHORIZONTAL);
+	addVarSizer->AddStretchSpacer(1);
+	m_addVariationBtn = new wxButton(groundEditorBoxSizer->GetStaticBox(), wxID_ANY, "Add Variation");
+	m_addVariationBtn->SetToolTip("Add a new empty variation at the end");
+	m_addVariationBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnAddVariation, this);
+	addVarSizer->Add(m_addVariationBtn, 0);
+	groundEditorBoxSizer->Add(addVarSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	groundRightSizer->Add(groundEditorBoxSizer, 1, wxEXPAND | wxALL, 5);
+
+	// Border Options inside StaticBox
+	wxStaticBoxSizer* borderOptionsBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Border Options");
+
+	wxBoxSizer* borderOptionsRow = new wxBoxSizer(wxHORIZONTAL);
+
+	borderOptionsRow->Add(new wxStaticText(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Alignment:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	m_borderAlignmentButton = new wxButton(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Outer ▼", wxDefaultPosition, wxSize(80, -1), wxBU_LEFT);
+	m_borderAlignmentButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBorderAlignmentButtonClick, this);
+	borderOptionsRow->Add(m_borderAlignmentButton, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+
+	m_includeToNoneCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "To None");
+	m_includeToNoneCheck->SetValue(true);
+	m_includeToNoneCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnGroundDraftChange, this);
+	borderOptionsRow->Add(m_includeToNoneCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
+
+	m_includeInnerCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Inner Border");
+	m_includeInnerCheck->Bind(wxEVT_CHECKBOX, &BorderEditorPanel::OnGroundDraftChange, this);
+	borderOptionsRow->Add(m_includeInnerCheck, 0, wxALIGN_CENTER_VERTICAL);
+
+	borderOptionsBoxSizer->Add(borderOptionsRow, 0, wxEXPAND | wxALL, 5);
+	groundRightSizer->Add(borderOptionsBoxSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	groundContentSizer->Add(groundRightSizer, 1, wxEXPAND | wxLEFT, 5);
+	groundSizer->Add(groundContentSizer, 1, wxEXPAND | wxALL, 5);
+
+	// --- Footer: Right-aligned buttons ---
+	wxBoxSizer* groundButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+	groundButtonSizer->AddStretchSpacer(1);
+
+	wxButton* groundNewButton = new wxButton(m_groundPanel, wxID_CLEAR, "New Ground");
+	groundNewButton->SetToolTip("Start creating a new ground brush (clears current form)");
+	groundButtonSizer->Add(groundNewButton, 0, wxRIGHT, 5);
+
+	groundButtonSizer->Add(new wxButton(m_groundPanel, wxID_SAVE, "Save Changes"), 0, wxRIGHT, 5);
+	groundButtonSizer->Add(new wxButton(m_groundPanel, wxID_CLOSE, "Close"), 0);
+
+	groundSizer->Add(groundButtonSizer, 0, wxEXPAND | wxALL, 5);
+
+	m_groundPanel->SetSizer(groundSizer);
+
+	// Add pages to simplebook (no visible tabs)
+	m_notebook->AddPage(m_borderPanel, "Border");
+	m_notebook->AddPage(m_groundPanel, "Ground");
+
+	// Notebook pages "Border Loop" and "Ground Brush" removed as they were duplicate pointers
+
+	// ========== WALL TAB ==========
+	m_wallPanel = new wxPanel(m_notebook);
+	wxBoxSizer* wallSizer = new wxBoxSizer(wxVERTICAL);
+
+	// --- Main Body: Palette (Left) + Editor (Right) ---
+	wxBoxSizer* wallContentSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	// === Left Column: Raw Item Palette ===
+	// === Left Column: Raw Item Palette ===
+	wxBoxSizer* wallLeftSizer = new wxBoxSizer(wxVERTICAL);
+
+	// Tileset selector row (ComboBox + Filter button)
+	wxBoxSizer* wallTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
+	wallTilesetRowSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+
+	m_wallTilesetButton = new wxButton(m_wallPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+	m_wallTilesetButton->SetToolTip("Select Tileset");
+	m_wallTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnWallTilesetButtonClick, this);
+	wallTilesetRowSizer->Add(m_wallTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
+
+	// Filter button
+	wxBitmapButton* wallFilterBtn = new wxBitmapButton(m_wallPanel, wxID_ANY, wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+	wallFilterBtn->SetToolTip("Filter visible tilesets");
+	wallFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
+	wallTilesetRowSizer->Add(wallFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
+
+	wallLeftSizer->Add(wallTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+
+	m_wallPalette = new SimpleRawPalettePanel(m_wallPanel);
+	m_wallPalette->SetMinSize(wxSize(220, 300));
+	m_wallPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnWallPaletteSelect, this);
+	wallLeftSizer->Add(m_wallPalette, 1, wxEXPAND | wxALL, 5);
+
+	wallContentSizer->Add(wallLeftSizer, 0, wxEXPAND);
+
+	// === Right Column: Editor Controls ===
+	wxBoxSizer* wallRightSizer = new wxBoxSizer(wxVERTICAL);
+
+	// Wall Structure inside StaticBox
+	wxStaticBoxSizer* structureSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Wall Structure");
+
+	// Logic Type Selector (Visual Grid)
+	wxBoxSizer* wallTypeSizer = new wxBoxSizer(wxVERTICAL);
+	// wallTypeSizer->Add(new wxStaticText(structureSizer->GetStaticBox(), wxID_ANY, "Select Type to Edit:"), 0, wxALIGN_LEFT | wxBOTTOM, 5); // Removed to save space
+
+	m_wallGridPanel = new WallGridPanel(structureSizer->GetStaticBox(), wxID_ANY);
+	m_wallGridPanel->SetMinSize(wxSize(280, 200)); // Increased height for 3x3 grid
+
+	// Bind click event (reusing BUTTON_CLICKED)
+	m_wallGridPanel->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &BorderEditorPanel::OnWallGridSelect, this);
+
+	wallTypeSizer->Add(m_wallGridPanel, 0, wxEXPAND | wxBOTTOM, 5);
+	structureSizer->Add(wallTypeSizer, 0, wxEXPAND | wxALL, 5);
+
+	// List of items for this type (REMOVED per user request)
+	// m_wallItemsList = new wxListBox(structureSizer->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(-1, 80));
+	// structureSizer->Add(m_wallItemsList, 1, wxEXPAND | wxLEFT | wxRIGHT, 5);
+	m_wallItemsList = nullptr;
+
+	// Add Item Controls row (REMOVED per user request)
+	// wxBoxSizer* wallItemInputSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	// wallItemInputSizer->Add(new wxStaticText(structureSizer->GetStaticBox(), wxID_ANY, "Item ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+	// m_wallItemIdCtrl = new wxSpinCtrl(structureSizer->GetStaticBox(), wxID_ANY, "0", wxDefaultPosition, wxSize(70, -1), wxSP_ARROW_KEYS, 0, 65535);
+	// wallItemInputSizer->Add(m_wallItemIdCtrl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
+	m_wallItemIdCtrl = nullptr;
+
+	// wxButton* addWallItemBtn = new wxButton(structureSizer->GetStaticBox(), wxID_ANY, "Add", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	// addWallItemBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnAddWallItem, this);
+	// wallItemInputSizer->Add(addWallItemBtn, 0, wxRIGHT, 5);
+
+	// wxButton* remWallItemBtn = new wxButton(structureSizer->GetStaticBox(), wxID_ANY, "Remove", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+	// remWallItemBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnRemoveWallItem, this);
+	// wallItemInputSizer->Add(remWallItemBtn, 0);
+
+	// structureSizer->Add(wallItemInputSizer, 0, wxEXPAND | wxALL, 5);
+	wallRightSizer->Add(structureSizer, 1, wxEXPAND | wxALL, 5);
+
+	// Preview inside StaticBox
+	wxStaticBoxSizer* wallVisualSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Preview");
+	m_wallVisualPanel = new WallVisualPanel(wallVisualSizer->GetStaticBox());
+	m_wallVisualPanel->SetMinSize(wxSize(150, 150));
+	wallVisualSizer->Add(m_wallVisualPanel, 1, wxEXPAND | wxALL, 5);
+	wallRightSizer->Add(wallVisualSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	wallContentSizer->Add(wallRightSizer, 1, wxEXPAND | wxLEFT, 5);
+	wallSizer->Add(wallContentSizer, 1, wxEXPAND | wxALL, 5);
+
+	// --- Footer: Right-aligned buttons ---
+	wxBoxSizer* wallButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+	wallButtonSizer->AddStretchSpacer(1);
+
+	wxButton* wallNewButton = new wxButton(m_wallPanel, wxID_ANY, "New Wall");
+	wallNewButton->SetToolTip("Start creating a new wall brush (clears current form)");
+	wallNewButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent &ev) {
+		DiscardCurrentDraft();
+		ClearWallItems();
+		if (m_groundNameCtrl) {
+			m_groundNameCtrl->SetValue("");
+		}
+		if (m_borderBrowserList) {
+			m_borderBrowserList->SetSelection(wxNOT_FOUND);
+		}
+	});
+	wallButtonSizer->Add(wallNewButton, 0, wxRIGHT, 5);
+
+	wxButton* saveWallButton = new wxButton(m_wallPanel, wxID_ANY, "Save Changes");
+	saveWallButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent &ev) { SaveWallBrush(); });
+	wallButtonSizer->Add(saveWallButton, 0, wxRIGHT, 5);
+	wallButtonSizer->Add(new wxButton(m_wallPanel, wxID_CLOSE, "Close"), 0);
+
+	wallSizer->Add(wallButtonSizer, 0, wxEXPAND | wxALL, 5);
+
+	m_wallPanel->SetSizer(wallSizer);
+	m_notebook->AddPage(m_wallPanel, "Wall");
+
+	// ========== HORIZONTAL LAYOUT: Content (Left) + Browser (Right) ==========
+	wxBoxSizer* mainHorizSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	// LEFT: Add notebook (existing content)
+	mainHorizSizer->Add(m_notebook, 1, wxEXPAND | wxALL, 5);
+
+	// RIGHT: Browser Sidebar
+	wxBoxSizer* browserSizer = new wxBoxSizer(wxVERTICAL);
+
+	// Mode Switcher Buttons (replaces m_browserLabel)
+	wxBoxSizer* modeSwitcherSizer = new wxBoxSizer(wxHORIZONTAL);
+
+	m_groundModeBtn = new wxToggleButton(this, wxID_ANY, "Variation", wxDefaultPosition, wxDefaultSize);
+	m_groundModeBtn->SetValue(true); // Default to Ground mode
+	m_groundModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
+	modeSwitcherSizer->Add(m_groundModeBtn, 1, wxEXPAND | wxRIGHT, 2);
+
+	m_wallModeBtn = new wxToggleButton(this, wxID_ANY, "Structure", wxDefaultPosition, wxDefaultSize);
+	m_wallModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
+	modeSwitcherSizer->Add(m_wallModeBtn, 1, wxEXPAND | wxRIGHT, 2);
+
+	m_borderModeBtn = new wxToggleButton(this, wxID_ANY, "Border", wxDefaultPosition, wxDefaultSize);
+	m_borderModeBtn->SetValue(false);
+	m_borderModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
+	modeSwitcherSizer->Add(m_borderModeBtn, 1, wxEXPAND);
+
+	browserSizer->Add(modeSwitcherSizer, 0, wxEXPAND | wxALL, 5);
+
+	m_browserTilesetFilterButton = new wxButton(this, wxID_ANY, "Tileset: Select ▼", wxDefaultPosition, wxSize(280, -1), wxBU_LEFT);
+	m_browserTilesetFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserTilesetFilterButtonClick, this);
+	browserSizer->Add(m_browserTilesetFilterButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+	// Search control
+	m_browserSearchCtrl = new wxSearchCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(280, -1));
+	m_browserSearchCtrl->SetDescriptiveText("Search...");
+	m_browserSearchCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &BorderEditorPanel::OnBrowserSearch, this);
+	m_browserSearchCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnBrowserSearch, this);
+	browserSizer->Add(m_browserSearchCtrl, 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
+
+	m_borderBrowserList = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxSize(280, -1), 0, nullptr, wxLB_SINGLE | wxBORDER_NONE);
+	m_borderBrowserList->Hide();
+	m_borderBrowserList->Bind(wxEVT_LISTBOX, &BorderEditorPanel::OnBorderBrowserSelection, this);
+
+	m_browserGrid = new BrushBrowserGridPanel(this, wxID_ANY);
+	m_browserGrid->SetToolTip("Click an item to load it for editing");
+	Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnBrowserGridSelection, this, m_browserGrid->GetId());
+	browserSizer->Add(m_browserGrid, 1, wxEXPAND | wxALL, 5);
+
+	mainHorizSizer->Add(browserSizer, 0, wxEXPAND);
+
+	// Add horizontal layout to top sizer
+	topSizer->Add(mainHorizSizer, 1, wxEXPAND);
+
+	SetSizer(topSizer);
+	Layout();
+
+	// Initialize Category Combo (Select Borders if available)
+	// Initialize Category Button (Select Borders if available)
+	if (!m_rawCategoryNames.IsEmpty()) {
+		int defaults = m_rawCategoryNames.Index("Borders");
+		if (defaults != wxNOT_FOUND) {
+			m_rawCategorySelection = defaults;
+		} else {
+			m_rawCategorySelection = 0;
+		}
+
+		if (m_rawCategoryButton) {
+			m_rawCategoryButton->SetLabel(m_rawCategoryNames[m_rawCategorySelection] + " \u25BC");
+		}
+
+		// Trigger load
+		if (m_itemPalettePanel) {
+			m_itemPalettePanel->LoadTileset(m_rawCategoryNames[m_rawCategorySelection]);
+		}
+	}
+
+	// Initialize Tileset Choice (Ground Tab)
+	LoadTilesets(); // Ensure m_tilesetListData is populated
+
+	// Select first tileset if any
+	if (!m_tilesetListData.IsEmpty()) {
+		m_groundTilesetSelection = 0;
+		if (m_groundTilesetButton) {
+			m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+		}
+
+		// Trigger load for ground
+		if (m_groundPalette) {
+			m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
+		}
+	}
+
+	{
+		const auto options = GetBrowserTilesetOptions();
+		if (!options.empty() && m_browserTilesetFilter.IsEmpty()) {
+			m_browserTilesetFilter = options.front().second;
+			if (m_browserTilesetFilterButton) {
+				m_browserTilesetFilterButton->SetLabel("Tileset: " + options.front().first + " ▼");
+			}
+		}
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::OnRawCategoryButtonClick(wxCommandEvent& event) {
-    if (m_rawCategoryNames.IsEmpty()) return;
-    
-    wxMenu menu;
-    for (size_t i = 0; i < m_rawCategoryNames.GetCount(); ++i) {
-        menu.AppendCheckItem(1000 + i, m_rawCategoryNames[i]);
-        if ((int)i == m_rawCategorySelection) {
-            menu.Check(1000 + i, true);
-        }
-    }
-    
-    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnRawCategoryMenuSelect, this);
-    const wxSize btnSize = m_rawCategoryButton->GetSize();
-    m_rawCategoryButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+void BorderEditorPanel::OnRawCategoryButtonClick(wxCommandEvent &event) {
+	if (m_rawCategoryNames.IsEmpty()) {
+		return;
+	}
+
+	wxMenu menu;
+	for (size_t i = 0; i < m_rawCategoryNames.GetCount(); ++i) {
+		menu.AppendCheckItem(1000 + i, m_rawCategoryNames[i]);
+		if ((int)i == m_rawCategorySelection) {
+			menu.Check(1000 + i, true);
+		}
+	}
+
+	menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnRawCategoryMenuSelect, this);
+	const wxSize btnSize = m_rawCategoryButton->GetSize();
+	m_rawCategoryButton->PopupMenu(&menu, 0, btnSize.GetHeight());
 }
 
-void BorderEditorPanel::OnRawCategoryMenuSelect(wxCommandEvent& event) {
-    int id = event.GetId() - 1000;
-    if (id < 0 || id >= (int)m_rawCategoryNames.GetCount()) return;
-    
-    m_rawCategorySelection = id;
-    if (m_rawCategoryButton) {
-        m_rawCategoryButton->SetLabel(m_rawCategoryNames[id] + " \u25BC");
-    }
-    
-    if (m_itemPalettePanel) {
-        m_itemPalettePanel->LoadTileset(m_rawCategoryNames[id]);
-    }
+void BorderEditorPanel::OnRawCategoryMenuSelect(wxCommandEvent &event) {
+	int id = event.GetId() - 1000;
+	if (id < 0 || id >= (int)m_rawCategoryNames.GetCount()) {
+		return;
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	m_rawCategorySelection = id;
+	if (m_rawCategoryButton) {
+		m_rawCategoryButton->SetLabel(m_rawCategoryNames[id] + " \u25BC");
+	}
+
+	if (m_itemPalettePanel) {
+		m_itemPalettePanel->LoadTileset(m_rawCategoryNames[id]);
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::OnGroundTilesetButtonClick(wxCommandEvent& event) {
-    if (m_tilesetListData.IsEmpty()) return;
-    
-    wxMenu menu;
-    for (size_t i = 0; i < m_tilesetListData.GetCount(); ++i) {
-        menu.AppendCheckItem(2000 + i, m_tilesetListData[i]);
-        if ((int)i == m_groundTilesetSelection) {
-            menu.Check(2000 + i, true);
-        }
-    }
-    
-    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnGroundTilesetMenuSelect, this);
-    const wxSize btnSize = m_groundTilesetButton->GetSize();
-    m_groundTilesetButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+void BorderEditorPanel::OnGroundTilesetButtonClick(wxCommandEvent &event) {
+	if (m_tilesetListData.IsEmpty()) {
+		return;
+	}
+
+	wxMenu menu;
+	for (size_t i = 0; i < m_tilesetListData.GetCount(); ++i) {
+		menu.AppendCheckItem(2000 + i, m_tilesetListData[i]);
+		if ((int)i == m_groundTilesetSelection) {
+			menu.Check(2000 + i, true);
+		}
+	}
+
+	menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnGroundTilesetMenuSelect, this);
+	const wxSize btnSize = m_groundTilesetButton->GetSize();
+	m_groundTilesetButton->PopupMenu(&menu, 0, btnSize.GetHeight());
 }
 
-void BorderEditorPanel::OnGroundTilesetMenuSelect(wxCommandEvent& event) {
-    int id = event.GetId() - 2000;
-    if (id < 0 || id >= (int)m_tilesetListData.GetCount()) return;
-    
-    m_groundTilesetSelection = id;
-    if (m_groundTilesetButton) {
-        m_groundTilesetButton->SetLabel(m_tilesetListData[id] + " \u25BC");
-    }
-    
-    if (m_groundPalette) {
-        m_groundPalette->LoadTileset(m_tilesetListData[id], FILTER_GROUND);
-    }
+void BorderEditorPanel::OnGroundTilesetMenuSelect(wxCommandEvent &event) {
+	int id = event.GetId() - 2000;
+	if (id < 0 || id >= (int)m_tilesetListData.GetCount()) {
+		return;
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	m_groundTilesetSelection = id;
+	if (m_groundTilesetButton) {
+		m_groundTilesetButton->SetLabel(m_tilesetListData[id] + " \u25BC");
+	}
+
+	if (m_groundPalette) {
+		m_groundPalette->LoadTileset(m_tilesetListData[id], FILTER_GROUND);
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::OnWallTilesetButtonClick(wxCommandEvent& event) {
-    if (m_tilesetListData.IsEmpty()) return;
-    
-    wxMenu menu;
-    for (size_t i = 0; i < m_tilesetListData.GetCount(); ++i) {
-        menu.AppendCheckItem(3000 + i, m_tilesetListData[i]);
-        if ((int)i == m_wallTilesetSelection) {
-            menu.Check(3000 + i, true);
-        }
-    }
-    
-    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnWallTilesetMenuSelect, this);
-    const wxSize btnSize = m_wallTilesetButton->GetSize();
-    m_wallTilesetButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+void BorderEditorPanel::OnWallTilesetButtonClick(wxCommandEvent &event) {
+	if (m_tilesetListData.IsEmpty()) {
+		return;
+	}
+
+	wxMenu menu;
+	for (size_t i = 0; i < m_tilesetListData.GetCount(); ++i) {
+		menu.AppendCheckItem(3000 + i, m_tilesetListData[i]);
+		if ((int)i == m_wallTilesetSelection) {
+			menu.Check(3000 + i, true);
+		}
+	}
+
+	menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnWallTilesetMenuSelect, this);
+	const wxSize btnSize = m_wallTilesetButton->GetSize();
+	m_wallTilesetButton->PopupMenu(&menu, 0, btnSize.GetHeight());
 }
 
-void BorderEditorPanel::OnWallTilesetMenuSelect(wxCommandEvent& event) {
-    int id = event.GetId() - 3000;
-    if (id < 0 || id >= (int)m_tilesetListData.GetCount()) return;
-    
-    m_wallTilesetSelection = id;
-    if (m_wallTilesetButton) {
-        m_wallTilesetButton->SetLabel(m_tilesetListData[id] + " \u25BC");
-    }
-    
-    if (m_wallPalette) {
-        m_wallPalette->LoadTileset(m_tilesetListData[id], FILTER_WALL);
-    }
+void BorderEditorPanel::OnWallTilesetMenuSelect(wxCommandEvent &event) {
+	int id = event.GetId() - 3000;
+	if (id < 0 || id >= (int)m_tilesetListData.GetCount()) {
+		return;
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	m_wallTilesetSelection = id;
+	if (m_wallTilesetButton) {
+		m_wallTilesetButton->SetLabel(m_tilesetListData[id] + " \u25BC");
+	}
+
+	if (m_wallPalette) {
+		m_wallPalette->LoadTileset(m_tilesetListData[id], FILTER_WALL);
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::OnBorderAlignmentButtonClick(wxCommandEvent& event) {
-    wxMenu menu;
-    menu.AppendCheckItem(4000, "Outer");
-    menu.AppendCheckItem(4001, "Inner");
-    
-    menu.Check(4000 + m_borderAlignmentSelection, true);
-    
-    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnBorderAlignmentMenuSelect, this);
-    const wxSize btnSize = m_borderAlignmentButton->GetSize();
-    m_borderAlignmentButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+void BorderEditorPanel::OnBorderAlignmentButtonClick(wxCommandEvent &event) {
+	wxMenu menu;
+	menu.AppendCheckItem(4000, "Outer");
+	menu.AppendCheckItem(4001, "Inner");
+
+	menu.Check(4000 + m_borderAlignmentSelection, true);
+
+	menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnBorderAlignmentMenuSelect, this);
+	const wxSize btnSize = m_borderAlignmentButton->GetSize();
+	m_borderAlignmentButton->PopupMenu(&menu, 0, btnSize.GetHeight());
 }
 
-void BorderEditorPanel::OnBorderAlignmentMenuSelect(wxCommandEvent& event) {
-    int id = event.GetId() - 4000;
-    if (id < 0 || id > 1) return;
-    
-    m_borderAlignmentSelection = id;
-    if (m_borderAlignmentButton) {
-        m_borderAlignmentButton->SetLabel((id == 0 ? "Outer" : "Inner") + wxString(" \u25BC"));
-    }
+void BorderEditorPanel::OnBorderAlignmentMenuSelect(wxCommandEvent &event) {
+	int id = event.GetId() - 4000;
+	if (id < 0 || id > 1) {
+		return;
+	}
 
-    SaveCurrentDraft(true);
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	m_borderAlignmentSelection = id;
+	if (m_borderAlignmentButton) {
+		m_borderAlignmentButton->SetLabel((id == 0 ? "Outer" : "Inner") + wxString(" \u25BC"));
+	}
+
+	SaveCurrentDraft(true);
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::OnWallPaletteSelect(wxCommandEvent& event) {
-    int itemId = event.GetInt();
-    if (itemId > 0) {
-        m_currentWallItemId = itemId;
-        // if (m_wallItemIdCtrl) m_wallItemIdCtrl->SetValue(itemId); // Ctrl removed
-    }
+void BorderEditorPanel::OnWallPaletteSelect(wxCommandEvent &event) {
+	int itemId = event.GetInt();
+	if (itemId > 0) {
+		m_currentWallItemId = itemId;
+		// if (m_wallItemIdCtrl) m_wallItemIdCtrl->SetValue(itemId); // Ctrl removed
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
+void BorderEditorPanel::OnWallGridSelect(wxCommandEvent &event) {
+	std::string type = event.GetString().ToStdString();
+	if (type.empty()) {
+		return;
+	}
 
-void BorderEditorPanel::OnWallGridSelect(wxCommandEvent& event) {
-    std::string type = event.GetString().ToStdString();
-    if (type.empty()) return;
+	bool changed = false;
 
-    bool changed = false;
+	// Select the type
+	m_wallGridPanel->SetSelectedType(type);
 
-    // Select the type
-    m_wallGridPanel->SetSelectedType(type);
-    
-    // If we have a valid item selected in palette, add it to this type!
-    if (m_currentWallItemId > 0) {
-        WallTypeData& data = m_wallTypes[type];
-        data.typeName = type;
-        
-        // Check if item already exists to avoid duplicates (optional, but good UX)
-        bool exists = false;
-        for (const auto& item : data.items) {
-            if (item.itemId == m_currentWallItemId) {
-                exists = true;
-                break;
-            }
-        }
-        
-        if (!exists) {
-            data.items.push_back(GroundItem(m_currentWallItemId, 10)); // Default chance
-            changed = true;
-            
-            // Refresh previews
-            m_wallVisualPanel->SetWallItems(m_wallTypes);
-            m_wallGridPanel->SetWallTypes(m_wallTypes); // Updates the grid icons
-        }
-    }
-    
-    UpdateWallItemsList(); // Keeps internal logic sync if needed (pointer null checked inside)
-    SaveCurrentDraft(changed);
+	// If we have a valid item selected in palette, add it to this type!
+	if (m_currentWallItemId > 0) {
+		WallTypeData &data = m_wallTypes[type];
+		data.typeName = type;
+
+		// Check if item already exists to avoid duplicates (optional, but good UX)
+		bool exists = false;
+		for (const auto &item : data.items) {
+			if (item.itemId == m_currentWallItemId) {
+				exists = true;
+				break;
+			}
+		}
+
+		if (!exists) {
+			data.items.push_back(GroundItem(m_currentWallItemId, 10)); // Default chance
+			changed = true;
+
+			// Refresh previews
+			m_wallVisualPanel->SetWallItems(m_wallTypes);
+			m_wallGridPanel->SetWallTypes(m_wallTypes); // Updates the grid icons
+		}
+	}
+
+	UpdateWallItemsList(); // Keeps internal logic sync if needed (pointer null checked inside)
+	SaveCurrentDraft(changed);
 }
 
+void BorderEditorPanel::OnOpenTilesetFilter(wxCommandEvent &event) {
+	// Get all available tilesets
+	wxArrayString allTilesets;
+	for (const auto &pair : g_materials.tilesets) {
+		if (pair.second) {
+			allTilesets.Add(wxString(pair.first));
+		}
+	}
+	allTilesets.Sort();
 
+	// Get the appropriate whitelist for the current mode
+	std::set<wxString> &currentWhitelist = (m_activeTab == 0) ? m_borderEnabledTilesets : (m_activeTab == 1) ? m_groundEnabledTilesets
+																											 : m_wallEnabledTilesets;
 
+	wxString modeLabel = (m_activeTab == 0) ? "Border" : (m_activeTab == 1) ? "Ground"
+																			: "Wall";
 
-void BorderEditorPanel::OnOpenTilesetFilter(wxCommandEvent& event) {
-    // Get all available tilesets
-    wxArrayString allTilesets;
-    for (const auto& pair : g_materials.tilesets) {
-        if (pair.second) {
-            allTilesets.Add(wxString(pair.first));
-        }
-    }
-    allTilesets.Sort();
-    
-    // Get the appropriate whitelist for the current mode
-    std::set<wxString>& currentWhitelist = 
-        (m_activeTab == 0) ? m_borderEnabledTilesets :
-        (m_activeTab == 1) ? m_groundEnabledTilesets :
-                             m_wallEnabledTilesets;
-    
-    wxString modeLabel = (m_activeTab == 0) ? "Border" :
-                         (m_activeTab == 1) ? "Ground" : "Wall";
-    
-    TilesetFilterDialog dlg(this, allTilesets, currentWhitelist, modeLabel);
-    if (dlg.ShowModal() == wxID_OK) {
-        currentWhitelist = dlg.GetEnabledTilesets();
-        SaveFilterConfig();  // Save to file immediately
-        LoadTilesets();  // Refresh the ComboBox with filtered list
-    }
+	TilesetFilterDialog dlg(this, allTilesets, currentWhitelist, modeLabel);
+	if (dlg.ShowModal() == wxID_OK) {
+		currentWhitelist = dlg.GetEnabledTilesets();
+		SaveFilterConfig(); // Save to file immediately
+		LoadTilesets(); // Refresh the ComboBox with filtered list
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
 // ============================================================================
 // TilesetFilterDialog Implementation
 
-TilesetFilterDialog::TilesetFilterDialog(wxWindow* parent,
-                                         const wxArrayString& allTilesets,
-                                         const std::set<wxString>& enabledTilesets,
-                                         const wxString& modeLabel)
-    : wxDialog(parent, wxID_ANY, "Filter Tilesets - " + modeLabel, 
-               wxDefaultPosition, wxSize(350, 450),
-               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
-      m_allTilesets(allTilesets)
-{
-    wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
-    
-    // Instructions
-    mainSizer->Add(new wxStaticText(this, wxID_ANY, 
-        "Select tilesets to show (click anywhere on row):"), 0, wxALL, 10);
-    
-    // Checklist
-    m_tilesetList = new wxCheckListBox(this, wxID_ANY, wxDefaultPosition, 
-                                        wxDefaultSize, allTilesets);
-    
-    // Check only items that ARE in the enabled set (whitelist)
-    // If whitelist is empty, all stay unchecked (default empty)
-    for (unsigned int i = 0; i < allTilesets.GetCount(); ++i) {
-        bool isEnabled = (enabledTilesets.find(allTilesets[i]) != enabledTilesets.end());
-        m_tilesetList->Check(i, isEnabled);
-    }
-    
-    // Bind click-anywhere toggle (clicking the label toggles the checkbox)
-    // REMOVED: Triggers on auto-selection (focus) in GTK, causing first item to be checked automatically
-    // m_tilesetList->Bind(wxEVT_LISTBOX, &TilesetFilterDialog::OnListItemClick, this);
-    
-    mainSizer->Add(m_tilesetList, 1, wxEXPAND | wxLEFT | wxRIGHT, 10);
-    
-    // Select All / None buttons
-    wxBoxSizer* selectBtnSizer = new wxBoxSizer(wxHORIZONTAL);
-    wxButton* selectAllBtn = new wxButton(this, wxID_ANY, "Select All");
-    wxButton* selectNoneBtn = new wxButton(this, wxID_ANY, "Select None");
-    selectAllBtn->Bind(wxEVT_BUTTON, &TilesetFilterDialog::OnSelectAll, this);
-    selectNoneBtn->Bind(wxEVT_BUTTON, &TilesetFilterDialog::OnSelectNone, this);
-    selectBtnSizer->Add(selectAllBtn, 0, wxRIGHT, 5);
-    selectBtnSizer->Add(selectNoneBtn, 0);
-    mainSizer->Add(selectBtnSizer, 0, wxALL, 10);
-    
-    // Save / Cancel buttons
-    wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
-    btnSizer->AddStretchSpacer(1);
-    wxButton* saveBtn = new wxButton(this, wxID_OK, "Save");
-    wxButton* cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
-    btnSizer->Add(saveBtn, 0, wxRIGHT, 5);
-    btnSizer->Add(cancelBtn, 0);
-    mainSizer->Add(btnSizer, 0, wxEXPAND | wxALL, 10);
-    
-    SetSizer(mainSizer);
-    CenterOnParent();
+TilesetFilterDialog::TilesetFilterDialog(wxWindow* parent, const wxArrayString &allTilesets, const std::set<wxString> &enabledTilesets, const wxString &modeLabel) : wxDialog(parent, wxID_ANY, "Filter Tilesets - " + modeLabel, wxDefaultPosition, wxSize(350, 450), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+																																									 m_allTilesets(allTilesets) {
+	wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+
+	// Instructions
+	mainSizer->Add(new wxStaticText(this, wxID_ANY, "Select tilesets to show (click anywhere on row):"), 0, wxALL, 10);
+
+	// Checklist
+	m_tilesetList = new wxCheckListBox(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, allTilesets);
+
+	// Check only items that ARE in the enabled set (whitelist)
+	// If whitelist is empty, all stay unchecked (default empty)
+	for (unsigned int i = 0; i < allTilesets.GetCount(); ++i) {
+		bool isEnabled = (enabledTilesets.find(allTilesets[i]) != enabledTilesets.end());
+		m_tilesetList->Check(i, isEnabled);
+	}
+
+	// Bind click-anywhere toggle (clicking the label toggles the checkbox)
+	// REMOVED: Triggers on auto-selection (focus) in GTK, causing first item to be checked automatically
+	// m_tilesetList->Bind(wxEVT_LISTBOX, &TilesetFilterDialog::OnListItemClick, this);
+
+	mainSizer->Add(m_tilesetList, 1, wxEXPAND | wxLEFT | wxRIGHT, 10);
+
+	// Select All / None buttons
+	wxBoxSizer* selectBtnSizer = new wxBoxSizer(wxHORIZONTAL);
+	wxButton* selectAllBtn = new wxButton(this, wxID_ANY, "Select All");
+	wxButton* selectNoneBtn = new wxButton(this, wxID_ANY, "Select None");
+	selectAllBtn->Bind(wxEVT_BUTTON, &TilesetFilterDialog::OnSelectAll, this);
+	selectNoneBtn->Bind(wxEVT_BUTTON, &TilesetFilterDialog::OnSelectNone, this);
+	selectBtnSizer->Add(selectAllBtn, 0, wxRIGHT, 5);
+	selectBtnSizer->Add(selectNoneBtn, 0);
+	mainSizer->Add(selectBtnSizer, 0, wxALL, 10);
+
+	// Save / Cancel buttons
+	wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
+	btnSizer->AddStretchSpacer(1);
+	wxButton* saveBtn = new wxButton(this, wxID_OK, "Save");
+	wxButton* cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
+	btnSizer->Add(saveBtn, 0, wxRIGHT, 5);
+	btnSizer->Add(cancelBtn, 0);
+	mainSizer->Add(btnSizer, 0, wxEXPAND | wxALL, 10);
+
+	SetSizer(mainSizer);
+	CenterOnParent();
 }
 
 std::set<wxString> TilesetFilterDialog::GetEnabledTilesets() const {
-    std::set<wxString> enabled;
-    for (unsigned int i = 0; i < m_allTilesets.GetCount(); ++i) {
-        if (m_tilesetList->IsChecked(i)) {
-            enabled.insert(m_allTilesets[i]);
-        }
-    }
-    return enabled;
+	std::set<wxString> enabled;
+	for (unsigned int i = 0; i < m_allTilesets.GetCount(); ++i) {
+		if (m_tilesetList->IsChecked(i)) {
+			enabled.insert(m_allTilesets[i]);
+		}
+	}
+	return enabled;
 }
 
-void TilesetFilterDialog::OnListItemClick(wxCommandEvent& event) {
-    // Toggle checkbox when clicking anywhere on the row
-    int sel = m_tilesetList->GetSelection();
-    if (sel != wxNOT_FOUND) {
-        m_tilesetList->Check(sel, !m_tilesetList->IsChecked(sel));
-    }
+void TilesetFilterDialog::OnListItemClick(wxCommandEvent &event) {
+	// Toggle checkbox when clicking anywhere on the row
+	int sel = m_tilesetList->GetSelection();
+	if (sel != wxNOT_FOUND) {
+		m_tilesetList->Check(sel, !m_tilesetList->IsChecked(sel));
+	}
 }
 
-void TilesetFilterDialog::OnSelectAll(wxCommandEvent& event) {
-    for (unsigned int i = 0; i < m_tilesetList->GetCount(); ++i) {
-        m_tilesetList->Check(i, true);
-    }
+void TilesetFilterDialog::OnSelectAll(wxCommandEvent &event) {
+	for (unsigned int i = 0; i < m_tilesetList->GetCount(); ++i) {
+		m_tilesetList->Check(i, true);
+	}
 }
 
-void TilesetFilterDialog::OnSelectNone(wxCommandEvent& event) {
-    for (unsigned int i = 0; i < m_tilesetList->GetCount(); ++i) {
-        m_tilesetList->Check(i, false);
-    }
+void TilesetFilterDialog::OnSelectNone(wxCommandEvent &event) {
+	for (unsigned int i = 0; i < m_tilesetList->GetCount(); ++i) {
+		m_tilesetList->Check(i, false);
+	}
 }
 
-void BorderEditorPanel::LoadWallBrushByName(const wxString& name) {
-    if (name.IsEmpty()) {
-        ClearWallItems();
-        return;
-    }
-    
-    // Find the walls.xml file
-    wxString dataDir = g_gui.GetDataDirectory();
-    
-    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + 
-                        "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
-    
-    // Load XML
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(wallsFile).c_str())) return;
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) return;
-    
-    // Find the brush
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute nameAttr = brushNode.attribute("name");
-        if (nameAttr && wxString(nameAttr.as_string()) == name) {
-            ClearWallItems(false);
-            if (m_groundNameCtrl) {
-                m_groundNameCtrl->SetValue(name);
-            }
-            m_wallTypes.clear();
-            
-            // Iterate over children to find <wall> nodes
-            for (pugi::xml_node wallNode = brushNode.child("wall"); wallNode; wallNode = wallNode.next_sibling("wall")) {
-                pugi::xml_attribute typeAttr = wallNode.attribute("type");
-                if (typeAttr) {
-                    std::string typeName = typeAttr.as_string();
-                    WallTypeData typeData;
-                    typeData.typeName = typeName;
-                    
-                    // Helper to parse items from a node
-                    auto parseItems = [&](pugi::xml_node parentNode) {
-                        for (pugi::xml_node itemNode = parentNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
-                            pugi::xml_attribute idAttr = itemNode.attribute("id");
-                            pugi::xml_attribute chanceAttr = itemNode.attribute("chance");
-                            
-                            if (idAttr) {
-                                uint16_t itemId = idAttr.as_uint();
-                                int chance = chanceAttr ? chanceAttr.as_int() : 10;
-                                typeData.items.push_back(GroundItem(itemId, chance));
-                            }
-                        }
-                    };
-                    
-                    // Parse direct items
-                    parseItems(wallNode);
-                    
-                    // Parse items inside <alternate>
-                    for (pugi::xml_node altNode = wallNode.child("alternate"); altNode; altNode = altNode.next_sibling("alternate")) {
-                         parseItems(altNode);
-                    }
-                    
-                    m_wallTypes[typeName] = typeData;
-                }
-            }
-            
-            // Update UI to reflect loaded data
-            m_wallGridPanel->SetWallTypes(m_wallTypes);
-            m_wallGridPanel->SetSelectedType("vertical"); // Default
-            UpdateWallItemsList();
-            m_wallVisualPanel->SetWallItems(m_wallTypes);
-            
-            break;
-        }
-    }
-} 
+void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
+	if (name.IsEmpty()) {
+		ClearWallItems();
+		return;
+	}
 
+	// Find the walls.xml file
+	wxString dataDir = g_gui.GetDataDirectory();
 
+	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+
+	// Load XML
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(wallsFile).c_str())) {
+		return;
+	}
+
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
+
+	// Find the brush
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute nameAttr = brushNode.attribute("name");
+		if (nameAttr && wxString(nameAttr.as_string()) == name) {
+			ClearWallItems(false);
+			if (m_groundNameCtrl) {
+				m_groundNameCtrl->SetValue(name);
+			}
+			m_wallTypes.clear();
+
+			// Iterate over children to find <wall> nodes
+			for (pugi::xml_node wallNode = brushNode.child("wall"); wallNode; wallNode = wallNode.next_sibling("wall")) {
+				pugi::xml_attribute typeAttr = wallNode.attribute("type");
+				if (typeAttr) {
+					std::string typeName = typeAttr.as_string();
+					WallTypeData typeData;
+					typeData.typeName = typeName;
+
+					// Helper to parse items from a node
+					auto parseItems = [&](pugi::xml_node parentNode) {
+						for (pugi::xml_node itemNode = parentNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
+							pugi::xml_attribute idAttr = itemNode.attribute("id");
+							pugi::xml_attribute chanceAttr = itemNode.attribute("chance");
+
+							if (idAttr) {
+								uint16_t itemId = idAttr.as_uint();
+								int chance = chanceAttr ? chanceAttr.as_int() : 10;
+								typeData.items.push_back(GroundItem(itemId, chance));
+							}
+						}
+					};
+
+					// Parse direct items
+					parseItems(wallNode);
+
+					// Parse items inside <alternate>
+					for (pugi::xml_node altNode = wallNode.child("alternate"); altNode; altNode = altNode.next_sibling("alternate")) {
+						parseItems(altNode);
+					}
+
+					m_wallTypes[typeName] = typeData;
+				}
+			}
+
+			// Update UI to reflect loaded data
+			m_wallGridPanel->SetWallTypes(m_wallTypes);
+			m_wallGridPanel->SetSelectedType("vertical"); // Default
+			UpdateWallItemsList();
+			m_wallVisualPanel->SetWallItems(m_wallTypes);
+
+			break;
+		}
+	}
+}
 
 void BorderEditorPanel::SaveWallBrush() {
-    wxString name = m_groundNameCtrl ? m_groundNameCtrl->GetValue().Trim() : wxString();
-    
-    if (name.IsEmpty()) {
-        wxMessageBox("Please enter a name for the wall brush.", "Error", wxICON_ERROR);
-        return;
-    }
-    
-    int preSave = wxMessageBox(
-        "This action will save the wall brush and reload data files (F5). Continue?",
-        "Confirm Save",
-        wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
-        this
-    );
-    if (preSave != wxYES) {
-        return;
-    }
+	wxString name = m_groundNameCtrl ? m_groundNameCtrl->GetValue().Trim() : wxString();
 
-    uint16_t mainTileId = m_selectedBrowserTileId;
-    if (mainTileId == 0) {
-        for (const auto& pair : m_wallTypes) {
-            const WallTypeData& typeData = pair.second;
-            if (!typeData.items.empty()) {
-                mainTileId = typeData.items.front().itemId;
-                break;
-            }
-        }
-    }
+	if (name.IsEmpty()) {
+		wxMessageBox("Please enter a name for the wall brush.", "Error", wxICON_ERROR);
+		return;
+	}
 
-    const int serverLookId = static_cast<int>(mainTileId);
-    
-    // Find walls.xml
-    wxString dataDir = g_gui.GetDataDirectory();
-    
-    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + 
-                        "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
-                        
-    pugi::xml_document doc;
-    bool loaded = doc.load_file(nstr(wallsFile).c_str());
-    if (!loaded) {
-        // Create new if not exists?
-        // Usually we expect it to exist.
-        // If not, maybe create simple structure
-        pugi::xml_node root = doc.append_child("materials");
-    }
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) materials = doc.append_child("materials");
-    
-    // Check if exists and remove OLD entry to replace it completely
-    pugi::xml_node existingNode;
-    for (pugi::xml_node node = materials.child("brush"); node; node = node.next_sibling("brush")) {
-        if (wxString(node.attribute("name").as_string()) == name) {
-            existingNode = node;
-            break;
-        }
-    }
-    
-    if (existingNode) {
-        if (wxMessageBox("Wall brush '" + name + "' already exists. Overwrite?", "Confirm Overwrite", wxYES_NO | wxICON_QUESTION) != wxYES) {
-            return;
-        }
-        materials.remove_child(existingNode);
-    }
-    
-    // Create NEW brush node
-    pugi::xml_node brushNode = materials.append_child("brush");
-    brushNode.append_attribute("name").set_value(nstr(name).c_str());
-    brushNode.append_attribute("type").set_value("wall");
-    brushNode.append_attribute("server_lookid").set_value(serverLookId);
-    
-    // Iterate over our map and save <wall> nodes
-    for (const auto& pair : m_wallTypes) {
-        const WallTypeData& typeData = pair.second;
-        if (typeData.items.empty()) continue; // Skip empty types
-        
-        pugi::xml_node wallNode = brushNode.append_child("wall");
-        wallNode.append_attribute("type").set_value(typeData.typeName.c_str());
-        
-        for (const GroundItem& item : typeData.items) {
-            pugi::xml_node itemNode = wallNode.append_child("item");
-            itemNode.append_attribute("id").set_value(item.itemId);
-            itemNode.append_attribute("chance").set_value(item.chance);
-        }
-    }
-    
-    wxString xmlText;
-    if (!ReadAllText(wallsFile, xmlText) || xmlText.IsEmpty()) {
-        xmlText = "<materials>\n</materials>\n";
-    }
+	int preSave = wxMessageBox(
+		"This action will save the wall brush and reload data files (F5). Continue?",
+		"Confirm Save",
+		wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
+		this
+	);
+	if (preSave != wxYES) {
+		return;
+	}
 
-    const wxString nl = DetectNewline(xmlText);
-    const wxString baseIndent = DetectChildIndent(xmlText, "brush");
-    const wxString newBlock = PrintNodeIndented(brushNode, baseIndent, nl);
-    const wxString attrNeedle = "name=\"" + name + "\"";
+	uint16_t mainTileId = m_selectedBrowserTileId;
+	if (mainTileId == 0) {
+		for (const auto &pair : m_wallTypes) {
+			const WallTypeData &typeData = pair.second;
+			if (!typeData.items.empty()) {
+				mainTileId = typeData.items.front().itemId;
+				break;
+			}
+		}
+	}
 
-    wxString oldText = xmlText;
-    if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
-        wxMessageBox("Invalid walls.xml file: missing '</materials>'", "Error", wxICON_ERROR);
-        return;
-    }
+	const int serverLookId = static_cast<int>(mainTileId);
 
-    if (xmlText != oldText && !WriteAllText(wallsFile, xmlText)) {
-        wxMessageBox("Failed to save walls.xml", "Error", wxICON_ERROR);
-        return;
-    }
+	// Find walls.xml
+	wxString dataDir = g_gui.GetDataDirectory();
 
-    DiscardDraft(2, mainTileId);
+	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 
-    TriggerReloadDataFiles();
-    ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+	pugi::xml_document doc;
+	bool loaded = doc.load_file(nstr(wallsFile).c_str());
+	if (!loaded) {
+		// Create new if not exists?
+		// Usually we expect it to exist.
+		// If not, maybe create simple structure
+		pugi::xml_node root = doc.append_child("materials");
+	}
 
-    wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		materials = doc.append_child("materials");
+	}
+
+	// Check if exists and remove OLD entry to replace it completely
+	pugi::xml_node existingNode;
+	for (pugi::xml_node node = materials.child("brush"); node; node = node.next_sibling("brush")) {
+		if (wxString(node.attribute("name").as_string()) == name) {
+			existingNode = node;
+			break;
+		}
+	}
+
+	if (existingNode) {
+		if (wxMessageBox("Wall brush '" + name + "' already exists. Overwrite?", "Confirm Overwrite", wxYES_NO | wxICON_QUESTION) != wxYES) {
+			return;
+		}
+		materials.remove_child(existingNode);
+	}
+
+	// Create NEW brush node
+	pugi::xml_node brushNode = materials.append_child("brush");
+	brushNode.append_attribute("name").set_value(nstr(name).c_str());
+	brushNode.append_attribute("type").set_value("wall");
+	brushNode.append_attribute("server_lookid").set_value(serverLookId);
+
+	// Iterate over our map and save <wall> nodes
+	for (const auto &pair : m_wallTypes) {
+		const WallTypeData &typeData = pair.second;
+		if (typeData.items.empty()) {
+			continue; // Skip empty types
+		}
+
+		pugi::xml_node wallNode = brushNode.append_child("wall");
+		wallNode.append_attribute("type").set_value(typeData.typeName.c_str());
+
+		for (const GroundItem &item : typeData.items) {
+			pugi::xml_node itemNode = wallNode.append_child("item");
+			itemNode.append_attribute("id").set_value(item.itemId);
+			itemNode.append_attribute("chance").set_value(item.chance);
+		}
+	}
+
+	wxString xmlText;
+	if (!ReadAllText(wallsFile, xmlText) || xmlText.IsEmpty()) {
+		xmlText = "<materials>\n</materials>\n";
+	}
+
+	const wxString nl = DetectNewline(xmlText);
+	const wxString baseIndent = DetectChildIndent(xmlText, "brush");
+	const wxString newBlock = PrintNodeIndented(brushNode, baseIndent, nl);
+	const wxString attrNeedle = "name=\"" + name + "\"";
+
+	wxString oldText = xmlText;
+	if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
+		wxMessageBox("Invalid walls.xml file: missing '</materials>'", "Error", wxICON_ERROR);
+		return;
+	}
+
+	if (xmlText != oldText && !WriteAllText(wallsFile, xmlText)) {
+		wxMessageBox("Failed to save walls.xml", "Error", wxICON_ERROR);
+		return;
+	}
+
+	DiscardDraft(2, mainTileId);
+
+	TriggerReloadDataFiles();
+	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+
+	wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
 }
 
 void BorderEditorPanel::LoadExistingWallBrushes() {
-    // Legacy method - wall brushes are now populated via PopulateWallList()
-    // Called from constructor for compatibility, actual population happens on tab change
+	// Legacy method - wall brushes are now populated via PopulateWallList()
+	// Called from constructor for compatibility, actual population happens on tab change
 }
 
 bool BorderEditorPanel::ValidateWallBrush() {
-    return true;
+	return true;
 }
 
 // Helper to get current selected type string
 
-
 void BorderEditorPanel::ClearWallItems(bool clearBrowser) {
-    if (m_wallVisualPanel) {
-        m_wallVisualPanel->Clear();
-    }
+	if (m_wallVisualPanel) {
+		m_wallVisualPanel->Clear();
+	}
 
-    if (m_wallGridPanel) {
-        m_wallGridPanel->SetWallTypes({});
-        m_wallGridPanel->SetSelectedType(std::string());
-    }
+	if (m_wallGridPanel) {
+		m_wallGridPanel->SetWallTypes({});
+		m_wallGridPanel->SetSelectedType(std::string());
+	}
 
-    m_wallTypes.clear();
-    m_currentWallItemId = 0;
+	m_wallTypes.clear();
+	m_currentWallItemId = 0;
 
-    if (m_groundNameCtrl) {
-        m_groundNameCtrl->SetValue("");
-    }
+	if (m_groundNameCtrl) {
+		m_groundNameCtrl->SetValue("");
+	}
 
-    if (clearBrowser && m_borderBrowserList) {
-        m_borderBrowserList->SetSelection(wxNOT_FOUND);
-        m_selectedBrowserTileId = 0;
-    }
+	if (clearBrowser && m_borderBrowserList) {
+		m_borderBrowserList->SetSelection(wxNOT_FOUND);
+		m_selectedBrowserTileId = 0;
+	}
 }
 
 void BorderEditorPanel::UpdateWallItemsList() {
-    if (!m_wallItemsList || !m_wallGridPanel) return;
-    
-    m_wallItemsList->Clear();
-    std::string type = m_wallGridPanel->GetSelectedType();
-    if (type.empty()) type = "vertical"; // Fallback
-    
-    if (m_wallTypes.find(type) != m_wallTypes.end()) {
-        const WallTypeData& data = m_wallTypes[type];
-        for (const GroundItem& item : data.items) {
-            m_wallItemsList->Append(wxString::Format("Item ID: %d", item.itemId));
-        }
-    }
+	if (!m_wallItemsList || !m_wallGridPanel) {
+		return;
+	}
+
+	m_wallItemsList->Clear();
+	std::string type = m_wallGridPanel->GetSelectedType();
+	if (type.empty()) {
+		type = "vertical"; // Fallback
+	}
+
+	if (m_wallTypes.find(type) != m_wallTypes.end()) {
+		const WallTypeData &data = m_wallTypes[type];
+		for (const GroundItem &item : data.items) {
+			m_wallItemsList->Append(wxString::Format("Item ID: %d", item.itemId));
+		}
+	}
 }
 
-void BorderEditorPanel::OnWallBrowse(wxCommandEvent& event) {
-    // Reuse Ground Browse Logic or create new dialog
-    // implementation pending... using manual ID for now
+void BorderEditorPanel::OnWallBrowse(wxCommandEvent &event) {
+	// Reuse Ground Browse Logic or create new dialog
+	// implementation pending... using manual ID for now
 }
 
-void BorderEditorPanel::OnAddWallItem(wxCommandEvent& event) {
-    if (!m_wallItemIdCtrl) return;
-    int id = m_wallItemIdCtrl->GetValue();
-    if (id <= 0) return;
-    
-    std::string type = m_wallGridPanel->GetSelectedType();
-    if (type.empty()) type = "vertical";
-    
-    WallTypeData& data = m_wallTypes[type];
-    data.typeName = type;
-    data.items.push_back(GroundItem(id, 10)); // Default chance 10
-    
-    m_wallItemsList->Append(wxString::Format("Item ID: %d", id));
-    m_wallVisualPanel->SetWallItems(m_wallTypes); // Update preview
-    m_wallGridPanel->SetWallTypes(m_wallTypes); // Update visual selector
+void BorderEditorPanel::OnAddWallItem(wxCommandEvent &event) {
+	if (!m_wallItemIdCtrl) {
+		return;
+	}
+	int id = m_wallItemIdCtrl->GetValue();
+	if (id <= 0) {
+		return;
+	}
+
+	std::string type = m_wallGridPanel->GetSelectedType();
+	if (type.empty()) {
+		type = "vertical";
+	}
+
+	WallTypeData &data = m_wallTypes[type];
+	data.typeName = type;
+	data.items.push_back(GroundItem(id, 10)); // Default chance 10
+
+	m_wallItemsList->Append(wxString::Format("Item ID: %d", id));
+	m_wallVisualPanel->SetWallItems(m_wallTypes); // Update preview
+	m_wallGridPanel->SetWallTypes(m_wallTypes); // Update visual selector
 }
 
-void BorderEditorPanel::OnRemoveWallItem(wxCommandEvent& event) {
-    if (!m_wallItemsList) return;
-    int sel = m_wallItemsList->GetSelection();
-    if (sel == wxNOT_FOUND) return;
-    
-    std::string type = m_wallGridPanel->GetSelectedType();
-    if (type.empty()) type = "vertical";
-    
-    if (m_wallTypes.find(type) != m_wallTypes.end()) {
-         WallTypeData& data = m_wallTypes[type];
-         if (sel >= 0 && sel < (int)data.items.size()) {
-             data.items.erase(data.items.begin() + sel);
-             UpdateWallItemsList();
-             m_wallVisualPanel->SetWallItems(m_wallTypes);
-             m_wallGridPanel->SetWallTypes(m_wallTypes);
-         }
-    }
-}
+void BorderEditorPanel::OnRemoveWallItem(wxCommandEvent &event) {
+	if (!m_wallItemsList) {
+		return;
+	}
+	int sel = m_wallItemsList->GetSelection();
+	if (sel == wxNOT_FOUND) {
+		return;
+	}
 
+	std::string type = m_wallGridPanel->GetSelectedType();
+	if (type.empty()) {
+		type = "vertical";
+	}
+
+	if (m_wallTypes.find(type) != m_wallTypes.end()) {
+		WallTypeData &data = m_wallTypes[type];
+		if (sel >= 0 && sel < (int)data.items.size()) {
+			data.items.erase(data.items.begin() + sel);
+			UpdateWallItemsList();
+			m_wallVisualPanel->SetWallItems(m_wallTypes);
+			m_wallGridPanel->SetWallTypes(m_wallTypes);
+		}
+	}
+}
 
 void BorderEditorPanel::LoadExistingBorders() {
-    // Clear the browser list
-    if (!m_borderBrowserList) return;
-    m_borderBrowserList->Clear();
-    
-    // Find borders.xml file - actual borders are in the borders/ subfolder
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + 
-                          "materials" + wxFileName::GetPathSeparator() + 
-                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
-    
-    if (!wxFileExists(bordersFile)) {
-        return; // Silently fail - no borders yet
-    }
-    
-    // Load XML
-    pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
-    if (!result) return;
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) return;
-    
-    int maxId = 0;
-    
-    // Parse all borders
-    for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-        pugi::xml_attribute idAttr = borderNode.attribute("id");
-        if (!idAttr) continue;
-        
-        int id = idAttr.as_int();
-        if (id > maxId) {
-            maxId = id;
-        }
-        
-        // Get name attribute
-        wxString name;
-        pugi::xml_attribute nameAttr = borderNode.attribute("name");
-        if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
-            name = wxString(nameAttr.as_string());
-        } else {
-            name = "(no name)";
-        }
-        
-        // Add to browser list: "ID - Name"
-        wxString label = wxString::Format("%d - %s", id, name);
-        m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", id)));
-    }
-    
-    // Set next border ID
-    m_nextBorderId = maxId + 1;
-    m_currentBorderId = m_nextBorderId;
+	// Clear the browser list
+	if (!m_borderBrowserList) {
+		return;
+	}
+	m_borderBrowserList->Clear();
+
+	// Find borders.xml file - actual borders are in the borders/ subfolder
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+
+	if (!wxFileExists(bordersFile)) {
+		return; // Silently fail - no borders yet
+	}
+
+	// Load XML
+	pugi::xml_document doc;
+	pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
+	if (!result) {
+		return;
+	}
+
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
+
+	int maxId = 0;
+
+	// Parse all borders
+	for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+		pugi::xml_attribute idAttr = borderNode.attribute("id");
+		if (!idAttr) {
+			continue;
+		}
+
+		int id = idAttr.as_int();
+		if (id > maxId) {
+			maxId = id;
+		}
+
+		// Get name attribute
+		wxString name;
+		pugi::xml_attribute nameAttr = borderNode.attribute("name");
+		if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
+			name = wxString(nameAttr.as_string());
+		} else {
+			name = "(no name)";
+		}
+
+		// Add to browser list: "ID - Name"
+		wxString label = wxString::Format("%d - %s", id, name);
+		m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", id)));
+	}
+
+	// Set next border ID
+	m_nextBorderId = maxId + 1;
+	m_currentBorderId = m_nextBorderId;
 }
 
 // Helper method to load a border by ID
 void BorderEditorPanel::LoadBorderById(int borderId) {
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + 
-                          "materials" + wxFileName::GetPathSeparator() + 
-                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
-    
-    if (!wxFileExists(bordersFile)) return;
-    
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(bordersFile).c_str())) return;
-    
-    ClearItems(false); // Don't clear browser selection logic
-    
-    pugi::xml_node materials = doc.child("materials");
-    for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-        pugi::xml_attribute idAttr = borderNode.attribute("id");
-        if (!idAttr || idAttr.as_int() != borderId) continue;
-        
-        m_currentBorderId = borderId; // Store the loaded ID
-        
-        // Name
-        pugi::xml_attribute nameAttr = borderNode.attribute("name");
-        m_loadedBorderName = nameAttr ? wxString(nameAttr.as_string()) : "";
-        
-        // Type
-        pugi::xml_attribute typeAttr = borderNode.attribute("type");
-        m_isOptionalCheck->SetValue(typeAttr && std::string(typeAttr.as_string()) == "optional");
-        
-        // Ground
-        pugi::xml_attribute groundAttr = borderNode.attribute("ground");
-        m_isGroundCheck->SetValue(groundAttr && groundAttr.as_bool());
-        
-        // Group (Checkbox now)
-        pugi::xml_attribute groupAttr = borderNode.attribute("group");
-        m_groupCheck->SetValue(groupAttr ? groupAttr.as_int() > 0 : false);
-        
-        // Border items
-        for (pugi::xml_node itemNode = borderNode.child("borderitem"); itemNode; itemNode = itemNode.next_sibling("borderitem")) {
-            pugi::xml_attribute edgeAttr = itemNode.attribute("edge");
-            pugi::xml_attribute itemAttr = itemNode.attribute("item");
-            if (!edgeAttr || !itemAttr) continue;
-            
-            BorderEdgePosition pos = edgeStringToPosition(edgeAttr.as_string());
-            uint16_t itemId = itemAttr.as_uint();
-            if (pos != EDGE_NONE && itemId > 0) {
-                m_borderItems.push_back(BorderItem(pos, itemId));
-                m_gridPanel->SetItemId(pos, itemId);
-            }
-        }
-        break;
-    }
-    UpdatePreview();
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+
+	if (!wxFileExists(bordersFile)) {
+		return;
+	}
+
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(bordersFile).c_str())) {
+		return;
+	}
+
+	ClearItems(false); // Don't clear browser selection logic
+
+	pugi::xml_node materials = doc.child("materials");
+	for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+		pugi::xml_attribute idAttr = borderNode.attribute("id");
+		if (!idAttr || idAttr.as_int() != borderId) {
+			continue;
+		}
+
+		m_currentBorderId = borderId; // Store the loaded ID
+
+		// Name
+		pugi::xml_attribute nameAttr = borderNode.attribute("name");
+		m_loadedBorderName = nameAttr ? wxString(nameAttr.as_string()) : "";
+
+		// Type
+		pugi::xml_attribute typeAttr = borderNode.attribute("type");
+		m_isOptionalCheck->SetValue(typeAttr && std::string(typeAttr.as_string()) == "optional");
+
+		// Ground
+		pugi::xml_attribute groundAttr = borderNode.attribute("ground");
+		m_isGroundCheck->SetValue(groundAttr && groundAttr.as_bool());
+
+		// Group (Checkbox now)
+		pugi::xml_attribute groupAttr = borderNode.attribute("group");
+		m_groupCheck->SetValue(groupAttr ? groupAttr.as_int() > 0 : false);
+
+		// Border items
+		for (pugi::xml_node itemNode = borderNode.child("borderitem"); itemNode; itemNode = itemNode.next_sibling("borderitem")) {
+			pugi::xml_attribute edgeAttr = itemNode.attribute("edge");
+			pugi::xml_attribute itemAttr = itemNode.attribute("item");
+			if (!edgeAttr || !itemAttr) {
+				continue;
+			}
+
+			BorderEdgePosition pos = edgeStringToPosition(edgeAttr.as_string());
+			uint16_t itemId = itemAttr.as_uint();
+			if (pos != EDGE_NONE && itemId > 0) {
+				m_borderItems.push_back(BorderItem(pos, itemId));
+				m_gridPanel->SetItemId(pos, itemId);
+			}
+		}
+		break;
+	}
+	UpdatePreview();
 }
 
 // Browser sidebar selection handler - dispatches based on active tab
-void BorderEditorPanel::OnBorderBrowserSelection(wxCommandEvent& event) {
-    SaveCurrentDraft(false);
+void BorderEditorPanel::OnBorderBrowserSelection(wxCommandEvent &event) {
+	SaveCurrentDraft(false);
 
-    if (!m_borderBrowserList) return;
+	if (!m_borderBrowserList) {
+		return;
+	}
 
-    int selection = m_borderBrowserList->GetSelection();
-    if (selection == wxNOT_FOUND) return;
+	int selection = m_borderBrowserList->GetSelection();
+	if (selection == wxNOT_FOUND) {
+		return;
+	}
 
-    wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(selection));
-    if (!data) return;
+	wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(selection));
+	if (!data) {
+		return;
+	}
 
-    const uint16_t tileId = static_cast<uint16_t>(wxAtoi(data->GetData()));
-    if (tileId == 0) {
-        return;
-    }
+	const uint16_t tileId = static_cast<uint16_t>(wxAtoi(data->GetData()));
+	if (tileId == 0) {
+		return;
+	}
 
-    m_selectedBrowserTileId = tileId;
+	m_selectedBrowserTileId = tileId;
 
-    switch (m_activeTab) {
-        case 0: LoadBorderByMainTileId(tileId); break;
-        case 1: LoadGroundBrushByMainTileId(tileId); break;
-        case 2: LoadWallBrushByMainTileId(tileId); break;
-    }
+	switch (m_activeTab) {
+		case 0:
+			LoadBorderByMainTileId(tileId);
+			break;
+		case 1:
+			LoadGroundBrushByMainTileId(tileId);
+			break;
+		case 2:
+			LoadWallBrushByMainTileId(tileId);
+			break;
+	}
 }
 
-void BorderEditorPanel::OnBrowserGridSelection(wxCommandEvent& event) {
-    SaveCurrentDraft(false);
+void BorderEditorPanel::OnBrowserGridSelection(wxCommandEvent &event) {
+	SaveCurrentDraft(false);
 
-    const wxString key = event.GetString();
-    if (key.IsEmpty()) {
-        return;
-    }
+	const wxString key = event.GetString();
+	if (key.IsEmpty()) {
+		return;
+	}
 
-    RestoreBrowserSelection(key);
+	RestoreBrowserSelection(key);
 
-    const uint16_t tileId = static_cast<uint16_t>(wxAtoi(key));
-    if (tileId == 0) {
-        return;
-    }
+	const uint16_t tileId = static_cast<uint16_t>(wxAtoi(key));
+	if (tileId == 0) {
+		return;
+	}
 
-    m_selectedBrowserTileId = tileId;
+	m_selectedBrowserTileId = tileId;
 
-    switch (m_activeTab) {
-        case 0: LoadBorderByMainTileId(tileId); break;
-        case 1: LoadGroundBrushByMainTileId(tileId); break;
-        case 2: LoadWallBrushByMainTileId(tileId); break;
-    }
+	switch (m_activeTab) {
+		case 0:
+			LoadBorderByMainTileId(tileId);
+			break;
+		case 1:
+			LoadGroundBrushByMainTileId(tileId);
+			break;
+		case 2:
+			LoadWallBrushByMainTileId(tileId);
+			break;
+	}
 }
 
-void BorderEditorPanel::OnLoadBorder(wxCommandEvent& event) {
-    // Old combo box handler - now unused as browser list handles loading
+void BorderEditorPanel::OnLoadBorder(wxCommandEvent &event) {
+	// Old combo box handler - now unused as browser list handles loading
 }
 
-void BorderEditorPanel::OnItemIdChanged(wxCommandEvent& event) {
-    // This event handler would update the display when an item ID is entered manually
-    // but we're handling this directly in OnAddItem instead
+void BorderEditorPanel::OnItemIdChanged(wxCommandEvent &event) {
+	// This event handler would update the display when an item ID is entered manually
+	// but we're handling this directly in OnAddItem instead
 }
 
-void BorderEditorPanel::OnBrowse(wxCommandEvent& event) {
-    // Open the Find Item dialog instead
-    FindItemDialog dialog(this, "Select Border Item");
-    
-    if (dialog.ShowModal() == wxID_OK) {
-        // Get the selected item ID
-        uint16_t itemId = dialog.getResultID();
-        
-        // Find the item ID spin control
-        // This logic is now obsolete as m_itemIdCtrl is removed.
-        // The item ID should be set in the context of the current operation (e.g., OnPositionSelected).
-        // For now, this function might need a different approach or be removed if no longer needed.
-        // Keeping it as is for now, assuming m_itemIdCtrl might be re-introduced or handled differently.
-        wxSpinCtrl* itemIdCtrl = nullptr;
-        wxWindowList& children = GetChildren();
-        for (wxWindowList::iterator it = children.begin(); it != children.end(); ++it) {
-            wxSpinCtrl* spinCtrl = dynamic_cast<wxSpinCtrl*>(*it);
-            if (spinCtrl /*&& spinCtrl != m_idCtrl*/) { // m_idCtrl is removed
-                itemIdCtrl = spinCtrl;
-                break;
-            }
-        }
-        
-        if (itemIdCtrl && itemId > 0) {
-            itemIdCtrl->SetValue(itemId);
-        }
-    }
+void BorderEditorPanel::OnBrowse(wxCommandEvent &event) {
+	// Open the Find Item dialog instead
+	FindItemDialog dialog(this, "Select Border Item");
+
+	if (dialog.ShowModal() == wxID_OK) {
+		// Get the selected item ID
+		uint16_t itemId = dialog.getResultID();
+
+		// Find the item ID spin control
+		// This logic is now obsolete as m_itemIdCtrl is removed.
+		// The item ID should be set in the context of the current operation (e.g., OnPositionSelected).
+		// For now, this function might need a different approach or be removed if no longer needed.
+		// Keeping it as is for now, assuming m_itemIdCtrl might be re-introduced or handled differently.
+		wxSpinCtrl* itemIdCtrl = nullptr;
+		wxWindowList &children = GetChildren();
+		for (wxWindowList::iterator it = children.begin(); it != children.end(); ++it) {
+			wxSpinCtrl* spinCtrl = dynamic_cast<wxSpinCtrl*>(*it);
+			if (spinCtrl /*&& spinCtrl != m_idCtrl*/) { // m_idCtrl is removed
+				itemIdCtrl = spinCtrl;
+				break;
+			}
+		}
+
+		if (itemIdCtrl && itemId > 0) {
+			itemIdCtrl->SetValue(itemId);
+		}
+	}
 }
 
-void BorderEditorPanel::OnPositionSelected(wxCommandEvent& event) {
-    // Get the position from the event
-    BorderEdgePosition pos = static_cast<BorderEdgePosition>(event.GetInt());
-    wxLogDebug("OnPositionSelected: Position %s selected", wxstr(edgePositionToString(pos)).c_str());
+void BorderEditorPanel::OnPositionSelected(wxCommandEvent &event) {
+	// Get the position from the event
+	BorderEdgePosition pos = static_cast<BorderEdgePosition>(event.GetInt());
+	wxLogDebug("OnPositionSelected: Position %s selected", wxstr(edgePositionToString(pos)).c_str());
 
-    
-    // Get the item ID from the current brush
-    Brush* currentBrush = g_gui.GetCurrentBrush();
-    uint16_t itemId = 0;
-    
-    if (currentBrush) {
-        wxLogDebug("OnPositionSelected: Using brush: %s", wxString(currentBrush->getName()).c_str());
-        
-        // Try to get the item ID directly - check if it's a RAW brush first
-        if (currentBrush->isRaw()) {
-            RAWBrush* rawBrush = currentBrush->asRaw();
-            if (rawBrush) {
-                itemId = rawBrush->getItemID();
-                wxLogDebug("OnPositionSelected: Got item ID %d directly from RAW brush", itemId);
-            }
-        } 
-        
-        // If we didn't get an ID from the RAW brush method, try the generic method
-        if (itemId == 0) {
-            itemId = GetItemIDFromBrush(currentBrush);
-            wxLogDebug("OnPositionSelected: Got item ID %d from GetItemIDFromBrush", itemId);
-        }
-    } else {
-        wxLogDebug("OnPositionSelected: No current brush selected");
-    }
-    
-    // If no valid ID from brush, check the manual input control
-    // m_itemIdCtrl is removed, so this block is now obsolete.
-    // The user is expected to select an item brush.
-    /*
-    if (itemId == 0 && m_itemIdCtrl) {
-        itemId = m_itemIdCtrl->GetValue();
-        if (itemId > 0) {
-            wxLogDebug("OnPositionSelected: Using item ID %d from manual control", itemId);
-        }
-    }
-    */
+	// Get the item ID from the current brush
+	Brush* currentBrush = g_gui.GetCurrentBrush();
+	uint16_t itemId = 0;
 
-    if (itemId > 0) {
-        // Update the item ID control - keeps the UI in sync with our selection
-        // m_itemIdCtrl is removed, so this block is now obsolete.
-        /*
-        if (m_itemIdCtrl) {
-            m_itemIdCtrl->SetValue(itemId);
-        }
-        */
-        
-        // Add or update the border item
-        bool updated = false;
-        for (size_t i = 0; i < m_borderItems.size(); i++) {
-            if (m_borderItems[i].position == pos) {
-                m_borderItems[i].itemId = itemId;
-                updated = true;
-                wxLogDebug("OnPositionSelected: Updated existing border item at position %s", wxstr(edgePositionToString(pos)).c_str());
+	if (currentBrush) {
+		wxLogDebug("OnPositionSelected: Using brush: %s", wxString(currentBrush->getName()).c_str());
 
-                break;
-            }
-        }
-        
-        if (!updated) {
-            m_borderItems.push_back(BorderItem(pos, itemId));
-            wxLogDebug("OnPositionSelected: Added new border item at position %s", wxstr(edgePositionToString(pos)).c_str());
+		// Try to get the item ID directly - check if it's a RAW brush first
+		if (currentBrush->isRaw()) {
+			RAWBrush* rawBrush = currentBrush->asRaw();
+			if (rawBrush) {
+				itemId = rawBrush->getItemID();
+				wxLogDebug("OnPositionSelected: Got item ID %d directly from RAW brush", itemId);
+			}
+		}
 
-        }
-        
-        // Update the grid panel
-        m_gridPanel->SetItemId(pos, itemId);
-        wxLogDebug("OnPositionSelected: Set grid panel item ID for position %s to %d", wxstr(edgePositionToString(pos)).c_str(), itemId);
+		// If we didn't get an ID from the RAW brush method, try the generic method
+		if (itemId == 0) {
+			itemId = GetItemIDFromBrush(currentBrush);
+			wxLogDebug("OnPositionSelected: Got item ID %d from GetItemIDFromBrush", itemId);
+		}
+	} else {
+		wxLogDebug("OnPositionSelected: No current brush selected");
+	}
 
-        
-        // Update the preview
-        UpdatePreview();
-        SaveCurrentDraft(true);
-        
-        // Log the addition
-        wxLogDebug("Added border item at position %s with item ID %d", 
-                  wxstr(edgePositionToString(pos)).c_str(), itemId);
+	// If no valid ID from brush, check the manual input control
+	// m_itemIdCtrl is removed, so this block is now obsolete.
+	// The user is expected to select an item brush.
+	/*
+	if (itemId == 0 && m_itemIdCtrl) {
+		itemId = m_itemIdCtrl->GetValue();
+		if (itemId > 0) {
+			wxLogDebug("OnPositionSelected: Using item ID %d from manual control", itemId);
+		}
+	}
+	*/
 
-    } else {
-        // If we couldn't get an item ID from the brush, check if there's a value in the item ID control
-        // m_itemIdCtrl is removed, so this block is now obsolete.
-        /*
-        itemId = m_itemIdCtrl->GetValue();
-        
-        if (itemId > 0) {
-            // Use the value from the control to update/add the border item
-            bool updated = false;
-            for (size_t i = 0; i < m_borderItems.size(); i++) {
-                if (m_borderItems[i].position == pos) {
-                    m_borderItems[i].itemId = itemId;
-                    updated = true;
-                    break;
-                }
-            }
-            
-            if (!updated) {
-                m_borderItems.push_back(BorderItem(pos, itemId));
-            }
-            
-            // Update the grid panel
-            m_gridPanel->SetItemId(pos, itemId);
-            
-            // Update the preview
-            UpdatePreview();
-            
-            wxLogDebug("Used item ID %d from control for position %s", 
-                       itemId, wxstr(edgePositionToString(pos)).c_str());
+	if (itemId > 0) {
+		// Update the item ID control - keeps the UI in sync with our selection
+		// m_itemIdCtrl is removed, so this block is now obsolete.
+		/*
+		if (m_itemIdCtrl) {
+			m_itemIdCtrl->SetValue(itemId);
+		}
+		*/
 
-        } else {
-        */
-            wxLogDebug("No valid item ID found from current brush: %s", currentBrush ? wxString(currentBrush->getName()).c_str() : wxT("NULL"));
+		// Add or update the border item
+		bool updated = false;
+		for (size_t i = 0; i < m_borderItems.size(); i++) {
+			if (m_borderItems[i].position == pos) {
+				m_borderItems[i].itemId = itemId;
+				updated = true;
+				wxLogDebug("OnPositionSelected: Updated existing border item at position %s", wxstr(edgePositionToString(pos)).c_str());
 
-            wxMessageBox("Could not get a valid item ID from the current brush. Please select an item brush or use the Browse button to select an item manually.", "Invalid Brush", wxICON_INFORMATION);
-        // }
-    }
+				break;
+			}
+		}
+
+		if (!updated) {
+			m_borderItems.push_back(BorderItem(pos, itemId));
+			wxLogDebug("OnPositionSelected: Added new border item at position %s", wxstr(edgePositionToString(pos)).c_str());
+		}
+
+		// Update the grid panel
+		m_gridPanel->SetItemId(pos, itemId);
+		wxLogDebug("OnPositionSelected: Set grid panel item ID for position %s to %d", wxstr(edgePositionToString(pos)).c_str(), itemId);
+
+		// Update the preview
+		UpdatePreview();
+		SaveCurrentDraft(true);
+
+		// Log the addition
+		wxLogDebug("Added border item at position %s with item ID %d", wxstr(edgePositionToString(pos)).c_str(), itemId);
+
+	} else {
+		// If we couldn't get an item ID from the brush, check if there's a value in the item ID control
+		// m_itemIdCtrl is removed, so this block is now obsolete.
+		/*
+		itemId = m_itemIdCtrl->GetValue();
+
+		if (itemId > 0) {
+			// Use the value from the control to update/add the border item
+			bool updated = false;
+			for (size_t i = 0; i < m_borderItems.size(); i++) {
+				if (m_borderItems[i].position == pos) {
+					m_borderItems[i].itemId = itemId;
+					updated = true;
+					break;
+				}
+			}
+
+			if (!updated) {
+				m_borderItems.push_back(BorderItem(pos, itemId));
+			}
+
+			// Update the grid panel
+			m_gridPanel->SetItemId(pos, itemId);
+
+			// Update the preview
+			UpdatePreview();
+
+			wxLogDebug("Used item ID %d from control for position %s",
+					   itemId, wxstr(edgePositionToString(pos)).c_str());
+
+		} else {
+		*/
+		wxLogDebug("No valid item ID found from current brush: %s", currentBrush ? wxString(currentBrush->getName()).c_str() : wxT("NULL"));
+
+		wxMessageBox("Could not get a valid item ID from the current brush. Please select an item brush or use the Browse button to select an item manually.", "Invalid Brush", wxICON_INFORMATION);
+		// }
+	}
 }
 
-void BorderEditorPanel::OnAddItem(wxCommandEvent& event) {
-    // This function is now obsolete as manual add buttons and m_itemIdCtrl are removed.
-    // If it were to be used, it would need to get the item ID from the currently selected brush.
-    wxMessageBox("This 'Add Item' functionality is no longer available. Please select an item brush and click on the grid to add items.", "Information", wxICON_INFORMATION);
-    return;
+void BorderEditorPanel::OnAddItem(wxCommandEvent &event) {
+	// This function is now obsolete as manual add buttons and m_itemIdCtrl are removed.
+	// If it were to be used, it would need to get the item ID from the currently selected brush.
+	wxMessageBox("This 'Add Item' functionality is no longer available. Please select an item brush and click on the grid to add items.", "Information", wxICON_INFORMATION);
+	return;
 
-    /*
-    // Get the currently selected position in the grid panel
-    static BorderEdgePosition lastSelectedPos = EDGE_NONE;
-    BorderEdgePosition selectedPos = m_gridPanel->GetSelectedPosition();
-    
-    // If no position is currently selected, use the last selected position
-    if (selectedPos == EDGE_NONE) {
-        selectedPos = lastSelectedPos;
-    }
-    
-    if (selectedPos == EDGE_NONE) {
-        wxMessageBox("Please select a position on the grid first by clicking on it.", "Error", wxICON_ERROR);
-        return;
-    }
-    
-    // Save this position for future use
-    lastSelectedPos = selectedPos;
-    
-    // Get the item ID from the control (now using the class member)
-    uint16_t itemId = m_itemIdCtrl->GetValue();
-    
-    if (itemId == 0) {
-        wxMessageBox("Please enter a valid item ID or use the Browse button.", "Error", wxICON_ERROR);
-        return;
-    }
-    
-    // Add or update the border item
-    bool updated = false;
-    for (size_t i = 0; i < m_borderItems.size(); i++) {
-        if (m_borderItems[i].position == selectedPos) {
-            m_borderItems[i].itemId = itemId;
-            updated = true;
-            break;
-        }
-    }
-    
-    if (!updated) {
-        m_borderItems.push_back(BorderItem(selectedPos, itemId));
-    }
-    
-    // Update the grid panel
-    m_gridPanel->SetItemId(selectedPos, itemId);
-    
-    // Update the preview
-    UpdatePreview();
-    
-    // Log the addition for debugging
-    wxLogDebug("Added item ID %d at position %s via Add button", 
-               itemId, wxstr(edgePositionToString(selectedPos)).c_str());
-    */
+	/*
+	// Get the currently selected position in the grid panel
+	static BorderEdgePosition lastSelectedPos = EDGE_NONE;
+	BorderEdgePosition selectedPos = m_gridPanel->GetSelectedPosition();
+
+	// If no position is currently selected, use the last selected position
+	if (selectedPos == EDGE_NONE) {
+		selectedPos = lastSelectedPos;
+	}
+
+	if (selectedPos == EDGE_NONE) {
+		wxMessageBox("Please select a position on the grid first by clicking on it.", "Error", wxICON_ERROR);
+		return;
+	}
+
+	// Save this position for future use
+	lastSelectedPos = selectedPos;
+
+	// Get the item ID from the control (now using the class member)
+	uint16_t itemId = m_itemIdCtrl->GetValue();
+
+	if (itemId == 0) {
+		wxMessageBox("Please enter a valid item ID or use the Browse button.", "Error", wxICON_ERROR);
+		return;
+	}
+
+	// Add or update the border item
+	bool updated = false;
+	for (size_t i = 0; i < m_borderItems.size(); i++) {
+		if (m_borderItems[i].position == selectedPos) {
+			m_borderItems[i].itemId = itemId;
+			updated = true;
+			break;
+		}
+	}
+
+	if (!updated) {
+		m_borderItems.push_back(BorderItem(selectedPos, itemId));
+	}
+
+	// Update the grid panel
+	m_gridPanel->SetItemId(selectedPos, itemId);
+
+	// Update the preview
+	UpdatePreview();
+
+	// Log the addition for debugging
+	wxLogDebug("Added item ID %d at position %s via Add button",
+			   itemId, wxstr(edgePositionToString(selectedPos)).c_str());
+	*/
 }
 
-void BorderEditorPanel::OnClear(wxCommandEvent& event) {
-    DiscardCurrentDraft();
+void BorderEditorPanel::OnClear(wxCommandEvent &event) {
+	DiscardCurrentDraft();
 
-    if (m_activeTab == 0) {
-        // Border tab
-    ClearItems();
-    } else {
-        // Ground tab
-        ClearGroundItems();
-    }
+	if (m_activeTab == 0) {
+		// Border tab
+		ClearItems();
+	} else {
+		// Ground tab
+		ClearGroundItems();
+	}
 }
 
 void BorderEditorPanel::ClearItems(bool clearBrowser) {
-    m_borderItems.clear();
-    m_gridPanel->Clear();
-    m_previewPanel->Clear();
-    
-    // Reset controls to defaults
-    m_currentBorderId = m_nextBorderId; // Use m_currentBorderId instead of m_idCtrl
-    m_loadedBorderName.clear();
-    if (m_isOptionalCheck) m_isOptionalCheck->SetValue(false);
-    if (m_isGroundCheck) m_isGroundCheck->SetValue(false);
-    if (m_groupCheck) m_groupCheck->SetValue(false);
-    
-    // Deselect browser list
-    if (clearBrowser && m_borderBrowserList) {
-        m_borderBrowserList->SetSelection(wxNOT_FOUND);
-        m_selectedBrowserTileId = 0;
-    }
+	m_borderItems.clear();
+	m_gridPanel->Clear();
+	m_previewPanel->Clear();
+
+	// Reset controls to defaults
+	m_currentBorderId = m_nextBorderId; // Use m_currentBorderId instead of m_idCtrl
+	m_loadedBorderName.clear();
+	if (m_isOptionalCheck) {
+		m_isOptionalCheck->SetValue(false);
+	}
+	if (m_isGroundCheck) {
+		m_isGroundCheck->SetValue(false);
+	}
+	if (m_groupCheck) {
+		m_groupCheck->SetValue(false);
+	}
+
+	// Deselect browser list
+	if (clearBrowser && m_borderBrowserList) {
+		m_borderBrowserList->SetSelection(wxNOT_FOUND);
+		m_selectedBrowserTileId = 0;
+	}
 }
 
 void BorderEditorPanel::UpdatePreview() {
-    m_previewPanel->SetBorderItems(m_borderItems);
-    m_previewPanel->Refresh();
+	m_previewPanel->SetBorderItems(m_borderItems);
+	m_previewPanel->Refresh();
 }
 
 bool BorderEditorPanel::ValidateBorder() {
-    if (m_borderItems.empty()) {
-        wxMessageBox("The border must have at least one item.", "Validation Error", wxICON_ERROR);
-        return false;
-    }
-    
-    // Check that there are no duplicate positions
-    std::set<BorderEdgePosition> positions;
-    for (const BorderItem& item : m_borderItems) {
-        if (positions.find(item.position) != positions.end()) {
-            wxMessageBox("The border contains duplicate positions.", "Validation Error", wxICON_ERROR);
-            return false;
-        }
-        positions.insert(item.position);
-    }
-    
-    // Check for ID validity (using m_currentBorderId)
-    int id = m_currentBorderId; // Use m_currentBorderId
-    if (id <= 0) {
-        wxMessageBox("Border ID must be greater than 0.", "Validation Error", wxICON_ERROR);
-        return false;
-    }
-    
-    return true;
+	if (m_borderItems.empty()) {
+		wxMessageBox("The border must have at least one item.", "Validation Error", wxICON_ERROR);
+		return false;
+	}
+
+	// Check that there are no duplicate positions
+	std::set<BorderEdgePosition> positions;
+	for (const BorderItem &item : m_borderItems) {
+		if (positions.find(item.position) != positions.end()) {
+			wxMessageBox("The border contains duplicate positions.", "Validation Error", wxICON_ERROR);
+			return false;
+		}
+		positions.insert(item.position);
+	}
+
+	// Check for ID validity (using m_currentBorderId)
+	int id = m_currentBorderId; // Use m_currentBorderId
+	if (id <= 0) {
+		wxMessageBox("Border ID must be greater than 0.", "Validation Error", wxICON_ERROR);
+		return false;
+	}
+
+	return true;
 }
 
 void BorderEditorPanel::SaveBorder() {
-    if (!ValidateBorder()) {
-        return;
-    }
+	if (!ValidateBorder()) {
+		return;
+	}
 
-    int preSave = wxMessageBox(
-        "This action will save the border and reload data files (F5). Continue?",
-        "Confirm Save",
-        wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
-        this
-    );
-    if (preSave != wxYES) {
-        return;
-    }
-    
-    // Get the border properties
-    int id = m_currentBorderId; // Use m_currentBorderId
-    wxString name = m_loadedBorderName;
-    bool isOptional = m_isOptionalCheck->GetValue();
-    bool isGround = m_isGroundCheck->GetValue();
-    int group = m_groupCheck->GetValue() ? 1 : 0; // Read m_groupCheck as checkbox
-    
-    // Find the borders.xml file using the same version path conversion
-    wxString dataDir = g_gui.GetDataDirectory();
-    
-    // actual borders are in the borders/ subfolder
-    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + 
-                          "materials" + wxFileName::GetPathSeparator() + 
-                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
-    
-    if (!wxFileExists(bordersFile)) {
-        wxMessageBox("Cannot find borders.xml file in the data directory.", "Error", wxICON_ERROR);
-        return;
-    }
-    
-    // Load the XML file
-    pugi::xml_document doc;
-    pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
-    
-    if (!result) {
-        wxMessageBox("Failed to load borders.xml: " + wxString(result.description()), "Error", wxICON_ERROR);
-        return;
-    }
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) {
-        wxMessageBox("Invalid borders.xml file: missing 'materials' node", "Error", wxICON_ERROR);
-        return;
-    }
-    
-    // Check if a border with this ID already exists
-    bool borderExists = false;
-    pugi::xml_node existingBorder;
-    
-    for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-        pugi::xml_attribute idAttr = borderNode.attribute("id");
-        if (idAttr && idAttr.as_int() == id) {
-            borderExists = true;
-            existingBorder = borderNode;
-            break;
-        }
-    }
-    
-    if (borderExists) {
-        // Check if there's a comment node before the existing border - we want to remove legacy comments too
-        pugi::xml_node commentNode = existingBorder.previous_sibling();
-        bool hadComment = (commentNode && commentNode.type() == pugi::node_comment);
-        
-        // Ask for confirmation to overwrite
-        if (wxMessageBox("A border with ID " + wxString::Format("%d", id) + " already exists. Do you want to overwrite it?", 
-                        "Confirm Overwrite", wxYES_NO | wxICON_QUESTION) != wxYES) {
-            return;
-        }
-        
-        // Remove precedent comment if it exists (legacy cleanup)
-        if (hadComment) {
-            materials.remove_child(commentNode);
-        }
-        
-        // Remove the existing border - this ensures all old PCDATA/children are gone
-        materials.remove_child(existingBorder);
-    }
-    
-    // Format the name - ensure we have a fallback
-    if (name.IsEmpty()) {
-        name = wxString::Format("Border %d", id);
-    }
-    
-    // Create the new border node
-    pugi::xml_node borderNode = materials.append_child("border");
-    borderNode.append_attribute("id").set_value(id);
-    
-    // RULE: Always save name as attribute, NOT as PCDATA/Comment
-    borderNode.append_attribute("name").set_value(nstr(name).c_str());
-    
-    if (isOptional) {
-        borderNode.append_attribute("type").set_value("optional");
-    }
-    
-    if (isGround) {
-        borderNode.append_attribute("ground").set_value("true");
-    }
-    
-    if (group > 0) {
-        borderNode.append_attribute("group").set_value(group);
-    }
-    
-    // Add all border items
-    for (const BorderItem& item : m_borderItems) {
-        pugi::xml_node itemNode = borderNode.append_child("borderitem");
-        itemNode.append_attribute("edge").set_value(edgePositionToString(item.position).c_str());
-        itemNode.append_attribute("item").set_value(item.itemId);
-    }
-    
-    wxString xmlText;
-    if (!ReadAllText(bordersFile, xmlText) || xmlText.IsEmpty()) {
-        wxMessageBox("Failed to read borders.xml", "Error", wxICON_ERROR);
-        return;
-    }
+	int preSave = wxMessageBox(
+		"This action will save the border and reload data files (F5). Continue?",
+		"Confirm Save",
+		wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
+		this
+	);
+	if (preSave != wxYES) {
+		return;
+	}
 
-    const wxString nl = DetectNewline(xmlText);
-    const wxString baseIndent = DetectChildIndent(xmlText, "border");
-    const wxString newBlock = PrintNodeIndented(borderNode, baseIndent, nl);
-    const wxString attrNeedle = wxString::Format("id=\"%d\"", id);
+	// Get the border properties
+	int id = m_currentBorderId; // Use m_currentBorderId
+	wxString name = m_loadedBorderName;
+	bool isOptional = m_isOptionalCheck->GetValue();
+	bool isGround = m_isGroundCheck->GetValue();
+	int group = m_groupCheck->GetValue() ? 1 : 0; // Read m_groupCheck as checkbox
 
-    wxString oldText = xmlText;
-    if (!ReplaceOrInsertChildSimple(xmlText, "border", attrNeedle, newBlock, true)) {
-        wxMessageBox("Invalid borders.xml file: missing '</materials>'", "Error", wxICON_ERROR);
-        return;
-    }
+	// Find the borders.xml file using the same version path conversion
+	wxString dataDir = g_gui.GetDataDirectory();
 
-    if (xmlText != oldText && !WriteAllText(bordersFile, xmlText)) {
-        wxMessageBox("Failed to save changes to borders.xml", "Error", wxICON_ERROR);
-        return;
-    }
+	// actual borders are in the borders/ subfolder
+	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
 
-    DiscardDraft(0, m_selectedBrowserTileId);
+	if (!wxFileExists(bordersFile)) {
+		wxMessageBox("Cannot find borders.xml file in the data directory.", "Error", wxICON_ERROR);
+		return;
+	}
 
-    TriggerReloadDataFiles();
-    ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
+	// Load the XML file
+	pugi::xml_document doc;
+	pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
 
-    wxMessageBox("Border saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
+	if (!result) {
+		wxMessageBox("Failed to load borders.xml: " + wxString(result.description()), "Error", wxICON_ERROR);
+		return;
+	}
+
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		wxMessageBox("Invalid borders.xml file: missing 'materials' node", "Error", wxICON_ERROR);
+		return;
+	}
+
+	// Check if a border with this ID already exists
+	bool borderExists = false;
+	pugi::xml_node existingBorder;
+
+	for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+		pugi::xml_attribute idAttr = borderNode.attribute("id");
+		if (idAttr && idAttr.as_int() == id) {
+			borderExists = true;
+			existingBorder = borderNode;
+			break;
+		}
+	}
+
+	if (borderExists) {
+		// Check if there's a comment node before the existing border - we want to remove legacy comments too
+		pugi::xml_node commentNode = existingBorder.previous_sibling();
+		bool hadComment = (commentNode && commentNode.type() == pugi::node_comment);
+
+		// Ask for confirmation to overwrite
+		if (wxMessageBox("A border with ID " + wxString::Format("%d", id) + " already exists. Do you want to overwrite it?", "Confirm Overwrite", wxYES_NO | wxICON_QUESTION) != wxYES) {
+			return;
+		}
+
+		// Remove precedent comment if it exists (legacy cleanup)
+		if (hadComment) {
+			materials.remove_child(commentNode);
+		}
+
+		// Remove the existing border - this ensures all old PCDATA/children are gone
+		materials.remove_child(existingBorder);
+	}
+
+	// Format the name - ensure we have a fallback
+	if (name.IsEmpty()) {
+		name = wxString::Format("Border %d", id);
+	}
+
+	// Create the new border node
+	pugi::xml_node borderNode = materials.append_child("border");
+	borderNode.append_attribute("id").set_value(id);
+
+	// RULE: Always save name as attribute, NOT as PCDATA/Comment
+	borderNode.append_attribute("name").set_value(nstr(name).c_str());
+
+	if (isOptional) {
+		borderNode.append_attribute("type").set_value("optional");
+	}
+
+	if (isGround) {
+		borderNode.append_attribute("ground").set_value("true");
+	}
+
+	if (group > 0) {
+		borderNode.append_attribute("group").set_value(group);
+	}
+
+	// Add all border items
+	for (const BorderItem &item : m_borderItems) {
+		pugi::xml_node itemNode = borderNode.append_child("borderitem");
+		itemNode.append_attribute("edge").set_value(edgePositionToString(item.position).c_str());
+		itemNode.append_attribute("item").set_value(item.itemId);
+	}
+
+	wxString xmlText;
+	if (!ReadAllText(bordersFile, xmlText) || xmlText.IsEmpty()) {
+		wxMessageBox("Failed to read borders.xml", "Error", wxICON_ERROR);
+		return;
+	}
+
+	const wxString nl = DetectNewline(xmlText);
+	const wxString baseIndent = DetectChildIndent(xmlText, "border");
+	const wxString newBlock = PrintNodeIndented(borderNode, baseIndent, nl);
+	const wxString attrNeedle = wxString::Format("id=\"%d\"", id);
+
+	wxString oldText = xmlText;
+	if (!ReplaceOrInsertChildSimple(xmlText, "border", attrNeedle, newBlock, true)) {
+		wxMessageBox("Invalid borders.xml file: missing '</materials>'", "Error", wxICON_ERROR);
+		return;
+	}
+
+	if (xmlText != oldText && !WriteAllText(bordersFile, xmlText)) {
+		wxMessageBox("Failed to save changes to borders.xml", "Error", wxICON_ERROR);
+		return;
+	}
+
+	DiscardDraft(0, m_selectedBrowserTileId);
+
+	TriggerReloadDataFiles();
+	ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
+
+	wxMessageBox("Border saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
 }
 
-void BorderEditorPanel::OnSave(wxCommandEvent& event) {
-    if (m_activeTab == 0) {
-        // Border tab
-        SaveBorder();
-    } else if (m_activeTab == 1) {
-        // Ground tab
-        SaveGroundBrush();
-    }
+void BorderEditorPanel::OnSave(wxCommandEvent &event) {
+	if (m_activeTab == 0) {
+		// Border tab
+		SaveBorder();
+	} else if (m_activeTab == 1) {
+		// Ground tab
+		SaveGroundBrush();
+	}
 }
 
-void BorderEditorPanel::OnClose(wxCommandEvent& event) {
-    if (g_gui.aui_manager) {
-        wxAuiPaneInfo& pane = g_gui.aui_manager->GetPane(this);
-        if (pane.IsOk()) {
-            pane.Hide();
-            g_gui.aui_manager->Update();
-            return;
-        }
-    }
+void BorderEditorPanel::OnClose(wxCommandEvent &event) {
+	if (g_gui.aui_manager) {
+		wxAuiPaneInfo &pane = g_gui.aui_manager->GetPane(this);
+		if (pane.IsOk()) {
+			pane.Hide();
+			g_gui.aui_manager->Update();
+			return;
+		}
+	}
 
-    wxWindow* parent = GetParent();
-    while (parent && !parent->IsTopLevel()) {
-        parent = parent->GetParent();
-    }
+	wxWindow* parent = GetParent();
+	while (parent && !parent->IsTopLevel()) {
+		parent = parent->GetParent();
+	}
 
-    if (parent) {
-        parent->Close();
-    } else {
-        Destroy();
-    }
+	if (parent) {
+		parent->Close();
+	} else {
+		Destroy();
+	}
 }
 
-void BorderEditorPanel::OnGridCellClicked(wxMouseEvent& event) {
-    // This event is handled by the BorderGridPanel directly
-    event.Skip();
+void BorderEditorPanel::OnGridCellClicked(wxMouseEvent &event) {
+	// This event is handled by the BorderGridPanel directly
+	event.Skip();
 }
 
 // ============================================================================
 // BorderItemButton
 
 BorderItemButton::BorderItemButton(wxWindow* parent, BorderEdgePosition position, wxWindowID id) :
-    wxButton(parent, id, "", wxDefaultPosition, wxSize(32, 32)),
-    m_itemId(0),
-    m_position(position) {
-    // Set up the button to show sprite graphics
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
+	wxButton(parent, id, "", wxDefaultPosition, wxSize(32, 32)),
+	m_itemId(0),
+	m_position(position) {
+	// Set up the button to show sprite graphics
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 BorderItemButton::~BorderItemButton() {
-    // No need to destroy anything manually
+	// No need to destroy anything manually
 }
 
 void BorderItemButton::SetItemId(uint16_t id) {
-    m_itemId = id;
-    Refresh();
+	m_itemId = id;
+	Refresh();
 }
 
-void BorderItemButton::OnPaint(wxPaintEvent& event) {
-    wxPaintDC dc(this);
-    
-    // Draw the button background
-    wxRect rect = GetClientRect();
-    dc.SetBrush(wxBrush(GetBackgroundColour()));
-    dc.SetPen(*wxTRANSPARENT_PEN);
-    dc.DrawRectangle(rect);
-    
-    // Draw the item sprite if available
-    if (m_itemId > 0) {
-        const ItemType& type = g_items.getItemType(m_itemId);
-        if (type.id != 0) {
-            Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
-            if (sprite) {
-                sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, 0, 0, rect.GetWidth(), rect.GetHeight());
-            }
-        }
-    }
-    
-    // Draw a border around the button if it's focused
-    if (HasFocus()) {
-        dc.SetPen(*wxBLACK_PEN);
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(rect);
-    }
+void BorderItemButton::OnPaint(wxPaintEvent &event) {
+	wxPaintDC dc(this);
+
+	// Draw the button background
+	wxRect rect = GetClientRect();
+	dc.SetBrush(wxBrush(GetBackgroundColour()));
+	dc.SetPen(*wxTRANSPARENT_PEN);
+	dc.DrawRectangle(rect);
+
+	// Draw the item sprite if available
+	if (m_itemId > 0) {
+		const ItemType &type = g_items.getItemType(m_itemId);
+		if (type.id != 0) {
+			Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+			if (sprite) {
+				sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, 0, 0, rect.GetWidth(), rect.GetHeight());
+			}
+		}
+	}
+
+	// Draw a border around the button if it's focused
+	if (HasFocus()) {
+		dc.SetPen(*wxBLACK_PEN);
+		dc.SetBrush(*wxTRANSPARENT_BRUSH);
+		dc.DrawRectangle(rect);
+	}
 }
 
 // ============================================================================
 // SimpleRawPalettePanel
 
 BEGIN_EVENT_TABLE(SimpleRawPalettePanel, wxScrolledWindow)
-    EVT_PAINT(SimpleRawPalettePanel::OnPaint)
-    EVT_LEFT_UP(SimpleRawPalettePanel::OnLeftUp)
-    EVT_MOTION(SimpleRawPalettePanel::OnMotion)
-    EVT_LEAVE_WINDOW(SimpleRawPalettePanel::OnLeave)
-    EVT_SIZE(SimpleRawPalettePanel::OnSize)
+EVT_PAINT(SimpleRawPalettePanel::OnPaint)
+EVT_LEFT_UP(SimpleRawPalettePanel::OnLeftUp)
+EVT_MOTION(SimpleRawPalettePanel::OnMotion)
+EVT_LEAVE_WINDOW(SimpleRawPalettePanel::OnLeave)
+EVT_SIZE(SimpleRawPalettePanel::OnSize)
 END_EVENT_TABLE()
 
 SimpleRawPalettePanel::SimpleRawPalettePanel(wxWindow* parent, wxWindowID id) :
-    wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxVSCROLL | wxBORDER_SUNKEN)
-{
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
-    
-    // Start empty, let the parent controller load the default tileset
-    // by calling LoadTileset("Borders")
-    
-    RecalculateLayout();
+	wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxVSCROLL | wxBORDER_SUNKEN) {
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+	// Start empty, let the parent controller load the default tileset
+	// by calling LoadTileset("Borders")
+
+	RecalculateLayout();
 }
 
-void SimpleRawPalettePanel::SetItemIds(const std::vector<uint16_t>& ids) {
-    m_itemIds = ids;
-    RecalculateLayout();
-    Refresh();
+void SimpleRawPalettePanel::SetItemIds(const std::vector<uint16_t> &ids) {
+	m_itemIds = ids;
+	RecalculateLayout();
+	Refresh();
 }
 
-void SimpleRawPalettePanel::LoadTileset(const wxString& categoryName, PaletteFilterMode filterMode) {
-    m_itemIds.clear();
-    
-    // Find the specific tileset by name
-    auto it = g_materials.tilesets.find(nstr(categoryName).c_str());
-    if (it != g_materials.tilesets.end()) {
-        Tileset* tileset = it->second;
-        if (tileset) {
-            // Load ONLY from RAW category
-            const TilesetCategory* rawCat = tileset->getCategory(TILESET_RAW);
-            if (rawCat) {
-                for (Brush* brush : rawCat->brushlist) {
-                    if (RAWBrush* rb = dynamic_cast<RAWBrush*>(brush)) {
-                        uint16_t id = rb->getItemID();
-                        
-                        // Apply filter
-                        bool include = true;
-                        if (filterMode == FILTER_GROUND) {
-                            include = g_items[id].isGroundTile();
-                        } else if (filterMode == FILTER_WALL) {
-                            include = g_items[id].isWall;
-                        }
-                        
-                        if (include) {
-                            m_itemIds.push_back(id);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    
-    // Remove duplicates and sort
-    std::sort(m_itemIds.begin(), m_itemIds.end());
-    m_itemIds.erase(std::unique(m_itemIds.begin(), m_itemIds.end()), m_itemIds.end());
-    
-    // Reset hover to avoid stuck highlighting
-    m_hoverIndex = -1;
+void SimpleRawPalettePanel::LoadTileset(const wxString &categoryName, PaletteFilterMode filterMode) {
+	m_itemIds.clear();
 
-    RecalculateLayout();
-    Refresh();
+	// Find the specific tileset by name
+	auto it = g_materials.tilesets.find(nstr(categoryName).c_str());
+	if (it != g_materials.tilesets.end()) {
+		Tileset* tileset = it->second;
+		if (tileset) {
+			// Load ONLY from RAW category
+			const TilesetCategory* rawCat = tileset->getCategory(TILESET_RAW);
+			if (rawCat) {
+				for (Brush* brush : rawCat->brushlist) {
+					if (RAWBrush* rb = dynamic_cast<RAWBrush*>(brush)) {
+						uint16_t id = rb->getItemID();
+
+						// Apply filter
+						bool include = true;
+						if (filterMode == FILTER_GROUND) {
+							include = g_items[id].isGroundTile();
+						} else if (filterMode == FILTER_WALL) {
+							include = g_items[id].isWall;
+						}
+
+						if (include) {
+							m_itemIds.push_back(id);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Remove duplicates and sort
+	std::sort(m_itemIds.begin(), m_itemIds.end());
+	m_itemIds.erase(std::unique(m_itemIds.begin(), m_itemIds.end()), m_itemIds.end());
+
+	// Reset hover to avoid stuck highlighting
+	m_hoverIndex = -1;
+
+	RecalculateLayout();
+	Refresh();
 }
 
-SimpleRawPalettePanel::~SimpleRawPalettePanel() {}
+SimpleRawPalettePanel::~SimpleRawPalettePanel() { }
 
 void SimpleRawPalettePanel::RecalculateLayout() {
-    int w, h;
-    GetClientSize(&w, &h);
-    if (w < m_itemSize) w = m_itemSize;
-    
-    m_cols = (w - m_padding) / (m_itemSize + m_padding);
-    if (m_cols < 1) m_cols = 1;
-    
-    // Ensure m_cols is at least 1 to avoid division by zero
-    if (m_cols < 1) m_cols = 1;
+	int w, h;
+	GetClientSize(&w, &h);
+	if (w < m_itemSize) {
+		w = m_itemSize;
+	}
 
-    m_rows = (m_itemIds.size() + m_cols - 1) / m_cols;
-    
-    int unitY = m_itemSize + m_padding;
-    SetVirtualSize(m_cols * (m_itemSize + m_padding) + m_padding, 
-                   m_rows * unitY + m_padding);
-    SetScrollRate(0, unitY); // Row-level scrolling for speed
-    Refresh();
+	m_cols = (w - m_padding) / (m_itemSize + m_padding);
+	if (m_cols < 1) {
+		m_cols = 1;
+	}
+
+	// Ensure m_cols is at least 1 to avoid division by zero
+	if (m_cols < 1) {
+		m_cols = 1;
+	}
+
+	m_rows = (m_itemIds.size() + m_cols - 1) / m_cols;
+
+	int unitY = m_itemSize + m_padding;
+	SetVirtualSize(m_cols * (m_itemSize + m_padding) + m_padding, m_rows * unitY + m_padding);
+	SetScrollRate(0, unitY); // Row-level scrolling for speed
+	Refresh();
 }
 
-void SimpleRawPalettePanel::OnSize(wxSizeEvent& event) {
-    RecalculateLayout();
-    event.Skip();
+void SimpleRawPalettePanel::OnSize(wxSizeEvent &event) {
+	RecalculateLayout();
+	event.Skip();
 }
 
-void SimpleRawPalettePanel::OnPaint(wxPaintEvent& event) {
-    wxAutoBufferedPaintDC dc(this);
-    DoPrepareDC(dc);
-    dc.SetBackground(wxBrush(wxColour(0, 0, 0)));
-    dc.SetTextForeground(wxColour(255, 255, 255)); // Ensure text is visible on black (if any)
-    dc.Clear();
-    
-    int startUnitX, startUnitY;
-    GetViewStart(&startUnitX, &startUnitY);
-    
-    int clientW, clientH;
-    GetClientSize(&clientW, &clientH);
-    
-    // Scroll unit is 1 row (itemSize + padding)
-    int startRow = startUnitY;
-    // Add extra buffer rows to be safe
-    int endRow = startRow + (clientH / (m_itemSize + m_padding)) + 2;
-    
-    if (startRow < 0) startRow = 0;
-    
-    int startIndex = startRow * m_cols;
-    int endIndex = endRow * m_cols;
-    if (endIndex > (int)m_itemIds.size()) endIndex = m_itemIds.size();
-    
-    for (int i = startIndex; i < endIndex; ++i) {
-        int col = i % m_cols;
-        int row = i / m_cols;
-        int x = m_padding + col * (m_itemSize + m_padding);
-        int y = m_padding + row * (m_itemSize + m_padding);
-        
-        wxRect rect(x, y, m_itemSize, m_itemSize);
-        
-        if (i == m_hoverIndex) {
-            dc.SetPen(wxPen(wxColour(180, 200, 255)));
-            dc.SetBrush(wxBrush(wxColour(220, 240, 255)));
-            dc.DrawRectangle(rect.Inflate(1));
-        }
+void SimpleRawPalettePanel::OnPaint(wxPaintEvent &event) {
+	wxAutoBufferedPaintDC dc(this);
+	DoPrepareDC(dc);
+	dc.SetBackground(wxBrush(wxColour(0, 0, 0)));
+	dc.SetTextForeground(wxColour(255, 255, 255)); // Ensure text is visible on black (if any)
+	dc.Clear();
 
-        uint16_t id = m_itemIds[i];
-        if (id != 0) {
-             const ItemType& type = g_items.getItemType(id);
-             Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
-             if (sprite) {
-                 // Draw directly to the DC to preserve transparency
-                 sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, x, y, m_itemSize, m_itemSize);
-             }
-        }
-    }
+	int startUnitX, startUnitY;
+	GetViewStart(&startUnitX, &startUnitY);
+
+	int clientW, clientH;
+	GetClientSize(&clientW, &clientH);
+
+	// Scroll unit is 1 row (itemSize + padding)
+	int startRow = startUnitY;
+	// Add extra buffer rows to be safe
+	int endRow = startRow + (clientH / (m_itemSize + m_padding)) + 2;
+
+	if (startRow < 0) {
+		startRow = 0;
+	}
+
+	int startIndex = startRow * m_cols;
+	int endIndex = endRow * m_cols;
+	if (endIndex > (int)m_itemIds.size()) {
+		endIndex = m_itemIds.size();
+	}
+
+	for (int i = startIndex; i < endIndex; ++i) {
+		int col = i % m_cols;
+		int row = i / m_cols;
+		int x = m_padding + col * (m_itemSize + m_padding);
+		int y = m_padding + row * (m_itemSize + m_padding);
+
+		wxRect rect(x, y, m_itemSize, m_itemSize);
+
+		if (i == m_hoverIndex) {
+			dc.SetPen(wxPen(wxColour(180, 200, 255)));
+			dc.SetBrush(wxBrush(wxColour(220, 240, 255)));
+			dc.DrawRectangle(rect.Inflate(1));
+		}
+
+		uint16_t id = m_itemIds[i];
+		if (id != 0) {
+			const ItemType &type = g_items.getItemType(id);
+			Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+			if (sprite) {
+				// Draw directly to the DC to preserve transparency
+				sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, x, y, m_itemSize, m_itemSize);
+			}
+		}
+	}
 }
 
-void SimpleRawPalettePanel::OnMotion(wxMouseEvent& event) {
-    wxPoint pos = event.GetPosition();
-    CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
-    int index = HitTest(pos);
-    if (index != m_hoverIndex) {
-        m_hoverIndex = index;
-        Refresh();
-        
-        if (index >= 0) {
-            // Tooltip
-             if (index < (int)m_itemIds.size()) {
-                 const ItemType& type = g_items.getItemType(m_itemIds[index]);
-                 SetToolTip(wxString::Format("%s (%d)", type.name, m_itemIds[index]));
-             }
-        } else {
-            UnsetToolTip();
-        }
-    }
+void SimpleRawPalettePanel::OnMotion(wxMouseEvent &event) {
+	wxPoint pos = event.GetPosition();
+	CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
+	int index = HitTest(pos);
+	if (index != m_hoverIndex) {
+		m_hoverIndex = index;
+		Refresh();
+
+		if (index >= 0) {
+			// Tooltip
+			if (index < (int)m_itemIds.size()) {
+				const ItemType &type = g_items.getItemType(m_itemIds[index]);
+				SetToolTip(wxString::Format("%s (%d)", type.name, m_itemIds[index]));
+			}
+		} else {
+			UnsetToolTip();
+		}
+	}
 }
 
-void SimpleRawPalettePanel::OnLeave(wxMouseEvent& event) {
-    if (m_hoverIndex != -1) {
-        m_hoverIndex = -1;
-        Refresh();
-    }
+void SimpleRawPalettePanel::OnLeave(wxMouseEvent &event) {
+	if (m_hoverIndex != -1) {
+		m_hoverIndex = -1;
+		Refresh();
+	}
 }
 
-int SimpleRawPalettePanel::HitTest(const wxPoint& pt) const {
-    int col = (pt.x - m_padding) / (m_itemSize + m_padding);
-    int row = (pt.y - m_padding) / (m_itemSize + m_padding);
-    
-    if (col >= 0 && col < m_cols && row >= 0) {
-        int index = row * m_cols + col;
-        if (index < (int)m_itemIds.size()) return index;
-    }
-    return -1;
+int SimpleRawPalettePanel::HitTest(const wxPoint &pt) const {
+	int col = (pt.x - m_padding) / (m_itemSize + m_padding);
+	int row = (pt.y - m_padding) / (m_itemSize + m_padding);
+
+	if (col >= 0 && col < m_cols && row >= 0) {
+		int index = row * m_cols + col;
+		if (index < (int)m_itemIds.size()) {
+			return index;
+		}
+	}
+	return -1;
 }
 
-void SimpleRawPalettePanel::OnLeftUp(wxMouseEvent& event) {
-    wxPoint pos = event.GetPosition();
-    CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
-    int index = HitTest(pos);
-    if (index >= 0 && index < (int)m_itemIds.size()) {
-         uint16_t id = m_itemIds[index];
-         // Force selection of the brush internally, bypassing the main palette's checks
-         // which might fail if the item isn't in the main palette's current view.
-         g_gui.SelectBrushInternal(newd RAWBrush(id));
-         
-         // Fire event so the dialog can handle it (e.g. for Ground tab)
-         wxCommandEvent evt(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
-         evt.SetEventObject(this);
-         evt.SetInt(id);
-         ProcessWindowEvent(evt);
-         
-         Refresh();
-    }
+void SimpleRawPalettePanel::OnLeftUp(wxMouseEvent &event) {
+	wxPoint pos = event.GetPosition();
+	CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
+	int index = HitTest(pos);
+	if (index >= 0 && index < (int)m_itemIds.size()) {
+		uint16_t id = m_itemIds[index];
+		// Force selection of the brush internally, bypassing the main palette's checks
+		// which might fail if the item isn't in the main palette's current view.
+		g_gui.SelectBrushInternal(newd RAWBrush(id));
+
+		// Fire event so the dialog can handle it (e.g. for Ground tab)
+		wxCommandEvent evt(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(id);
+		ProcessWindowEvent(evt);
+
+		Refresh();
+	}
 }
 
 #if 0
@@ -2753,1056 +2924,1165 @@ END_EVENT_TABLE()
 // BorderGridPanel
 
 BorderGridPanel::BorderGridPanel(wxWindow* parent, wxWindowID id) :
-    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_SUNKEN)
-{
-    m_items.clear();
-    m_selectedPosition = EDGE_NONE;
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
-    
-    // Enable Full Repaint on Resize for responsive drawing
-    SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
+	wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_SUNKEN) {
+	m_items.clear();
+	m_selectedPosition = EDGE_NONE;
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+	// Enable Full Repaint on Resize for responsive drawing
+	SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
 }
 
 BorderGridPanel::~BorderGridPanel() {
-    // Nothing to destroy manually
+	// Nothing to destroy manually
 }
 
 void BorderGridPanel::SetItemId(BorderEdgePosition pos, uint16_t itemId) {
-    if (pos >= 0 && pos < EDGE_COUNT) {
-        m_items[pos] = itemId;
-        Refresh();
-    }
+	if (pos >= 0 && pos < EDGE_COUNT) {
+		m_items[pos] = itemId;
+		Refresh();
+	}
 }
 
 uint16_t BorderGridPanel::GetItemId(BorderEdgePosition pos) const {
-    auto it = m_items.find(pos);
-    if (it != m_items.end()) {
-        return it->second;
-    }
-    return 0;
+	auto it = m_items.find(pos);
+	if (it != m_items.end()) {
+		return it->second;
+	}
+	return 0;
 }
 
 void BorderGridPanel::Clear() {
-    for (auto& item : m_items) {
-        item.second = 0;
-    }
-    Refresh();
+	for (auto &item : m_items) {
+		item.second = 0;
+	}
+	Refresh();
 }
 
 void BorderGridPanel::SetSelectedPosition(BorderEdgePosition pos) {
-    m_selectedPosition = pos;
-    Refresh();
+	m_selectedPosition = pos;
+	Refresh();
 }
 
 // Helper to calculate grid metrics
 // struct GridMetrics { ... } // MOVED TO TOP OF FILE
 
-void BorderGridPanel::OnPaint(wxPaintEvent& event) {
-    wxAutoBufferedPaintDC dc(this);
-    
-    // Draw the panel background using system colors
-    wxRect rect = GetClientRect();
-    dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
-    dc.Clear();
-    
-    GridMetrics m(rect.GetSize());
-    
-    // Draw the grid layout
-    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-    dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    
-    // Helper function to draw a grid
-    auto drawGrid = [&](int offsetX, int offsetY, int gridSize, int cellSize) {
-        for (int i = 0; i <= gridSize; i++) {
-            dc.DrawLine(
-                offsetX + i * cellSize, 
-                offsetY, 
-                offsetX + i * cellSize, 
-                offsetY + gridSize * cellSize
-            );
-            
-            // Horizontal lines
-            dc.DrawLine(
-                offsetX, 
-                offsetY + i * cellSize, 
-                offsetX + gridSize * cellSize, 
-                offsetY + i * cellSize
-            );
-        }
-    };
-    
-    // Draw the three grid sections
-    drawGrid(m.normalX, m.normalY, 2, m.cellSize);
-    drawGrid(m.cornerX, m.cornerY, 2, m.cellSize);
-    drawGrid(m.diagX, m.diagY, 2, m.cellSize);
-    
-    // Set font for position labels
-    dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-    // Scale font size roughly
-    font.SetPixelSize(wxSize(0, std::max(10, m.cellSize / 4)));
-    dc.SetFont(font);
-    
-    int padding = 2; // Fixed small padding to maximize sprite size
-    
-    // Function to draw an item at a position
-    auto drawItemAtPos = [&](BorderEdgePosition pos, int gridX, int gridY, int offsetX, int offsetY) {
-        int x = offsetX + gridX * m.cellSize + padding;
-        int y = offsetY + gridY * m.cellSize + padding;
-        int size = m.cellSize - 2 * padding;
-        
-        // Highlight selected position
-        if (pos == m_selectedPosition) {
-            // "Selection Blue" border, transparent fill to keep sprite visible
-            dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
-            dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.DrawRectangle(x - padding, y - padding, m.cellSize, m.cellSize);
-        }
-        
-        // Draw sprite if available
-        uint16_t itemId = GetItemId(pos);
-        if (itemId > 0) {
-            const ItemType& type = g_items.getItemType(itemId);
-            if (type.id != 0) {
-                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
-                if (sprite) {
-                    // Local scaling: Draw to temp DC, extract bitmap, scale, then draw
-                    wxMemoryDC tempDC;
-                    wxBitmap tempBitmap(32, 32);
-                    tempDC.SelectObject(tempBitmap);
-                    tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
-                    tempDC.Clear();
-                    
-                    // Draw sprite at native size to temp DC
-                    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
-                    
-                    tempDC.SelectObject(wxNullBitmap);
-                    
-                    // Convert to image, scale, and draw
-                    wxImage img = tempBitmap.ConvertToImage();
-                    if (img.IsOk()) {
-                        img.Rescale(size, size, wxIMAGE_QUALITY_NEAREST);
-                        wxBitmap scaledBmp(img);
-                        dc.DrawBitmap(scaledBmp, x, y, true);
-                    }
-                }
-            }
-        } else {
-            // Only draw text label if NO item is present to prevent overlap
-            wxString label = wxstr(edgePositionToString(pos));
-            wxSize textSize = dc.GetTextExtent(label);
-            
-            // Center text
-            dc.DrawText(label, x + (size - textSize.GetWidth()) / 2, 
-                      y + size - textSize.GetHeight());
-        }
-    };
-    
-    // Draw normal direction items
-    drawItemAtPos(EDGE_N, 0, 0, m.normalX, m.normalY);
-    drawItemAtPos(EDGE_E, 1, 0, m.normalX, m.normalY);
-    drawItemAtPos(EDGE_S, 0, 1, m.normalX, m.normalY);
-    drawItemAtPos(EDGE_W, 1, 1, m.normalX, m.normalY);
-    
-    // Draw corner items
-    drawItemAtPos(EDGE_CNW, 0, 0, m.cornerX, m.cornerY);
-    drawItemAtPos(EDGE_CNE, 1, 0, m.cornerX, m.cornerY);
-    drawItemAtPos(EDGE_CSW, 0, 1, m.cornerX, m.cornerY);
-    drawItemAtPos(EDGE_CSE, 1, 1, m.cornerX, m.cornerY);
-    
-    // Draw diagonal items
-    drawItemAtPos(EDGE_DNW, 0, 0, m.diagX, m.diagY);
-    drawItemAtPos(EDGE_DNE, 1, 0, m.diagX, m.diagY);
-    drawItemAtPos(EDGE_DSW, 0, 1, m.diagX, m.diagY);
-    drawItemAtPos(EDGE_DSE, 1, 1, m.diagX, m.diagY);
+void BorderGridPanel::OnPaint(wxPaintEvent &event) {
+	wxAutoBufferedPaintDC dc(this);
+
+	// Draw the panel background using system colors
+	wxRect rect = GetClientRect();
+	dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+	dc.Clear();
+
+	GridMetrics m(rect.GetSize());
+
+	// Draw the grid layout
+	dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+
+	// Helper function to draw a grid
+	auto drawGrid = [&](int offsetX, int offsetY, int gridSize, int cellSize) {
+		for (int i = 0; i <= gridSize; i++) {
+			dc.DrawLine(
+				offsetX + i * cellSize,
+				offsetY,
+				offsetX + i * cellSize,
+				offsetY + gridSize * cellSize
+			);
+
+			// Horizontal lines
+			dc.DrawLine(
+				offsetX,
+				offsetY + i * cellSize,
+				offsetX + gridSize * cellSize,
+				offsetY + i * cellSize
+			);
+		}
+	};
+
+	// Draw the three grid sections
+	drawGrid(m.normalX, m.normalY, 2, m.cellSize);
+	drawGrid(m.cornerX, m.cornerY, 2, m.cellSize);
+	drawGrid(m.diagX, m.diagY, 2, m.cellSize);
+
+	// Set font for position labels
+	dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	// Scale font size roughly
+	font.SetPixelSize(wxSize(0, std::max(10, m.cellSize / 4)));
+	dc.SetFont(font);
+
+	int padding = 2; // Fixed small padding to maximize sprite size
+
+	// Function to draw an item at a position
+	auto drawItemAtPos = [&](BorderEdgePosition pos, int gridX, int gridY, int offsetX, int offsetY) {
+		int x = offsetX + gridX * m.cellSize + padding;
+		int y = offsetY + gridY * m.cellSize + padding;
+		int size = m.cellSize - 2 * padding;
+
+		// Highlight selected position
+		if (pos == m_selectedPosition) {
+			// "Selection Blue" border, transparent fill to keep sprite visible
+			dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
+			dc.SetBrush(*wxTRANSPARENT_BRUSH);
+			dc.DrawRectangle(x - padding, y - padding, m.cellSize, m.cellSize);
+		}
+
+		// Draw sprite if available
+		uint16_t itemId = GetItemId(pos);
+		if (itemId > 0) {
+			const ItemType &type = g_items.getItemType(itemId);
+			if (type.id != 0) {
+				Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+				if (sprite) {
+					// Local scaling: Draw to temp DC, extract bitmap, scale, then draw
+					wxMemoryDC tempDC;
+					wxBitmap tempBitmap(32, 32);
+					tempDC.SelectObject(tempBitmap);
+					tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+					tempDC.Clear();
+
+					// Draw sprite at native size to temp DC
+					sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
+
+					tempDC.SelectObject(wxNullBitmap);
+
+					// Convert to image, scale, and draw
+					wxImage img = tempBitmap.ConvertToImage();
+					if (img.IsOk()) {
+						img.Rescale(size, size, wxIMAGE_QUALITY_NEAREST);
+						wxBitmap scaledBmp(img);
+						dc.DrawBitmap(scaledBmp, x, y, true);
+					}
+				}
+			}
+		} else {
+			// Only draw text label if NO item is present to prevent overlap
+			wxString label = wxstr(edgePositionToString(pos));
+			wxSize textSize = dc.GetTextExtent(label);
+
+			// Center text
+			dc.DrawText(label, x + (size - textSize.GetWidth()) / 2, y + size - textSize.GetHeight());
+		}
+	};
+
+	// Draw normal direction items
+	drawItemAtPos(EDGE_N, 0, 0, m.normalX, m.normalY);
+	drawItemAtPos(EDGE_E, 1, 0, m.normalX, m.normalY);
+	drawItemAtPos(EDGE_S, 0, 1, m.normalX, m.normalY);
+	drawItemAtPos(EDGE_W, 1, 1, m.normalX, m.normalY);
+
+	// Draw corner items
+	drawItemAtPos(EDGE_CNW, 0, 0, m.cornerX, m.cornerY);
+	drawItemAtPos(EDGE_CNE, 1, 0, m.cornerX, m.cornerY);
+	drawItemAtPos(EDGE_CSW, 0, 1, m.cornerX, m.cornerY);
+	drawItemAtPos(EDGE_CSE, 1, 1, m.cornerX, m.cornerY);
+
+	// Draw diagonal items
+	drawItemAtPos(EDGE_DNW, 0, 0, m.diagX, m.diagY);
+	drawItemAtPos(EDGE_DNE, 1, 0, m.diagX, m.diagY);
+	drawItemAtPos(EDGE_DSW, 0, 1, m.diagX, m.diagY);
+	drawItemAtPos(EDGE_DSE, 1, 1, m.diagX, m.diagY);
 }
 
 wxPoint BorderGridPanel::GetPositionCoordinates(BorderEdgePosition pos) const {
-    switch (pos) {
-        case EDGE_N:   return wxPoint(1, 0);
-        case EDGE_E:   return wxPoint(2, 1);
-        case EDGE_S:   return wxPoint(1, 2);
-        case EDGE_W:   return wxPoint(0, 1);
-        case EDGE_CNW: return wxPoint(0, 0);
-        case EDGE_CNE: return wxPoint(2, 0);
-        case EDGE_CSE: return wxPoint(2, 2);
-        case EDGE_CSW: return wxPoint(0, 2);
-        case EDGE_DNW: return wxPoint(0.5, 0.5);
-        case EDGE_DNE: return wxPoint(1.5, 0.5);
-        case EDGE_DSE: return wxPoint(1.5, 1.5);
-        case EDGE_DSW: return wxPoint(0.5, 1.5);
-        default:       return wxPoint(-1, -1);
-    }
+	switch (pos) {
+		case EDGE_N:
+			return wxPoint(1, 0);
+		case EDGE_E:
+			return wxPoint(2, 1);
+		case EDGE_S:
+			return wxPoint(1, 2);
+		case EDGE_W:
+			return wxPoint(0, 1);
+		case EDGE_CNW:
+			return wxPoint(0, 0);
+		case EDGE_CNE:
+			return wxPoint(2, 0);
+		case EDGE_CSE:
+			return wxPoint(2, 2);
+		case EDGE_CSW:
+			return wxPoint(0, 2);
+		case EDGE_DNW:
+			return wxPoint(0.5, 0.5);
+		case EDGE_DNE:
+			return wxPoint(1.5, 0.5);
+		case EDGE_DSE:
+			return wxPoint(1.5, 1.5);
+		case EDGE_DSW:
+			return wxPoint(0.5, 1.5);
+		default:
+			return wxPoint(-1, -1);
+	}
 }
 
-BorderEdgePosition BorderGridPanel::GetPositionFromCoordinates(int x, int y) const
-{
-    GridMetrics m(GetClientSize());
-    
-    const int block_width = 2 * m.cellSize;
-    const int block_height = 2 * m.cellSize;
-    
-    // Check which grid section the click is in and calculate the grid cell
-    
-    // Normal grid
-    if (x >= m.normalX && x < m.normalX + block_width &&
-        y >= m.normalY && y < m.normalY + block_height) {
-        
-        int gridX = (x - m.normalX) / m.cellSize;
-        int gridY = (y - m.normalY) / m.cellSize;
-        
-        if (gridX == 0 && gridY == 0) return EDGE_N;
-        if (gridX == 1 && gridY == 0) return EDGE_E;
-        if (gridX == 0 && gridY == 1) return EDGE_S;
-        if (gridX == 1 && gridY == 1) return EDGE_W;
-    }
-    
-    // Corner grid
-    if (x >= m.cornerX && x < m.cornerX + block_width &&
-        y >= m.cornerY && y < m.cornerY + block_height) {
-        
-        int gridX = (x - m.cornerX) / m.cellSize;
-        int gridY = (y - m.cornerY) / m.cellSize;
-        
-        if (gridX == 0 && gridY == 0) return EDGE_CNW;
-        if (gridX == 1 && gridY == 0) return EDGE_CNE;
-        if (gridX == 0 && gridY == 1) return EDGE_CSW;
-        if (gridX == 1 && gridY == 1) return EDGE_CSE;
-    }
-    
-    // Diagonal grid
-    if (x >= m.diagX && x < m.diagX + block_width &&
-        y >= m.diagY && y < m.diagY + block_height) {
-        
-        int gridX = (x - m.diagX) / m.cellSize;
-        int gridY = (y - m.diagY) / m.cellSize;
-        
-        if (gridX == 0 && gridY == 0) return EDGE_DNW;
-        if (gridX == 1 && gridY == 0) return EDGE_DNE;
-        if (gridX == 0 && gridY == 1) return EDGE_DSW;
-        if (gridX == 1 && gridY == 1) return EDGE_DSE;
-    }
-    
-    return EDGE_NONE;
+BorderEdgePosition BorderGridPanel::GetPositionFromCoordinates(int x, int y) const {
+	GridMetrics m(GetClientSize());
+
+	const int block_width = 2 * m.cellSize;
+	const int block_height = 2 * m.cellSize;
+
+	// Check which grid section the click is in and calculate the grid cell
+
+	// Normal grid
+	if (x >= m.normalX && x < m.normalX + block_width && y >= m.normalY && y < m.normalY + block_height) {
+
+		int gridX = (x - m.normalX) / m.cellSize;
+		int gridY = (y - m.normalY) / m.cellSize;
+
+		if (gridX == 0 && gridY == 0) {
+			return EDGE_N;
+		}
+		if (gridX == 1 && gridY == 0) {
+			return EDGE_E;
+		}
+		if (gridX == 0 && gridY == 1) {
+			return EDGE_S;
+		}
+		if (gridX == 1 && gridY == 1) {
+			return EDGE_W;
+		}
+	}
+
+	// Corner grid
+	if (x >= m.cornerX && x < m.cornerX + block_width && y >= m.cornerY && y < m.cornerY + block_height) {
+
+		int gridX = (x - m.cornerX) / m.cellSize;
+		int gridY = (y - m.cornerY) / m.cellSize;
+
+		if (gridX == 0 && gridY == 0) {
+			return EDGE_CNW;
+		}
+		if (gridX == 1 && gridY == 0) {
+			return EDGE_CNE;
+		}
+		if (gridX == 0 && gridY == 1) {
+			return EDGE_CSW;
+		}
+		if (gridX == 1 && gridY == 1) {
+			return EDGE_CSE;
+		}
+	}
+
+	// Diagonal grid
+	if (x >= m.diagX && x < m.diagX + block_width && y >= m.diagY && y < m.diagY + block_height) {
+
+		int gridX = (x - m.diagX) / m.cellSize;
+		int gridY = (y - m.diagY) / m.cellSize;
+
+		if (gridX == 0 && gridY == 0) {
+			return EDGE_DNW;
+		}
+		if (gridX == 1 && gridY == 0) {
+			return EDGE_DNE;
+		}
+		if (gridX == 0 && gridY == 1) {
+			return EDGE_DSW;
+		}
+		if (gridX == 1 && gridY == 1) {
+			return EDGE_DSE;
+		}
+	}
+
+	return EDGE_NONE;
 }
 
 wxSize BorderGridPanel::DoGetBestSize() const {
-    const int grid_cell_size = 64;
-    const int SECTION_SPACING = 20;
-    const int MARGIN = 10;
-    
-    // 3 blocks of 2 cells each, plus 2 spacings, plus side margins
-    int width = MARGIN + (2 * grid_cell_size) + SECTION_SPACING + 
-                (2 * grid_cell_size) + SECTION_SPACING + 
-                (2 * grid_cell_size) + MARGIN;
-                
-    // 1 block height plus margins
-    int height = MARGIN + (2 * grid_cell_size) + MARGIN;
-    
-    return wxSize(width, height);
+	const int grid_cell_size = 64;
+	const int SECTION_SPACING = 20;
+	const int MARGIN = 10;
+
+	// 3 blocks of 2 cells each, plus 2 spacings, plus side margins
+	int width = MARGIN + (2 * grid_cell_size) + SECTION_SPACING + (2 * grid_cell_size) + SECTION_SPACING + (2 * grid_cell_size) + MARGIN;
+
+	// 1 block height plus margins
+	int height = MARGIN + (2 * grid_cell_size) + MARGIN;
+
+	return wxSize(width, height);
 }
 
-void BorderGridPanel::OnMouseClick(wxMouseEvent& event) {
-    int x = event.GetX();
-    int y = event.GetY();
-    
-    BorderEdgePosition pos = GetPositionFromCoordinates(x, y);
-    if (pos != EDGE_NONE) {
-        // Set the position as selected in the grid
-        SetSelectedPosition(pos);
-        
-        // Notify the parent dialog that a position was selected
-        wxCommandEvent selEvent(wxEVT_COMMAND_BUTTON_CLICKED, ID_BORDER_GRID_SELECT);
-        selEvent.SetInt(static_cast<int>(pos));
-        
-        // Find the parent BorderEditorPanel
-        wxWindow* parent = GetParent();
-        while (parent && !dynamic_cast<BorderEditorPanel*>(parent)) {
-            parent = parent->GetParent();
-        }
-        
-        // Send the event to the parent dialog
-        BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(parent);
-        if (dialog) {
-            // Call the event handler directly
-            wxLogDebug("BorderGridPanel::OnMouseClick: Calling OnPositionSelected directly for position %s", wxstr(edgePositionToString(pos)));
-            dialog->OnPositionSelected(selEvent);
-        } else {
-            // If we couldn't find the parent dialog, post the event to the parent
-            wxLogDebug("BorderGridPanel::OnMouseClick: Could not find BorderEditorPanel parent, posting event");
-            wxPostEvent(GetParent(), selEvent);
-        }
-    }
+void BorderGridPanel::OnMouseClick(wxMouseEvent &event) {
+	int x = event.GetX();
+	int y = event.GetY();
+
+	BorderEdgePosition pos = GetPositionFromCoordinates(x, y);
+	if (pos != EDGE_NONE) {
+		// Set the position as selected in the grid
+		SetSelectedPosition(pos);
+
+		// Notify the parent dialog that a position was selected
+		wxCommandEvent selEvent(wxEVT_COMMAND_BUTTON_CLICKED, ID_BORDER_GRID_SELECT);
+		selEvent.SetInt(static_cast<int>(pos));
+
+		// Find the parent BorderEditorPanel
+		wxWindow* parent = GetParent();
+		while (parent && !dynamic_cast<BorderEditorPanel*>(parent)) {
+			parent = parent->GetParent();
+		}
+
+		// Send the event to the parent dialog
+		BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(parent);
+		if (dialog) {
+			// Call the event handler directly
+			wxLogDebug("BorderGridPanel::OnMouseClick: Calling OnPositionSelected directly for position %s", wxstr(edgePositionToString(pos)));
+			dialog->OnPositionSelected(selEvent);
+		} else {
+			// If we couldn't find the parent dialog, post the event to the parent
+			wxLogDebug("BorderGridPanel::OnMouseClick: Could not find BorderEditorPanel parent, posting event");
+			wxPostEvent(GetParent(), selEvent);
+		}
+	}
 }
 
-void BorderGridPanel::OnMouseDown(wxMouseEvent& event) {
-    // Get the position from the coordinates
-    BorderEdgePosition pos = GetPositionFromCoordinates(event.GetX(), event.GetY());
-    
-    // Set the selected position
-    SetSelectedPosition(pos);
-    
-    event.Skip();
+void BorderGridPanel::OnMouseDown(wxMouseEvent &event) {
+	// Get the position from the coordinates
+	BorderEdgePosition pos = GetPositionFromCoordinates(event.GetX(), event.GetY());
+
+	// Set the selected position
+	SetSelectedPosition(pos);
+
+	event.Skip();
 }
 
 // ============================================================================
 // BorderPreviewPanel
 
 BorderPreviewPanel::BorderPreviewPanel(wxWindow* parent, wxWindowID id) :
-    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize) { // Use default size, let sizer expand
-    // Set up the panel to handle painting
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
-    
-    // Enable Full Repaint on Resize
-    SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
+	wxPanel(parent, id, wxDefaultPosition, wxDefaultSize) { // Use default size, let sizer expand
+	// Set up the panel to handle painting
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+	// Enable Full Repaint on Resize
+	SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
 }
 
 BorderPreviewPanel::~BorderPreviewPanel() {
-    // Nothing to destroy manually
+	// Nothing to destroy manually
 }
 
-void BorderPreviewPanel::SetBorderItems(const std::vector<BorderItem>& items) {
-    m_borderItems = items;
-    Refresh();
+void BorderPreviewPanel::SetBorderItems(const std::vector<BorderItem> &items) {
+	m_borderItems = items;
+	Refresh();
 }
 
 void BorderPreviewPanel::Clear() {
-    m_borderItems.clear();
-    Refresh();
+	m_borderItems.clear();
+	Refresh();
 }
 
-void BorderPreviewPanel::OnPaint(wxPaintEvent& event) {
-    wxAutoBufferedPaintDC dc(this);
-    
-    // Get panel dimensions
-    wxRect rect = GetClientRect();
-    int panelWidth = rect.GetWidth();
-    int panelHeight = rect.GetHeight();
-    
-    // Use parent's background instead of filling entire panel with grey
-    dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
-    dc.Clear();
-    
-    // 5x5 Cross Test Pattern for comprehensive border verification
-    const int GRID_SIZE = 5;
-    const int TITLE_HEIGHT = 25;  // Space for the title label
-    const int MARGIN = 5;         // Small margin around the grid
-    
-    // *** DYNAMIC CELL SIZE: Calculate based on available space (like BorderGridPanel) ***
-    int availableWidth = panelWidth - 2 * MARGIN;
-    int availableHeight = panelHeight - TITLE_HEIGHT - 2 * MARGIN;
-    
-    // Calculate cell size to fit the 5x5 grid in available space
-    int cellSize = std::min(availableWidth / GRID_SIZE, availableHeight / GRID_SIZE);
-    
-    // Enforce minimum and maximum cell size for visual consistency
-    if (cellSize < 32) cellSize = 32;   // Minimum: match native sprite size
-    if (cellSize > 64) cellSize = 64;   // Maximum: don't go too large
-    
-    int totalGridSize = GRID_SIZE * cellSize;
-    
-    // Center grid in the panel
-    int startX = (panelWidth - totalGridSize) / 2;
-    int startY = TITLE_HEIGHT + (availableHeight - totalGridSize) / 2;
-    
-    // Ensure grid doesn't go above the title
-    if (startY < TITLE_HEIGHT) {
-        startY = TITLE_HEIGHT;
-    }
-    
-    // Visual Polish: Add "Preview" label at the top
-    dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-    font.MakeBold();
-    dc.SetFont(font);
-    
-    wxString label = "Preview (5x5 Test Pattern)";
-    wxSize textSize = dc.GetTextExtent(label);
-    dc.DrawText(label, (panelWidth - textSize.GetWidth()) / 2, 5);
-    
-    // *** TIGHT BACKGROUND: Draw grey background exactly around the grid (1px border) ***
-    const int BORDER_WIDTH = 1;
-    wxRect gridBgRect(
-        startX - BORDER_WIDTH,
-        startY - BORDER_WIDTH,
-        totalGridSize + 2 * BORDER_WIDTH,
-        totalGridSize + 2 * BORDER_WIDTH
-    );
-    dc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
-    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-    dc.DrawRectangle(gridBgRect);
-    
-    // Draw grid lines for the 5x5 area
-    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-    
-    // Vertical lines
-    for (int i = 0; i <= GRID_SIZE; i++) {
-        dc.DrawLine(startX + i * cellSize, startY, 
-                    startX + i * cellSize, startY + totalGridSize);
-    }
-    
-    // Horizontal lines
-    for (int i = 0; i <= GRID_SIZE; i++) {
-        dc.DrawLine(startX, startY + i * cellSize, 
-                    startX + totalGridSize, startY + i * cellSize);
-    }
-    
-    // Helper lambda: Get the target edge for a grid position (x, y)
-    auto getEdgeAtPosition = [](int x, int y) -> BorderEdgePosition {
-        // Row 0
-        if (y == 0) {
-            if (x == 1) return EDGE_CSE;
-            if (x == 2) return EDGE_S;
-            if (x == 3) return EDGE_CSW;
-        }
-        // Row 1
-        else if (y == 1) {
-            if (x == 0) return EDGE_CSE;
-            if (x == 1) return EDGE_DSE;
-            if (x == 3) return EDGE_DSW;
-            if (x == 4) return EDGE_CSW;
-        }
-        // Row 2 (Center row)
-        else if (y == 2) {
-            if (x == 0) return EDGE_E;
-            if (x == 4) return EDGE_W;
-            // x=2 is center ground (empty)
-        }
-        // Row 3
-        else if (y == 3) {
-            if (x == 0) return EDGE_CNE;
-            if (x == 1) return EDGE_DNE;
-            if (x == 3) return EDGE_DNW;
-            if (x == 4) return EDGE_CNW;
-        }
-        // Row 4
-        else if (y == 4) {
-            if (x == 1) return EDGE_CNE;
-            if (x == 2) return EDGE_N;
-            if (x == 3) return EDGE_CNW;
-        }
-        
-        return static_cast<BorderEdgePosition>(-1); // No edge for this cell
-    };
-    
-    // *** SPRITE SCALING: Use same technique as BorderGridPanel for consistency ***
-    const int spritePadding = 2;  // Small padding within each cell
-    const int spriteSize = cellSize - 2 * spritePadding;
-    
-    // Draw border items based on the cross pattern
-    for (int y = 0; y < GRID_SIZE; y++) {
-        for (int x = 0; x < GRID_SIZE; x++) {
-            BorderEdgePosition targetEdge = getEdgeAtPosition(x, y);
-            
-            if (targetEdge == static_cast<BorderEdgePosition>(-1)) {
-                continue; // Empty cell
-            }
-            
-            // Search for an item with this edge position
-            for (const BorderItem& item : m_borderItems) {
-                if (item.position == targetEdge) {
-                    int cellX = startX + x * cellSize + spritePadding;
-                    int cellY = startY + y * cellSize + spritePadding;
-                    
-                    // Draw the item sprite using same scaling as BorderGridPanel
-                    const ItemType& type = g_items.getItemType(item.itemId);
-                    if (type.id != 0) {
-                        Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
-                        if (sprite) {
-                            // Create temp bitmap, draw sprite at native size, then scale
-                            wxMemoryDC tempDC;
-                            wxBitmap tempBitmap(32, 32);
-                            tempDC.SelectObject(tempBitmap);
-                            tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
-                            tempDC.Clear();
-                            
-                            // Draw sprite at native 32x32 size to temp DC
-                            sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
-                            
-                            tempDC.SelectObject(wxNullBitmap);
-                            
-                            // Convert to image, scale to fill cell, and draw
-                            wxImage img = tempBitmap.ConvertToImage();
-                            if (img.IsOk()) {
-                                // Scale to fit the cell (dynamic size)
-                                img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
-                                wxBitmap scaledBmp(img);
-                                dc.DrawBitmap(scaledBmp, cellX, cellY, true);
-                            }
-                        }
-                    }
-                    break; // Found and drawn, move to next grid cell
-                }
-            }
-        }
-    }
+void BorderPreviewPanel::OnPaint(wxPaintEvent &event) {
+	wxAutoBufferedPaintDC dc(this);
+
+	// Get panel dimensions
+	wxRect rect = GetClientRect();
+	int panelWidth = rect.GetWidth();
+	int panelHeight = rect.GetHeight();
+
+	// Use parent's background instead of filling entire panel with grey
+	dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
+	dc.Clear();
+
+	// 5x5 Cross Test Pattern for comprehensive border verification
+	const int GRID_SIZE = 5;
+	const int TITLE_HEIGHT = 25; // Space for the title label
+	const int MARGIN = 5; // Small margin around the grid
+
+	// *** DYNAMIC CELL SIZE: Calculate based on available space (like BorderGridPanel) ***
+	int availableWidth = panelWidth - 2 * MARGIN;
+	int availableHeight = panelHeight - TITLE_HEIGHT - 2 * MARGIN;
+
+	// Calculate cell size to fit the 5x5 grid in available space
+	int cellSize = std::min(availableWidth / GRID_SIZE, availableHeight / GRID_SIZE);
+
+	// Enforce minimum and maximum cell size for visual consistency
+	if (cellSize < 32) {
+		cellSize = 32; // Minimum: match native sprite size
+	}
+	if (cellSize > 64) {
+		cellSize = 64; // Maximum: don't go too large
+	}
+
+	int totalGridSize = GRID_SIZE * cellSize;
+
+	// Center grid in the panel
+	int startX = (panelWidth - totalGridSize) / 2;
+	int startY = TITLE_HEIGHT + (availableHeight - totalGridSize) / 2;
+
+	// Ensure grid doesn't go above the title
+	if (startY < TITLE_HEIGHT) {
+		startY = TITLE_HEIGHT;
+	}
+
+	// Visual Polish: Add "Preview" label at the top
+	dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	font.MakeBold();
+	dc.SetFont(font);
+
+	wxString label = "Preview (5x5 Test Pattern)";
+	wxSize textSize = dc.GetTextExtent(label);
+	dc.DrawText(label, (panelWidth - textSize.GetWidth()) / 2, 5);
+
+	// *** TIGHT BACKGROUND: Draw grey background exactly around the grid (1px border) ***
+	const int BORDER_WIDTH = 1;
+	wxRect gridBgRect(
+		startX - BORDER_WIDTH,
+		startY - BORDER_WIDTH,
+		totalGridSize + 2 * BORDER_WIDTH,
+		totalGridSize + 2 * BORDER_WIDTH
+	);
+	dc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+	dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+	dc.DrawRectangle(gridBgRect);
+
+	// Draw grid lines for the 5x5 area
+	dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+
+	// Vertical lines
+	for (int i = 0; i <= GRID_SIZE; i++) {
+		dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + totalGridSize);
+	}
+
+	// Horizontal lines
+	for (int i = 0; i <= GRID_SIZE; i++) {
+		dc.DrawLine(startX, startY + i * cellSize, startX + totalGridSize, startY + i * cellSize);
+	}
+
+	// Helper lambda: Get the target edge for a grid position (x, y)
+	auto getEdgeAtPosition = [](int x, int y) -> BorderEdgePosition {
+		// Row 0
+		if (y == 0) {
+			if (x == 1) {
+				return EDGE_CSE;
+			}
+			if (x == 2) {
+				return EDGE_S;
+			}
+			if (x == 3) {
+				return EDGE_CSW;
+			}
+		}
+		// Row 1
+		else if (y == 1) {
+			if (x == 0) {
+				return EDGE_CSE;
+			}
+			if (x == 1) {
+				return EDGE_DSE;
+			}
+			if (x == 3) {
+				return EDGE_DSW;
+			}
+			if (x == 4) {
+				return EDGE_CSW;
+			}
+		}
+		// Row 2 (Center row)
+		else if (y == 2) {
+			if (x == 0) {
+				return EDGE_E;
+			}
+			if (x == 4) {
+				return EDGE_W;
+			}
+			// x=2 is center ground (empty)
+		}
+		// Row 3
+		else if (y == 3) {
+			if (x == 0) {
+				return EDGE_CNE;
+			}
+			if (x == 1) {
+				return EDGE_DNE;
+			}
+			if (x == 3) {
+				return EDGE_DNW;
+			}
+			if (x == 4) {
+				return EDGE_CNW;
+			}
+		}
+		// Row 4
+		else if (y == 4) {
+			if (x == 1) {
+				return EDGE_CNE;
+			}
+			if (x == 2) {
+				return EDGE_N;
+			}
+			if (x == 3) {
+				return EDGE_CNW;
+			}
+		}
+
+		return static_cast<BorderEdgePosition>(-1); // No edge for this cell
+	};
+
+	// *** SPRITE SCALING: Use same technique as BorderGridPanel for consistency ***
+	const int spritePadding = 2; // Small padding within each cell
+	const int spriteSize = cellSize - 2 * spritePadding;
+
+	// Draw border items based on the cross pattern
+	for (int y = 0; y < GRID_SIZE; y++) {
+		for (int x = 0; x < GRID_SIZE; x++) {
+			BorderEdgePosition targetEdge = getEdgeAtPosition(x, y);
+
+			if (targetEdge == static_cast<BorderEdgePosition>(-1)) {
+				continue; // Empty cell
+			}
+
+			// Search for an item with this edge position
+			for (const BorderItem &item : m_borderItems) {
+				if (item.position == targetEdge) {
+					int cellX = startX + x * cellSize + spritePadding;
+					int cellY = startY + y * cellSize + spritePadding;
+
+					// Draw the item sprite using same scaling as BorderGridPanel
+					const ItemType &type = g_items.getItemType(item.itemId);
+					if (type.id != 0) {
+						Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+						if (sprite) {
+							// Create temp bitmap, draw sprite at native size, then scale
+							wxMemoryDC tempDC;
+							wxBitmap tempBitmap(32, 32);
+							tempDC.SelectObject(tempBitmap);
+							tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+							tempDC.Clear();
+
+							// Draw sprite at native 32x32 size to temp DC
+							sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
+
+							tempDC.SelectObject(wxNullBitmap);
+
+							// Convert to image, scale to fill cell, and draw
+							wxImage img = tempBitmap.ConvertToImage();
+							if (img.IsOk()) {
+								// Scale to fit the cell (dynamic size)
+								img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
+								wxBitmap scaledBmp(img);
+								dc.DrawBitmap(scaledBmp, cellX, cellY, true);
+							}
+						}
+					}
+					break; // Found and drawn, move to next grid cell
+				}
+			}
+		}
+	}
 }
 
 void BorderEditorPanel::LoadExistingGroundBrushes() {
-    // Legacy method - ground brushes are now populated via PopulateGroundList()
-    // Called from constructor for compatibility, actual population happens on tab change
+	// Legacy method - ground brushes are now populated via PopulateGroundList()
+	// Called from constructor for compatibility, actual population happens on tab change
 }
 void BorderEditorPanel::ClearGroundItems(bool clearBrowser) {
-    if (m_groundGridContainer) m_groundGridContainer->Clear();
-    if (m_groundNameCtrl) m_groundNameCtrl->SetValue("");
-    if (m_zOrderCtrl) m_zOrderCtrl->SetValue(0);
-    
-    // Reset border alignment options
-    if (m_includeToNoneCheck) m_includeToNoneCheck->SetValue(true);
-    if (m_includeInnerCheck) m_includeInnerCheck->SetValue(false);
-    if (m_borderAlignmentButton) {
-        m_borderAlignmentSelection = 0;
-        m_borderAlignmentButton->SetLabel("Outer \u25BC");
-    }
-    if (m_groundPreviewPanel) m_groundPreviewPanel->SetWeightedItems({}); // Clear preview
+	if (m_groundGridContainer) {
+		m_groundGridContainer->Clear();
+	}
+	if (m_groundNameCtrl) {
+		m_groundNameCtrl->SetValue("");
+	}
+	if (m_zOrderCtrl) {
+		m_zOrderCtrl->SetValue(0);
+	}
 
-    // Deselect browser list
-    if (clearBrowser && m_borderBrowserList) {
-        m_borderBrowserList->SetSelection(wxNOT_FOUND);
-        m_selectedBrowserTileId = 0;
-    }
+	// Reset border alignment options
+	if (m_includeToNoneCheck) {
+		m_includeToNoneCheck->SetValue(true);
+	}
+	if (m_includeInnerCheck) {
+		m_includeInnerCheck->SetValue(false);
+	}
+	if (m_borderAlignmentButton) {
+		m_borderAlignmentSelection = 0;
+		m_borderAlignmentButton->SetLabel("Outer \u25BC");
+	}
+	if (m_groundPreviewPanel) {
+		m_groundPreviewPanel->SetWeightedItems({}); // Clear preview
+	}
+
+	// Deselect browser list
+	if (clearBrowser && m_borderBrowserList) {
+		m_borderBrowserList->SetSelection(wxNOT_FOUND);
+		m_selectedBrowserTileId = 0;
+	}
 }
 
-void BorderEditorPanel::OnPageChanged(wxBookCtrlEvent& event) {
-    SaveCurrentDraft(false);
+void BorderEditorPanel::OnPageChanged(wxBookCtrlEvent &event) {
+	SaveCurrentDraft(false);
 
-    m_activeTab = event.GetSelection();
+	m_activeTab = event.GetSelection();
 
-    LoadTilesets();
+	LoadTilesets();
 
-    if (m_browserSearchCtrl) {
-        m_browserSearchCtrl->Clear();
-    }
+	if (m_browserSearchCtrl) {
+		m_browserSearchCtrl->Clear();
+	}
 
-    UpdateBrowserLabel();
+	UpdateBrowserLabel();
 
-    if (m_newButton) {
-        switch (m_activeTab) {
-            case 0: m_newButton->SetLabel("New Border"); break;
-            case 1: m_newButton->SetLabel("New Ground"); break;
-            case 2: m_newButton->SetLabel("New Wall"); break;
-        }
-    }
+	if (m_newButton) {
+		switch (m_activeTab) {
+			case 0:
+				m_newButton->SetLabel("New Border");
+				break;
+			case 1:
+				m_newButton->SetLabel("New Ground");
+				break;
+			case 2:
+				m_newButton->SetLabel("New Wall");
+				break;
+		}
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 
-    if (m_selectedBrowserTileId != 0) {
-        RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
-        switch (m_activeTab) {
-            case 0: LoadBorderByMainTileId(m_selectedBrowserTileId); break;
-            case 1: LoadGroundBrushByMainTileId(m_selectedBrowserTileId); break;
-            case 2: LoadWallBrushByMainTileId(m_selectedBrowserTileId); break;
-        }
-    }
+	if (m_selectedBrowserTileId != 0) {
+		RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
+		switch (m_activeTab) {
+			case 0:
+				LoadBorderByMainTileId(m_selectedBrowserTileId);
+				break;
+			case 1:
+				LoadGroundBrushByMainTileId(m_selectedBrowserTileId);
+				break;
+			case 2:
+				LoadWallBrushByMainTileId(m_selectedBrowserTileId);
+				break;
+		}
+	}
 
-    event.Skip();
+	event.Skip();
 }
 
 void BorderEditorPanel::UpdateBrowserLabel() {
-    // No longer needed - mode is indicated by toggle buttons
+	// No longer needed - mode is indicated by toggle buttons
 }
 
-void BorderEditorPanel::OnModeSwitch(wxCommandEvent& event) {
-    SaveCurrentDraft(false);
+void BorderEditorPanel::OnModeSwitch(wxCommandEvent &event) {
+	SaveCurrentDraft(false);
 
-    wxToggleButton* clickedBtn = dynamic_cast<wxToggleButton*>(event.GetEventObject());
-    if (!clickedBtn) return;
-    
-    // Determine which mode was selected
-    int newTab = 0;
-    if (clickedBtn == m_borderModeBtn) {
-        newTab = 0;
-    } else if (clickedBtn == m_groundModeBtn) {
-        newTab = 1;
-    } else if (clickedBtn == m_wallModeBtn) {
-        newTab = 2;
-    }
-    
-    // Update toggle button states (only clicked one should be depressed)
-    m_borderModeBtn->SetValue(newTab == 0);
-    m_groundModeBtn->SetValue(newTab == 1);
-    m_wallModeBtn->SetValue(newTab == 2);
-    
-    // Switch the notebook page to show the correct editor panel for this mode
-    if (m_notebook) {
-        m_notebook->ChangeSelection(newTab);
-    }
-    m_activeTab = newTab;
-    
-    // Refresh tileset list (and apply filters) for the new mode
-    LoadTilesets();
+	wxToggleButton* clickedBtn = dynamic_cast<wxToggleButton*>(event.GetEventObject());
+	if (!clickedBtn) {
+		return;
+	}
 
-    {
-        const auto options = GetBrowserTilesetOptions();
-        if (!options.empty()) {
-            bool filterExists = false;
-            for (const auto& opt : options) {
-                if (opt.second == m_browserTilesetFilter) {
-                    filterExists = true;
-                    break;
-                }
-            }
+	// Determine which mode was selected
+	int newTab = 0;
+	if (clickedBtn == m_borderModeBtn) {
+		newTab = 0;
+	} else if (clickedBtn == m_groundModeBtn) {
+		newTab = 1;
+	} else if (clickedBtn == m_wallModeBtn) {
+		newTab = 2;
+	}
 
-            if (m_browserTilesetFilter.IsEmpty() || !filterExists) {
-                m_browserTilesetFilter = options.front().second;
-            }
+	// Update toggle button states (only clicked one should be depressed)
+	m_borderModeBtn->SetValue(newTab == 0);
+	m_groundModeBtn->SetValue(newTab == 1);
+	m_wallModeBtn->SetValue(newTab == 2);
 
-            wxString shown = options.front().first;
-            for (const auto& opt : options) {
-                if (opt.second == m_browserTilesetFilter) {
-                    shown = opt.first;
-                    break;
-                }
-            }
+	// Switch the notebook page to show the correct editor panel for this mode
+	if (m_notebook) {
+		m_notebook->ChangeSelection(newTab);
+	}
+	m_activeTab = newTab;
 
-            if (m_browserTilesetFilterButton) {
-                m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
-            }
-        } else {
-            m_browserTilesetFilter.clear();
-            if (m_browserTilesetFilterButton) {
-                m_browserTilesetFilterButton->SetLabel("Tileset: Select ▼");
-            }
-        }
-    }
-    
-    // Clear search and repopulate sidebar
-    if (m_browserSearchCtrl) {
-        m_browserSearchCtrl->Clear();
-    }
-    
-    // Keep browser list unified; just re-apply search/filter
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	// Refresh tileset list (and apply filters) for the new mode
+	LoadTilesets();
 
-    bool restored = false;
-    if (m_selectedBrowserTileId != 0) {
-        restored = RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
-    }
+	{
+		const auto options = GetBrowserTilesetOptions();
+		if (!options.empty()) {
+			bool filterExists = false;
+			for (const auto &opt : options) {
+				if (opt.second == m_browserTilesetFilter) {
+					filterExists = true;
+					break;
+				}
+			}
 
-    if (!restored) {
-        switch (m_activeTab) {
-            case 0: ClearItems(false); break;
-            case 1: ClearGroundItems(false); break;
-            case 2: ClearWallItems(false); break;
-        }
-        return;
-    }
+			if (m_browserTilesetFilter.IsEmpty() || !filterExists) {
+				m_browserTilesetFilter = options.front().second;
+			}
 
-    switch (m_activeTab) {
-        case 0: LoadBorderByMainTileId(m_selectedBrowserTileId); break;
-        case 1: LoadGroundBrushByMainTileId(m_selectedBrowserTileId); break;
-        case 2: LoadWallBrushByMainTileId(m_selectedBrowserTileId); break;
-    }
+			wxString shown = options.front().first;
+			for (const auto &opt : options) {
+				if (opt.second == m_browserTilesetFilter) {
+					shown = opt.first;
+					break;
+				}
+			}
+
+			if (m_browserTilesetFilterButton) {
+				m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
+			}
+		} else {
+			m_browserTilesetFilter.clear();
+			if (m_browserTilesetFilterButton) {
+				m_browserTilesetFilterButton->SetLabel("Tileset: Select ▼");
+			}
+		}
+	}
+
+	// Clear search and repopulate sidebar
+	if (m_browserSearchCtrl) {
+		m_browserSearchCtrl->Clear();
+	}
+
+	// Keep browser list unified; just re-apply search/filter
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+
+	bool restored = false;
+	if (m_selectedBrowserTileId != 0) {
+		restored = RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
+	}
+
+	if (!restored) {
+		switch (m_activeTab) {
+			case 0:
+				ClearItems(false);
+				break;
+			case 1:
+				ClearGroundItems(false);
+				break;
+			case 2:
+				ClearWallItems(false);
+				break;
+		}
+		return;
+	}
+
+	switch (m_activeTab) {
+		case 0:
+			LoadBorderByMainTileId(m_selectedBrowserTileId);
+			break;
+		case 1:
+			LoadGroundBrushByMainTileId(m_selectedBrowserTileId);
+			break;
+		case 2:
+			LoadWallBrushByMainTileId(m_selectedBrowserTileId);
+			break;
+	}
 }
 
 void BorderEditorPanel::PopulateBorderList() {
-    m_fullBrowserList.Clear();
-    m_fullBrowserIds.Clear();
-    m_fullBrowserPreviewIds.clear();
-    m_borderBrowserList->Clear();
+	m_fullBrowserList.Clear();
+	m_fullBrowserIds.Clear();
+	m_fullBrowserPreviewIds.clear();
+	m_borderBrowserList->Clear();
 
-    wxString dataDir = g_gui.GetDataDirectory();
+	wxString dataDir = g_gui.GetDataDirectory();
 
-    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() +
-                          "materials" + wxFileName::GetPathSeparator() +
-                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+	wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
 
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
-                          "materials" + wxFileName::GetPathSeparator() +
-                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
 
-    if (!wxFileExists(bordersFile) || !wxFileExists(groundsFile)) {
-        return;
-    }
+	if (!wxFileExists(bordersFile) || !wxFileExists(groundsFile)) {
+		return;
+	}
 
-    std::map<int, wxString> borderNames;
-    int maxId = 0;
+	std::map<int, wxString> borderNames;
+	int maxId = 0;
 
-    {
-        pugi::xml_document doc;
-        pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
-        if (!result) {
-            return;
-        }
+	{
+		pugi::xml_document doc;
+		pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
+		if (!result) {
+			return;
+		}
 
-        pugi::xml_node materials = doc.child("materials");
-        if (!materials) {
-            return;
-        }
+		pugi::xml_node materials = doc.child("materials");
+		if (!materials) {
+			return;
+		}
 
-        for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-            pugi::xml_attribute idAttr = borderNode.attribute("id");
-            if (!idAttr) {
-                continue;
-            }
+		for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+			pugi::xml_attribute idAttr = borderNode.attribute("id");
+			if (!idAttr) {
+				continue;
+			}
 
-            const int id = idAttr.as_int();
-            if (id > maxId) {
-                maxId = id;
-            }
+			const int id = idAttr.as_int();
+			if (id > maxId) {
+				maxId = id;
+			}
 
-            wxString name;
-            pugi::xml_attribute nameAttr = borderNode.attribute("name");
-            if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
-                name = wxString(nameAttr.as_string());
-            } else {
-                const char* nodeText = borderNode.child_value();
-                if (nodeText && strlen(nodeText) > 0) {
-                    wxString textContent = wxString(nodeText).Trim(true).Trim(false);
-                    while (textContent.StartsWith("-") || textContent.StartsWith(" ")) {
-                        textContent = textContent.Mid(1);
-                    }
-                    while (textContent.EndsWith("-") || textContent.EndsWith(" ")) {
-                        textContent = textContent.RemoveLast();
-                    }
-                    textContent = textContent.Trim(true).Trim(false);
-                    if (!textContent.IsEmpty()) {
-                        name = textContent;
-                    }
-                }
+			wxString name;
+			pugi::xml_attribute nameAttr = borderNode.attribute("name");
+			if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
+				name = wxString(nameAttr.as_string());
+			} else {
+				const char* nodeText = borderNode.child_value();
+				if (nodeText && strlen(nodeText) > 0) {
+					wxString textContent = wxString(nodeText).Trim(true).Trim(false);
+					while (textContent.StartsWith("-") || textContent.StartsWith(" ")) {
+						textContent = textContent.Mid(1);
+					}
+					while (textContent.EndsWith("-") || textContent.EndsWith(" ")) {
+						textContent = textContent.RemoveLast();
+					}
+					textContent = textContent.Trim(true).Trim(false);
+					if (!textContent.IsEmpty()) {
+						name = textContent;
+					}
+				}
 
-                if (name.IsEmpty()) {
-                    name = "(no name)";
-                }
-            }
+				if (name.IsEmpty()) {
+					name = "(no name)";
+				}
+			}
 
-            borderNames[id] = name;
-        }
-    }
+			borderNames[id] = name;
+		}
+	}
 
-    std::map<int, std::pair<uint16_t, wxString>> borderToMainTile;
+	std::map<int, std::pair<uint16_t, wxString>> borderToMainTile;
 
-    {
-        pugi::xml_document doc;
-        if (!doc.load_file(nstr(groundsFile).c_str())) {
-            return;
-        }
+	{
+		pugi::xml_document doc;
+		if (!doc.load_file(nstr(groundsFile).c_str())) {
+			return;
+		}
 
-        pugi::xml_node materials = doc.child("materials");
-        if (!materials) {
-            return;
-        }
+		pugi::xml_node materials = doc.child("materials");
+		if (!materials) {
+			return;
+		}
 
-        for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-            pugi::xml_attribute typeAttr = brushNode.attribute("type");
-            if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
-                continue;
-            }
+		for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+			pugi::xml_attribute typeAttr = brushNode.attribute("type");
+			if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+				continue;
+			}
 
-            pugi::xml_attribute nameAttr = brushNode.attribute("name");
-            if (!nameAttr) {
-                continue;
-            }
+			pugi::xml_attribute nameAttr = brushNode.attribute("name");
+			if (!nameAttr) {
+				continue;
+			}
 
-            uint16_t mainTileId = 0;
-            if (pugi::xml_attribute serverLookIdAttr = brushNode.attribute("server_lookid")) {
-                mainTileId = serverLookIdAttr.as_uint();
-            } else if (pugi::xml_attribute lookIdAttr = brushNode.attribute("lookid")) {
-                mainTileId = lookIdAttr.as_uint();
-            }
+			uint16_t mainTileId = 0;
+			if (pugi::xml_attribute serverLookIdAttr = brushNode.attribute("server_lookid")) {
+				mainTileId = serverLookIdAttr.as_uint();
+			} else if (pugi::xml_attribute lookIdAttr = brushNode.attribute("lookid")) {
+				mainTileId = lookIdAttr.as_uint();
+			}
 
-            if (mainTileId == 0) {
-                continue;
-            }
+			if (mainTileId == 0) {
+				continue;
+			}
 
-            int outerBorderId = 0;
-            for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-                pugi::xml_attribute idAttr = borderNode.attribute("id");
-                if (!idAttr) {
-                    continue;
-                }
+			int outerBorderId = 0;
+			for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+				pugi::xml_attribute idAttr = borderNode.attribute("id");
+				if (!idAttr) {
+					continue;
+				}
 
-                wxString align = wxString(borderNode.attribute("align").as_string());
-                if (align.IsEmpty() || align == "outer") {
-                    outerBorderId = idAttr.as_int();
-                    break;
-                }
-            }
+				wxString align = wxString(borderNode.attribute("align").as_string());
+				if (align.IsEmpty() || align == "outer") {
+					outerBorderId = idAttr.as_int();
+					break;
+				}
+			}
 
-            if (outerBorderId <= 0) {
-                continue;
-            }
+			if (outerBorderId <= 0) {
+				continue;
+			}
 
-            if (borderToMainTile.find(outerBorderId) == borderToMainTile.end()) {
-                borderToMainTile[outerBorderId] = { mainTileId, wxString(nameAttr.as_string()) };
-            }
-        }
-    }
+			if (borderToMainTile.find(outerBorderId) == borderToMainTile.end()) {
+				borderToMainTile[outerBorderId] = { mainTileId, wxString(nameAttr.as_string()) };
+			}
+		}
+	}
 
-    for (const auto& pair : borderToMainTile) {
-        const int borderId = pair.first;
-        const uint16_t tileId = pair.second.first;
-        const wxString brushName = pair.second.second;
+	for (const auto &pair : borderToMainTile) {
+		const int borderId = pair.first;
+		const uint16_t tileId = pair.second.first;
+		const wxString brushName = pair.second.second;
 
-        wxString borderName;
-        auto itName = borderNames.find(borderId);
-        if (itName != borderNames.end()) {
-            borderName = itName->second;
-        } else {
-            borderName = wxString::Format("border %d", borderId);
-        }
+		wxString borderName;
+		auto itName = borderNames.find(borderId);
+		if (itName != borderNames.end()) {
+			borderName = itName->second;
+		} else {
+			borderName = wxString::Format("border %d", borderId);
+		}
 
-        wxString label = wxString::Format("%d - %s [%s]", (int)tileId, brushName, borderName);
+		wxString label = wxString::Format("%d - %s [%s]", (int)tileId, brushName, borderName);
 
-        m_fullBrowserList.Add(label);
-        m_fullBrowserIds.Add(wxString::Format("%d", borderId));
-        m_fullBrowserPreviewIds.push_back(tileId);
+		m_fullBrowserList.Add(label);
+		m_fullBrowserIds.Add(wxString::Format("%d", borderId));
+		m_fullBrowserPreviewIds.push_back(tileId);
 
-        m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", borderId)));
-    }
+		m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", borderId)));
+	}
 
-    m_nextBorderId = maxId + 1;
+	m_nextBorderId = maxId + 1;
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
 void BorderEditorPanel::PopulateGroundList() {
-    m_fullBrowserList.Clear();
-    m_fullBrowserIds.Clear();
-    m_fullBrowserPreviewIds.clear();
-    m_borderBrowserList->Clear();
-    
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + 
-                          "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
-    
-    if (!wxFileExists(groundsFile)) return;
-    
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(groundsFile).c_str())) return;
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) return;
-    
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute typeAttr = brushNode.attribute("type");
-        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") continue;
-        
-        pugi::xml_attribute nameAttr = brushNode.attribute("name");
-        if (!nameAttr) continue;
-        
-        wxString brushName = wxString(nameAttr.as_string());
-        m_fullBrowserList.Add(brushName);
-        m_fullBrowserIds.Add(brushName);
+	m_fullBrowserList.Clear();
+	m_fullBrowserIds.Clear();
+	m_fullBrowserPreviewIds.clear();
+	m_borderBrowserList->Clear();
 
-        uint16_t previewId = 0;
-        pugi::xml_node itemNode = brushNode.child("item");
-        if (itemNode) {
-            previewId = itemNode.attribute("id").as_uint();
-        }
-        m_fullBrowserPreviewIds.push_back(previewId);
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
 
-        m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
-    }
+	if (!wxFileExists(groundsFile)) {
+		return;
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(groundsFile).c_str())) {
+		return;
+	}
+
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
+
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute typeAttr = brushNode.attribute("type");
+		if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+			continue;
+		}
+
+		pugi::xml_attribute nameAttr = brushNode.attribute("name");
+		if (!nameAttr) {
+			continue;
+		}
+
+		wxString brushName = wxString(nameAttr.as_string());
+		m_fullBrowserList.Add(brushName);
+		m_fullBrowserIds.Add(brushName);
+
+		uint16_t previewId = 0;
+		pugi::xml_node itemNode = brushNode.child("item");
+		if (itemNode) {
+			previewId = itemNode.attribute("id").as_uint();
+		}
+		m_fullBrowserPreviewIds.push_back(previewId);
+
+		m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
 void BorderEditorPanel::PopulateWallList() {
-    m_fullBrowserList.Clear();
-    m_fullBrowserIds.Clear();
-    m_fullBrowserPreviewIds.clear();
-    m_borderBrowserList->Clear();
-    
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + 
-                        "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
-    
-    if (!wxFileExists(wallsFile)) return;
-    
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(wallsFile).c_str())) return;
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) return;
-    
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute nameAttr = brushNode.attribute("name");
-        if (!nameAttr) continue;
-        
-        wxString brushName = wxString(nameAttr.as_string());
-        m_fullBrowserList.Add(brushName);
-        m_fullBrowserIds.Add(brushName);
+	m_fullBrowserList.Clear();
+	m_fullBrowserIds.Clear();
+	m_fullBrowserPreviewIds.clear();
+	m_borderBrowserList->Clear();
 
-        uint16_t previewId = 0;
-        pugi::xml_node wallNode = brushNode.child("wall");
-        if (wallNode) {
-            pugi::xml_node itemNode = wallNode.child("item");
-            if (itemNode) {
-                previewId = itemNode.attribute("id").as_uint();
-            }
-        }
-        m_fullBrowserPreviewIds.push_back(previewId);
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 
-        m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
-    }
+	if (!wxFileExists(wallsFile)) {
+		return;
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(wallsFile).c_str())) {
+		return;
+	}
+
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
+
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute nameAttr = brushNode.attribute("name");
+		if (!nameAttr) {
+			continue;
+		}
+
+		wxString brushName = wxString(nameAttr.as_string());
+		m_fullBrowserList.Add(brushName);
+		m_fullBrowserIds.Add(brushName);
+
+		uint16_t previewId = 0;
+		pugi::xml_node wallNode = brushNode.child("wall");
+		if (wallNode) {
+			pugi::xml_node itemNode = wallNode.child("item");
+			if (itemNode) {
+				previewId = itemNode.attribute("id").as_uint();
+			}
+		}
+		m_fullBrowserPreviewIds.push_back(previewId);
+
+		m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
+	}
+
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
 void BorderEditorPanel::PopulateUnifiedList() {
-    m_fullBrowserList.Clear();
-    m_fullBrowserIds.Clear();
-    m_fullBrowserPreviewIds.clear();
-    m_borderBrowserList->Clear();
+	m_fullBrowserList.Clear();
+	m_fullBrowserIds.Clear();
+	m_fullBrowserPreviewIds.clear();
+	m_borderBrowserList->Clear();
 
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
-                          "materials" + wxFileName::GetPathSeparator() +
-                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
 
-    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() +
-                        "materials" + wxFileName::GetPathSeparator() +
-                        "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 
-    std::set<uint16_t> seen;
+	std::set<uint16_t> seen;
 
-    if (wxFileExists(groundsFile)) {
-        pugi::xml_document doc;
-        if (doc.load_file(nstr(groundsFile).c_str())) {
-            pugi::xml_node materials = doc.child("materials");
-            for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-                pugi::xml_attribute typeAttr = brushNode.attribute("type");
-                if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
-                    continue;
-                }
+	if (wxFileExists(groundsFile)) {
+		pugi::xml_document doc;
+		if (doc.load_file(nstr(groundsFile).c_str())) {
+			pugi::xml_node materials = doc.child("materials");
+			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+				pugi::xml_attribute typeAttr = brushNode.attribute("type");
+				if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+					continue;
+				}
 
-                pugi::xml_attribute nameAttr = brushNode.attribute("name");
-                if (!nameAttr) {
-                    continue;
-                }
+				pugi::xml_attribute nameAttr = brushNode.attribute("name");
+				if (!nameAttr) {
+					continue;
+				}
 
-                uint16_t tileId = 0;
-                if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
-                    tileId = a.as_uint();
-                } else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
-                    tileId = a.as_uint();
-                } else if (pugi::xml_node itemNode = brushNode.child("item")) {
-                    tileId = itemNode.attribute("id").as_uint();
-                }
+				uint16_t tileId = 0;
+				if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+					tileId = a.as_uint();
+				} else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+					tileId = a.as_uint();
+				} else if (pugi::xml_node itemNode = brushNode.child("item")) {
+					tileId = itemNode.attribute("id").as_uint();
+				}
 
-                if (tileId == 0) {
-                    continue;
-                }
+				if (tileId == 0) {
+					continue;
+				}
 
-                if (seen.find(tileId) != seen.end()) {
-                    continue;
-                }
-                seen.insert(tileId);
+				if (seen.find(tileId) != seen.end()) {
+					continue;
+				}
+				seen.insert(tileId);
 
-                wxString brushName = wxString(nameAttr.as_string());
-                wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
+				wxString brushName = wxString(nameAttr.as_string());
+				wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
 
-                m_fullBrowserList.Add(label);
-                m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
-                m_fullBrowserPreviewIds.push_back(tileId);
+				m_fullBrowserList.Add(label);
+				m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
+				m_fullBrowserPreviewIds.push_back(tileId);
 
-                m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
-            }
-        }
-    }
+				m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
+			}
+		}
+	}
 
-    if (wxFileExists(wallsFile)) {
-        pugi::xml_document doc;
-        if (doc.load_file(nstr(wallsFile).c_str())) {
-            pugi::xml_node materials = doc.child("materials");
-            for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-                pugi::xml_attribute nameAttr = brushNode.attribute("name");
-                if (!nameAttr) {
-                    continue;
-                }
+	if (wxFileExists(wallsFile)) {
+		pugi::xml_document doc;
+		if (doc.load_file(nstr(wallsFile).c_str())) {
+			pugi::xml_node materials = doc.child("materials");
+			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+				pugi::xml_attribute nameAttr = brushNode.attribute("name");
+				if (!nameAttr) {
+					continue;
+				}
 
-                uint16_t tileId = 0;
-                if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
-                    tileId = a.as_uint();
-                }
+				uint16_t tileId = 0;
+				if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+					tileId = a.as_uint();
+				}
 
-                if (tileId == 0) {
-                    continue;
-                }
+				if (tileId == 0) {
+					continue;
+				}
 
-                if (seen.find(tileId) != seen.end()) {
-                    continue;
-                }
-                seen.insert(tileId);
+				if (seen.find(tileId) != seen.end()) {
+					continue;
+				}
+				seen.insert(tileId);
 
-                wxString brushName = wxString(nameAttr.as_string());
-                wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
+				wxString brushName = wxString(nameAttr.as_string());
+				wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
 
-                m_fullBrowserList.Add(label);
-                m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
-                m_fullBrowserPreviewIds.push_back(tileId);
+				m_fullBrowserList.Add(label);
+				m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
+				m_fullBrowserPreviewIds.push_back(tileId);
 
-                m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
-            }
-        }
-    }
+				m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
+			}
+		}
+	}
 
-    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 }
 
-void BorderEditorPanel::OnBrowserSearch(wxCommandEvent& event) {
-    FilterBrowserList(m_browserSearchCtrl->GetValue());
+void BorderEditorPanel::OnBrowserSearch(wxCommandEvent &event) {
+	FilterBrowserList(m_browserSearchCtrl->GetValue());
 }
 
-static wxString FindTilesetByPreferredOrContains(const wxString& preferred, const std::vector<wxString>& needlesLower) {
-    if (!preferred.IsEmpty() && g_materials.tilesets.find(nstr(preferred).c_str()) != g_materials.tilesets.end()) {
-        return preferred;
-    }
+static wxString FindTilesetByPreferredOrContains(const wxString &preferred, const std::vector<wxString> &needlesLower) {
+	if (!preferred.IsEmpty() && g_materials.tilesets.find(nstr(preferred).c_str()) != g_materials.tilesets.end()) {
+		return preferred;
+	}
 
-    for (const auto& pair : g_materials.tilesets) {
-        wxString ts = wxString(pair.first);
-        wxString lower = ts.Lower();
-        for (const wxString& needle : needlesLower) {
-            if (!needle.IsEmpty() && lower.Contains(needle)) {
-                return ts;
-            }
-        }
-    }
+	for (const auto &pair : g_materials.tilesets) {
+		wxString ts = wxString(pair.first);
+		wxString lower = ts.Lower();
+		for (const wxString &needle : needlesLower) {
+			if (!needle.IsEmpty() && lower.Contains(needle)) {
+				return ts;
+			}
+		}
+	}
 
-    return wxString();
+	return wxString();
 }
 
 static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions() {
-    std::vector<std::pair<wxString, wxString>> options;
+	std::vector<std::pair<wxString, wxString>> options;
 
-    wxString mountains = FindTilesetByPreferredOrContains("Grounds - Mountains", { "mountain", "montain" });
-    if (!mountains.IsEmpty()) {
-        options.push_back({ "Mountains", mountains });
-    }
+	wxString mountains = FindTilesetByPreferredOrContains("Grounds - Mountains", { "mountain", "montain" });
+	if (!mountains.IsEmpty()) {
+		options.push_back({ "Mountains", mountains });
+	}
 
-    wxString nature = FindTilesetByPreferredOrContains("Grounds - Nature", { "nature" });
-    if (!nature.IsEmpty()) {
-        options.push_back({ "Nature", nature });
-    }
+	wxString nature = FindTilesetByPreferredOrContains("Grounds - Nature", { "nature" });
+	if (!nature.IsEmpty()) {
+		options.push_back({ "Nature", nature });
+	}
 
-    wxString ornamented = FindTilesetByPreferredOrContains("Grounds - Ornamented", { "ornament" });
-    if (!ornamented.IsEmpty()) {
-        options.push_back({ "Ornamented", ornamented });
-    }
+	wxString ornamented = FindTilesetByPreferredOrContains("Grounds - Ornamented", { "ornament" });
+	if (!ornamented.IsEmpty()) {
+		options.push_back({ "Ornamented", ornamented });
+	}
 
-    wxString wall = FindTilesetByPreferredOrContains("Walls", { "wall" });
-    if (!wall.IsEmpty()) {
-        options.push_back({ "Wall", wall });
-    }
+	wxString wall = FindTilesetByPreferredOrContains("Walls", { "wall" });
+	if (!wall.IsEmpty()) {
+		options.push_back({ "Wall", wall });
+	}
 
-    return options;
+	return options;
 }
 
-void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent& event) {
-    wxMenu menu;
+void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event) {
+	wxMenu menu;
 
-    const auto options = GetBrowserTilesetOptions();
-    if (options.empty()) {
-        return;
-    }
+	const auto options = GetBrowserTilesetOptions();
+	if (options.empty()) {
+		return;
+	}
 
-    auto addRadio = [&](const wxString& shown, const wxString& value) {
-        wxMenuItem* item = menu.AppendRadioItem(wxID_ANY, shown);
-        if (value == m_browserTilesetFilter) {
-            item->Check(true);
-        }
-        menu.Bind(wxEVT_MENU, [this, shown, value](wxCommandEvent&) {
+	auto addRadio = [&](const wxString &shown, const wxString &value) {
+		wxMenuItem* item = menu.AppendRadioItem(wxID_ANY, shown);
+		if (value == m_browserTilesetFilter) {
+			item->Check(true);
+		}
+		menu.Bind(wxEVT_MENU, [this, shown, value](wxCommandEvent &) {
             const uint16_t keepTileId = m_selectedBrowserTileId;
 
             m_browserTilesetFilter = value;
@@ -3829,332 +4109,344 @@ void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent& event)
                     case 1: ClearGroundItems(false); break;
                     case 2: ClearWallItems(false); break;
                 }
-            }
-        }, item->GetId());
-    };
+            } }, item->GetId());
+	};
 
-    for (const auto& opt : options) {
-        addRadio(opt.first, opt.second);
-    }
+	for (const auto &opt : options) {
+		addRadio(opt.first, opt.second);
+	}
 
-    PopupMenu(&menu);
+	PopupMenu(&menu);
 }
 
-void BorderEditorPanel::FilterBrowserList(const wxString& query) {
-    m_borderBrowserList->Clear();
-    wxString lowerQuery = query.Lower();
+void BorderEditorPanel::FilterBrowserList(const wxString &query) {
+	m_borderBrowserList->Clear();
+	wxString lowerQuery = query.Lower();
 
-    const auto filterOptions = GetBrowserTilesetOptions();
+	const auto filterOptions = GetBrowserTilesetOptions();
 
-    const bool useTilesetFilter = !m_browserTilesetFilter.IsEmpty();
-    const std::string tilesetName = useTilesetFilter ? nstr(m_browserTilesetFilter) : std::string();
+	const bool useTilesetFilter = !m_browserTilesetFilter.IsEmpty();
+	const std::string tilesetName = useTilesetFilter ? nstr(m_browserTilesetFilter) : std::string();
 
-    std::vector<BrushBrowserGridPanel::Entry> entries;
-    entries.reserve(m_fullBrowserList.GetCount());
+	std::vector<BrushBrowserGridPanel::Entry> entries;
+	entries.reserve(m_fullBrowserList.GetCount());
 
-    for (size_t i = 0; i < m_fullBrowserList.GetCount(); i++) {
-        if (!query.IsEmpty() && !m_fullBrowserList[i].Lower().Contains(lowerQuery)) {
-            continue;
-        }
+	for (size_t i = 0; i < m_fullBrowserList.GetCount(); i++) {
+		if (!query.IsEmpty() && !m_fullBrowserList[i].Lower().Contains(lowerQuery)) {
+			continue;
+		}
 
-        uint16_t previewId = 0;
-        if (i < m_fullBrowserPreviewIds.size()) {
-            previewId = m_fullBrowserPreviewIds[i];
-        }
+		uint16_t previewId = 0;
+		if (i < m_fullBrowserPreviewIds.size()) {
+			previewId = m_fullBrowserPreviewIds[i];
+		}
 
-        if (useTilesetFilter) {
-            if (previewId == 0) {
-                continue;
-            }
+		if (useTilesetFilter) {
+			if (previewId == 0) {
+				continue;
+			}
 
-            const ItemType& type = g_items.getItemType(previewId);
-            if (type.id == 0) {
-                continue;
-            }
+			const ItemType &type = g_items.getItemType(previewId);
+			if (type.id == 0) {
+				continue;
+			}
 
-            auto inTilesetFor = [&](const wxString& tilesetWx) -> bool {
-                const std::string ts = nstr(tilesetWx);
-                return
-                    g_materials.isInTileset(type.brush, ts) ||
-                    g_materials.isInTileset(type.doodad_brush, ts) ||
-                    g_materials.isInTileset(type.raw_brush, ts);
-            };
+			auto inTilesetFor = [&](const wxString &tilesetWx) -> bool {
+				const std::string ts = nstr(tilesetWx);
+				return g_materials.isInTileset(type.brush, ts) || g_materials.isInTileset(type.doodad_brush, ts) || g_materials.isInTileset(type.raw_brush, ts);
+			};
 
-            if (!inTilesetFor(m_browserTilesetFilter)) {
-                continue;
-            }
+			if (!inTilesetFor(m_browserTilesetFilter)) {
+				continue;
+			}
 
-            if (filterOptions.size() > 1) {
-                size_t selectedIndex = filterOptions.size();
-                for (size_t idx = 0; idx < filterOptions.size(); ++idx) {
-                    if (filterOptions[idx].second == m_browserTilesetFilter) {
-                        selectedIndex = idx;
-                        break;
-                    }
-                }
+			if (filterOptions.size() > 1) {
+				size_t selectedIndex = filterOptions.size();
+				for (size_t idx = 0; idx < filterOptions.size(); ++idx) {
+					if (filterOptions[idx].second == m_browserTilesetFilter) {
+						selectedIndex = idx;
+						break;
+					}
+				}
 
-                if (selectedIndex != filterOptions.size()) {
-                    bool belongsToHigher = false;
-                    for (size_t idx = 0; idx < selectedIndex; ++idx) {
-                        const wxString& higherTs = filterOptions[idx].second;
-                        if (higherTs.IsEmpty()) {
-                            continue;
-                        }
-                        if (inTilesetFor(higherTs)) {
-                            belongsToHigher = true;
-                            break;
-                        }
-                    }
-                    if (belongsToHigher) {
-                        continue;
-                    }
-                }
-            }
-        }
+				if (selectedIndex != filterOptions.size()) {
+					bool belongsToHigher = false;
+					for (size_t idx = 0; idx < selectedIndex; ++idx) {
+						const wxString &higherTs = filterOptions[idx].second;
+						if (higherTs.IsEmpty()) {
+							continue;
+						}
+						if (inTilesetFor(higherTs)) {
+							belongsToHigher = true;
+							break;
+						}
+					}
+					if (belongsToHigher) {
+						continue;
+					}
+				}
+			}
+		}
 
-        wxString displayLabel = m_fullBrowserList[i];
-        if (previewId != 0 && !filterOptions.empty()) {
-            if (useTilesetFilter) {
-                wxString selectedShown;
-                for (const auto& opt : filterOptions) {
-                    if (opt.second == m_browserTilesetFilter) {
-                        selectedShown = opt.first;
-                        break;
-                    }
-                }
+		wxString displayLabel = m_fullBrowserList[i];
+		if (previewId != 0 && !filterOptions.empty()) {
+			if (useTilesetFilter) {
+				wxString selectedShown;
+				for (const auto &opt : filterOptions) {
+					if (opt.second == m_browserTilesetFilter) {
+						selectedShown = opt.first;
+						break;
+					}
+				}
 
-                if (!selectedShown.IsEmpty()) {
-                    displayLabel += " [" + selectedShown + "]";
-                }
-            } else {
-                const ItemType& type = g_items.getItemType(previewId);
-                if (type.id != 0) {
-                    wxString tagList;
-                    bool first = true;
+				if (!selectedShown.IsEmpty()) {
+					displayLabel += " [" + selectedShown + "]";
+				}
+			} else {
+				const ItemType &type = g_items.getItemType(previewId);
+				if (type.id != 0) {
+					wxString tagList;
+					bool first = true;
 
-                    for (const auto& opt : filterOptions) {
-                        const wxString& shown = opt.first;
-                        const wxString& tsNameWx = opt.second;
-                        if (tsNameWx.IsEmpty()) {
-                            continue;
-                        }
+					for (const auto &opt : filterOptions) {
+						const wxString &shown = opt.first;
+						const wxString &tsNameWx = opt.second;
+						if (tsNameWx.IsEmpty()) {
+							continue;
+						}
 
-                        const std::string tsName = nstr(tsNameWx);
-                        const bool inTileset =
-                            g_materials.isInTileset(type.brush, tsName) ||
-                            g_materials.isInTileset(type.doodad_brush, tsName) ||
-                            g_materials.isInTileset(type.raw_brush, tsName);
+						const std::string tsName = nstr(tsNameWx);
+						const bool inTileset = g_materials.isInTileset(type.brush, tsName) || g_materials.isInTileset(type.doodad_brush, tsName) || g_materials.isInTileset(type.raw_brush, tsName);
 
-                        if (inTileset) {
-                            if (!first) {
-                                tagList += ", ";
-                            }
-                            tagList += shown;
-                            first = false;
-                        }
-                    }
+						if (inTileset) {
+							if (!first) {
+								tagList += ", ";
+							}
+							tagList += shown;
+							first = false;
+						}
+					}
 
-                    if (!tagList.IsEmpty()) {
-                        displayLabel += " [" + tagList + "]";
-                    }
-                }
-            }
-        }
+					if (!tagList.IsEmpty()) {
+						displayLabel += " [" + tagList + "]";
+					}
+				}
+			}
+		}
 
-        m_borderBrowserList->Append(displayLabel, new wxStringClientData(m_fullBrowserIds[i]));
+		m_borderBrowserList->Append(displayLabel, new wxStringClientData(m_fullBrowserIds[i]));
 
-        BrushBrowserGridPanel::Entry e;
-        e.label = displayLabel;
-        e.key = m_fullBrowserIds[i];
-        e.previewItemId = previewId;
-        entries.push_back(std::move(e));
-    }
+		BrushBrowserGridPanel::Entry e;
+		e.label = displayLabel;
+		e.key = m_fullBrowserIds[i];
+		e.previewItemId = previewId;
+		entries.push_back(std::move(e));
+	}
 
-    if (m_browserGrid) {
-        m_browserGrid->SetEntries(std::move(entries));
-    }
+	if (m_browserGrid) {
+		m_browserGrid->SetEntries(std::move(entries));
+	}
 }
 
-void BorderEditorPanel::OnGroundGridSelect(wxCommandEvent& event) {
-    // Selection logic logic is handled by container/cell highlighting
-    // No UI updates needed here anymore as editing is via double-click modal
+void BorderEditorPanel::OnGroundGridSelect(wxCommandEvent &event) {
+	// Selection logic logic is handled by container/cell highlighting
+	// No UI updates needed here anymore as editing is via double-click modal
 }
 
 void BorderEditorPanel::LoadTilesets() {
-    // Clear the choice control
-    m_tilesetListData.Clear();
-    m_tilesets.clear();
-    
-    // Get the appropriate whitelist for the current mode
-    const std::set<wxString>& whitelist = 
-        (m_activeTab == 0) ? m_borderEnabledTilesets :
-        (m_activeTab == 1) ? m_groundEnabledTilesets :
-                             m_wallEnabledTilesets;
-    
-    // Use the already-loaded tilesets from g_materials
-    // (g_materials.tilesets is populated by the Materials loader at startup)
-    wxArrayString tilesetNames;
-    for (const auto& pair : g_materials.tilesets) {
-        if (pair.second) {
-            wxString tilesetName = wxString(pair.first);
-            const bool allowed = whitelist.empty() || whitelist.find(tilesetName) != whitelist.end();
-            if (allowed) {
-                tilesetNames.Add(tilesetName);
-                m_tilesets[tilesetName] = tilesetName;
-            }
-        }
-    }
-    
-    // Sort tileset names alphabetically
-    tilesetNames.Sort();
-    
-    // Add sorted names to the tileset list
-    m_tilesetListData = tilesetNames;
-    
-    // Update the appropriate ComboBox based on active tab
-    // Update the appropriate Control based on active tab
-    if (m_activeTab == 0 && m_rawCategoryButton) {
-        // Border tab
-        m_rawCategoryNames = m_tilesetListData;
-        
-        if (!m_tilesetListData.IsEmpty()) {
-            m_rawCategorySelection = 0;
-            m_rawCategoryButton->SetLabel(m_tilesetListData[0] + " \u25BC");
-            
-            if(m_itemPalettePanel) m_itemPalettePanel->LoadTileset(m_tilesetListData[0]);
-        } else {
-             m_rawCategoryButton->SetLabel("Select \u25BC");
-             if(m_itemPalettePanel) m_itemPalettePanel->LoadTileset("");
-        }
-    } else if (m_activeTab == 1 && m_groundTilesetButton) {
-        // Ground tab
-        if (!m_tilesetListData.IsEmpty()) {
-            m_groundTilesetSelection = 0;
-            m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
-            
-            if(m_groundPalette) m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
-        } else {
-            m_groundTilesetButton->SetLabel("Select \u25BC");
-        }
-    } else if (m_activeTab == 2 && m_wallTilesetButton) {
-        // Wall tab
-         if (!m_tilesetListData.IsEmpty()) {
-            m_wallTilesetSelection = 0;
-            m_wallTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
-            
-            if(m_wallPalette) m_wallPalette->LoadTileset(m_tilesetListData[0], FILTER_WALL);
-         } else {
-             m_wallTilesetButton->SetLabel("Select \u25BC");
-         }
-    }
+	// Clear the choice control
+	m_tilesetListData.Clear();
+	m_tilesets.clear();
 
-} 
+	// Get the appropriate whitelist for the current mode
+	const std::set<wxString> &whitelist = (m_activeTab == 0) ? m_borderEnabledTilesets : (m_activeTab == 1) ? m_groundEnabledTilesets
+																											: m_wallEnabledTilesets;
+
+	// Use the already-loaded tilesets from g_materials
+	// (g_materials.tilesets is populated by the Materials loader at startup)
+	wxArrayString tilesetNames;
+	for (const auto &pair : g_materials.tilesets) {
+		if (pair.second) {
+			wxString tilesetName = wxString(pair.first);
+			const bool allowed = whitelist.empty() || whitelist.find(tilesetName) != whitelist.end();
+			if (allowed) {
+				tilesetNames.Add(tilesetName);
+				m_tilesets[tilesetName] = tilesetName;
+			}
+		}
+	}
+
+	// Sort tileset names alphabetically
+	tilesetNames.Sort();
+
+	// Add sorted names to the tileset list
+	m_tilesetListData = tilesetNames;
+
+	// Update the appropriate ComboBox based on active tab
+	// Update the appropriate Control based on active tab
+	if (m_activeTab == 0 && m_rawCategoryButton) {
+		// Border tab
+		m_rawCategoryNames = m_tilesetListData;
+
+		if (!m_tilesetListData.IsEmpty()) {
+			m_rawCategorySelection = 0;
+			m_rawCategoryButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+
+			if (m_itemPalettePanel) {
+				m_itemPalettePanel->LoadTileset(m_tilesetListData[0]);
+			}
+		} else {
+			m_rawCategoryButton->SetLabel("Select \u25BC");
+			if (m_itemPalettePanel) {
+				m_itemPalettePanel->LoadTileset("");
+			}
+		}
+	} else if (m_activeTab == 1 && m_groundTilesetButton) {
+		// Ground tab
+		if (!m_tilesetListData.IsEmpty()) {
+			m_groundTilesetSelection = 0;
+			m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+
+			if (m_groundPalette) {
+				m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
+			}
+		} else {
+			m_groundTilesetButton->SetLabel("Select \u25BC");
+		}
+	} else if (m_activeTab == 2 && m_wallTilesetButton) {
+		// Wall tab
+		if (!m_tilesetListData.IsEmpty()) {
+			m_wallTilesetSelection = 0;
+			m_wallTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+
+			if (m_wallPalette) {
+				m_wallPalette->LoadTileset(m_tilesetListData[0], FILTER_WALL);
+			}
+		} else {
+			m_wallTilesetButton->SetLabel("Select \u25BC");
+		}
+	}
+}
 
 // ============================================================================
 // Filter Config Persistence
 
 void BorderEditorPanel::SaveFilterConfig() {
-    // Save filter configuration to JSON file
-    wxString configDir = wxFileName::GetHomeDir() + wxFileName::GetPathSeparator() + ".rme";
-    if (!wxDirExists(configDir)) {
-        if (!wxMkdir(configDir)) {
-            // Failed to create directory
-            return;
-        }
-    }
-    
-    wxString configFile = configDir + wxFileName::GetPathSeparator() + "border_editor_filters_v2.json";
-    
-    // Build JSON manually (simple format)
-    wxString json = "{\n";
-    
-    // Border enabled tilesets
-    json += "  \"border_enabled\": [";
-    bool first = true;
-    for (const wxString& ts : m_borderEnabledTilesets) {
-        if (!first) json += ", ";
-        json += "\"" + ts + "\"";
-        first = false;
-    }
-    json += "],\n";
-    
-    // Ground enabled tilesets
-    json += "  \"ground_enabled\": [";
-    first = true;
-    for (const wxString& ts : m_groundEnabledTilesets) {
-        if (!first) json += ", ";
-        json += "\"" + ts + "\"";
-        first = false;
-    }
-    json += "],\n";
-    
-    // Wall enabled tilesets
-    json += "  \"wall_enabled\": [";
-    first = true;
-    for (const wxString& ts : m_wallEnabledTilesets) {
-        if (!first) json += ", ";
-        json += "\"" + ts + "\"";
-        first = false;
-    }
-    json += "]\n";
-    
-    json += "}\n";
-    
-    wxFile file;
-    if (file.Create(configFile, true)) { // true = overwrite
-        file.Write(json);
-        file.Close();
-    }
+	// Save filter configuration to JSON file
+	wxString configDir = wxFileName::GetHomeDir() + wxFileName::GetPathSeparator() + ".rme";
+	if (!wxDirExists(configDir)) {
+		if (!wxMkdir(configDir)) {
+			// Failed to create directory
+			return;
+		}
+	}
+
+	wxString configFile = configDir + wxFileName::GetPathSeparator() + "border_editor_filters_v2.json";
+
+	// Build JSON manually (simple format)
+	wxString json = "{\n";
+
+	// Border enabled tilesets
+	json += "  \"border_enabled\": [";
+	bool first = true;
+	for (const wxString &ts : m_borderEnabledTilesets) {
+		if (!first) {
+			json += ", ";
+		}
+		json += "\"" + ts + "\"";
+		first = false;
+	}
+	json += "],\n";
+
+	// Ground enabled tilesets
+	json += "  \"ground_enabled\": [";
+	first = true;
+	for (const wxString &ts : m_groundEnabledTilesets) {
+		if (!first) {
+			json += ", ";
+		}
+		json += "\"" + ts + "\"";
+		first = false;
+	}
+	json += "],\n";
+
+	// Wall enabled tilesets
+	json += "  \"wall_enabled\": [";
+	first = true;
+	for (const wxString &ts : m_wallEnabledTilesets) {
+		if (!first) {
+			json += ", ";
+		}
+		json += "\"" + ts + "\"";
+		first = false;
+	}
+	json += "]\n";
+
+	json += "}\n";
+
+	wxFile file;
+	if (file.Create(configFile, true)) { // true = overwrite
+		file.Write(json);
+		file.Close();
+	}
 }
 
 void BorderEditorPanel::LoadFilterConfig() {
-    // Ensure clean state
-    m_borderEnabledTilesets.clear();
-    m_groundEnabledTilesets.clear();
-    m_wallEnabledTilesets.clear();
+	// Ensure clean state
+	m_borderEnabledTilesets.clear();
+	m_groundEnabledTilesets.clear();
+	m_wallEnabledTilesets.clear();
 
-    wxString configDir = wxFileName::GetHomeDir() + wxFileName::GetPathSeparator() + ".rme";
-    wxString configFile = configDir + wxFileName::GetPathSeparator() + "border_editor_filters_v2.json";
-    
-    if (!wxFileExists(configFile)) {
-        // No config file - whitelists stay empty (default: no filter applied / clean state)
-        // This ensures "Addon and Quest Items" is NOT selected by default
-        return;
-    }
-    
-    wxFile file(configFile, wxFile::read);
-    if (!file.IsOpened()) return;
-    
-    wxString content;
-    file.ReadAll(&content);
-    file.Close();
-    
-    // Simple JSON parsing for our specific format
-    auto parseArray = [&content](const wxString& key) -> std::set<wxString> {
-        std::set<wxString> result;
-        int startPos = content.Find("\"" + key + "\": [");
-        if (startPos == wxNOT_FOUND) return result;
-        
-        int arrayStart = content.find('[', startPos);
-        int arrayEnd = content.find(']', arrayStart);
-        if (arrayStart == wxNOT_FOUND || arrayEnd == wxNOT_FOUND) return result;
-        
-        wxString arrayContent = content.Mid(arrayStart + 1, arrayEnd - arrayStart - 1);
-        
-        // Parse quoted strings
-        int pos = 0;
-        while ((pos = arrayContent.find('"', pos)) != wxNOT_FOUND) {
-            int endQuote = arrayContent.find('"', pos + 1);
-            if (endQuote == wxNOT_FOUND) break;
-            result.insert(arrayContent.Mid(pos + 1, endQuote - pos - 1));
-            pos = endQuote + 1;
-        }
-        return result;
-    };
-    
-    m_borderEnabledTilesets = parseArray("border_enabled");
-    m_groundEnabledTilesets = parseArray("ground_enabled");
-    m_wallEnabledTilesets = parseArray("wall_enabled");
+	wxString configDir = wxFileName::GetHomeDir() + wxFileName::GetPathSeparator() + ".rme";
+	wxString configFile = configDir + wxFileName::GetPathSeparator() + "border_editor_filters_v2.json";
+
+	if (!wxFileExists(configFile)) {
+		// No config file - whitelists stay empty (default: no filter applied / clean state)
+		// This ensures "Addon and Quest Items" is NOT selected by default
+		return;
+	}
+
+	wxFile file(configFile, wxFile::read);
+	if (!file.IsOpened()) {
+		return;
+	}
+
+	wxString content;
+	file.ReadAll(&content);
+	file.Close();
+
+	// Simple JSON parsing for our specific format
+	auto parseArray = [&content](const wxString &key) -> std::set<wxString> {
+		std::set<wxString> result;
+		int startPos = content.Find("\"" + key + "\": [");
+		if (startPos == wxNOT_FOUND) {
+			return result;
+		}
+
+		int arrayStart = content.find('[', startPos);
+		int arrayEnd = content.find(']', arrayStart);
+		if (arrayStart == wxNOT_FOUND || arrayEnd == wxNOT_FOUND) {
+			return result;
+		}
+
+		wxString arrayContent = content.Mid(arrayStart + 1, arrayEnd - arrayStart - 1);
+
+		// Parse quoted strings
+		int pos = 0;
+		while ((pos = arrayContent.find('"', pos)) != wxNOT_FOUND) {
+			int endQuote = arrayContent.find('"', pos + 1);
+			if (endQuote == wxNOT_FOUND) {
+				break;
+			}
+			result.insert(arrayContent.Mid(pos + 1, endQuote - pos - 1));
+			pos = endQuote + 1;
+		}
+		return result;
+	};
+
+	m_borderEnabledTilesets = parseArray("border_enabled");
+	m_groundEnabledTilesets = parseArray("ground_enabled");
+	m_wallEnabledTilesets = parseArray("wall_enabled");
 }
 
 // ============================================================================
@@ -4162,352 +4454,381 @@ void BorderEditorPanel::LoadFilterConfig() {
 // ============================================================================
 
 BEGIN_EVENT_TABLE(WallGridPanel, wxPanel)
-    EVT_PAINT(WallGridPanel::OnPaint)
-    EVT_LEFT_DOWN(WallGridPanel::OnMouseClick)
+EVT_PAINT(WallGridPanel::OnPaint)
+EVT_LEFT_DOWN(WallGridPanel::OnMouseClick)
 END_EVENT_TABLE()
 
 WallGridPanel::WallGridPanel(wxWindow* parent, wxWindowID id) :
-    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize)
-{
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
+	wxPanel(parent, id, wxDefaultPosition, wxDefaultSize) {
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 WallGridPanel::~WallGridPanel() {
 }
 
-void WallGridPanel::SetWallTypes(const std::map<std::string, WallTypeData>& types) {
-    m_types = types;
-    Refresh();
+void WallGridPanel::SetWallTypes(const std::map<std::string, WallTypeData> &types) {
+	m_types = types;
+	Refresh();
 }
 
-void WallGridPanel::SetSelectedType(const std::string& type) {
-    m_selectedType = type;
-    Refresh();
+void WallGridPanel::SetSelectedType(const std::string &type) {
+	m_selectedType = type;
+	Refresh();
 }
 
-void WallGridPanel::OnPaint(wxPaintEvent& event) {
-    wxAutoBufferedPaintDC dc(this);
-    
-    // Background
-    dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
-    dc.Clear();
-    
-    wxRect rect = GetClientRect();
-    int w = rect.GetWidth();
-    int h = rect.GetHeight();
-    
-    // Calculate 3x3 grid metrics centered
-    int padding = 2;
-    int cellSize = std::min((w - 2 * 5) / 3, (h - 2 * 5) / 3);
-    if (cellSize < 32) cellSize = 32;
-    
-    int startX = (w - (cellSize * 3)) / 2;
-    int startY = (h - (cellSize * 3)) / 2;
-    
-    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-    dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    
-    // Draw Grid (3x3)
-    for (int i = 0; i <= 3; i++) {
-        dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + 3 * cellSize);
-        dc.DrawLine(startX, startY + i * cellSize, startX + 3 * cellSize, startY + i * cellSize);
-    }
-    
-    auto drawTypeAt = [&](const std::string& type, int gridX, int gridY) {
-        int x = startX + gridX * cellSize + padding;
-        int y = startY + gridY * cellSize + padding;
-        int size = cellSize - 2 * padding;
-        
-        bool isSelected = (m_selectedType == type);
-        
-        if (isSelected) {
-            dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
-            dc.DrawRectangle(x - padding, y - padding, cellSize, cellSize);
-        }
-        
-        if (m_types.find(type) != m_types.end() && !m_types[type].items.empty()) {
-            uint16_t itemId = m_types[type].items[0].itemId;
-            if (itemId > 0) {
-                const ItemType& it = g_items.getItemType(itemId);
-                if (it.id != 0) {
-                    Sprite* s = g_gui.gfx.getSprite(it.clientID);
-                    if (s) {
-                        wxMemoryDC tempDC;
-                        wxBitmap tempBitmap(32, 32);
-                        tempDC.SelectObject(tempBitmap);
-                        tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
-                        tempDC.Clear();
-                        s->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
-                        tempDC.SelectObject(wxNullBitmap);
-                        
-                        wxImage img = tempBitmap.ConvertToImage();
-                        if (img.IsOk()) {
-                            img.Rescale(size, size, wxIMAGE_QUALITY_NEAREST);
-                            dc.DrawBitmap(wxBitmap(img), x, y, true);
-                        }
-                    }
-                }
-            }
-        }
-    };
-    
-    // 3x3 Mapping (User configured)
-    // Row 0: Pole, horizontal, horizontal (Swapped Corner/Pole)
-    drawTypeAt("pole", 0, 0); 
-    drawTypeAt("horizontal", 1, 0);
-    drawTypeAt("horizontal", 2, 0);
-    
-    // Row 1: vertical, (empty), vertical
-    drawTypeAt("vertical", 0, 1);
-    // (1,1) is empty/vazio
-    drawTypeAt("vertical", 2, 1);
-    
-    // Row 2: vertical, horizontal, Corner (Swapped Corner/Pole)
-    drawTypeAt("vertical", 0, 2);
-    drawTypeAt("horizontal", 1, 2);
-    drawTypeAt("corner", 2, 2);
+void WallGridPanel::OnPaint(wxPaintEvent &event) {
+	wxAutoBufferedPaintDC dc(this);
+
+	// Background
+	dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+	dc.Clear();
+
+	wxRect rect = GetClientRect();
+	int w = rect.GetWidth();
+	int h = rect.GetHeight();
+
+	// Calculate 3x3 grid metrics centered
+	int padding = 2;
+	int cellSize = std::min((w - 2 * 5) / 3, (h - 2 * 5) / 3);
+	if (cellSize < 32) {
+		cellSize = 32;
+	}
+
+	int startX = (w - (cellSize * 3)) / 2;
+	int startY = (h - (cellSize * 3)) / 2;
+
+	dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+	dc.SetBrush(*wxTRANSPARENT_BRUSH);
+
+	// Draw Grid (3x3)
+	for (int i = 0; i <= 3; i++) {
+		dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + 3 * cellSize);
+		dc.DrawLine(startX, startY + i * cellSize, startX + 3 * cellSize, startY + i * cellSize);
+	}
+
+	auto drawTypeAt = [&](const std::string &type, int gridX, int gridY) {
+		int x = startX + gridX * cellSize + padding;
+		int y = startY + gridY * cellSize + padding;
+		int size = cellSize - 2 * padding;
+
+		bool isSelected = (m_selectedType == type);
+
+		if (isSelected) {
+			dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
+			dc.DrawRectangle(x - padding, y - padding, cellSize, cellSize);
+		}
+
+		if (m_types.find(type) != m_types.end() && !m_types[type].items.empty()) {
+			uint16_t itemId = m_types[type].items[0].itemId;
+			if (itemId > 0) {
+				const ItemType &it = g_items.getItemType(itemId);
+				if (it.id != 0) {
+					Sprite* s = g_gui.gfx.getSprite(it.clientID);
+					if (s) {
+						wxMemoryDC tempDC;
+						wxBitmap tempBitmap(32, 32);
+						tempDC.SelectObject(tempBitmap);
+						tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+						tempDC.Clear();
+						s->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
+						tempDC.SelectObject(wxNullBitmap);
+
+						wxImage img = tempBitmap.ConvertToImage();
+						if (img.IsOk()) {
+							img.Rescale(size, size, wxIMAGE_QUALITY_NEAREST);
+							dc.DrawBitmap(wxBitmap(img), x, y, true);
+						}
+					}
+				}
+			}
+		}
+	};
+
+	// 3x3 Mapping (User configured)
+	// Row 0: Pole, horizontal, horizontal (Swapped Corner/Pole)
+	drawTypeAt("pole", 0, 0);
+	drawTypeAt("horizontal", 1, 0);
+	drawTypeAt("horizontal", 2, 0);
+
+	// Row 1: vertical, (empty), vertical
+	drawTypeAt("vertical", 0, 1);
+	// (1,1) is empty/vazio
+	drawTypeAt("vertical", 2, 1);
+
+	// Row 2: vertical, horizontal, Corner (Swapped Corner/Pole)
+	drawTypeAt("vertical", 0, 2);
+	drawTypeAt("horizontal", 1, 2);
+	drawTypeAt("corner", 2, 2);
 }
 
-void WallGridPanel::OnMouseClick(wxMouseEvent& event) {
-    wxRect rect = GetClientRect();
-    int w = rect.GetWidth();
-    int h = rect.GetHeight();
-    
-    int cellSize = std::min((w - 2 * 5) / 3, (h - 2 * 5) / 3);
-    if (cellSize < 32) cellSize = 32;
-    
-    int startX = (w - (cellSize * 3)) / 2;
-    int startY = (h - (cellSize * 3)) / 2;
-    
-    int mouseX = event.GetX();
-    int mouseY = event.GetY();
-    
-    if (mouseX >= startX && mouseX < startX + 3 * cellSize &&
-        mouseY >= startY && mouseY < startY + 3 * cellSize) {
-        
-        int gridX = (mouseX - startX) / cellSize;
-        int gridY = (mouseY - startY) / cellSize;
-        
-        std::string clickedType = "";
-        
-        // Row 0
-        if (gridX == 0 && gridY == 0) clickedType = "pole"; // Swapped
-        else if (gridX == 1 && gridY == 0) clickedType = "horizontal";
-        else if (gridX == 2 && gridY == 0) clickedType = "horizontal";
-        
-        // Row 1
-        else if (gridX == 0 && gridY == 1) clickedType = "vertical";
-        // (1,1) is empty
-        else if (gridX == 2 && gridY == 1) clickedType = "vertical";
-        
-        // Row 2
-        else if (gridX == 0 && gridY == 2) clickedType = "vertical";
-        else if (gridX == 1 && gridY == 2) clickedType = "horizontal";
-        else if (gridX == 2 && gridY == 2) clickedType = "corner"; // Swapped
-        
-        if (!clickedType.empty()) {
-            m_selectedType = clickedType;
-            Refresh();
-            
-            wxCommandEvent evt(wxEVT_COMMAND_BUTTON_CLICKED, GetId());
-            evt.SetString(clickedType);
-            evt.SetEventObject(this);
-            
-            // Find parent dialog and call callback directly
-            wxWindow* parent = GetParent();
-            while (parent && !dynamic_cast<BorderEditorPanel*>(parent)) {
-                parent = parent->GetParent();
-            }
-            
-            if (BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(parent)) {
-                dialog->OnWallGridSelect(evt);
-            }
-        }
-    }
+void WallGridPanel::OnMouseClick(wxMouseEvent &event) {
+	wxRect rect = GetClientRect();
+	int w = rect.GetWidth();
+	int h = rect.GetHeight();
+
+	int cellSize = std::min((w - 2 * 5) / 3, (h - 2 * 5) / 3);
+	if (cellSize < 32) {
+		cellSize = 32;
+	}
+
+	int startX = (w - (cellSize * 3)) / 2;
+	int startY = (h - (cellSize * 3)) / 2;
+
+	int mouseX = event.GetX();
+	int mouseY = event.GetY();
+
+	if (mouseX >= startX && mouseX < startX + 3 * cellSize && mouseY >= startY && mouseY < startY + 3 * cellSize) {
+
+		int gridX = (mouseX - startX) / cellSize;
+		int gridY = (mouseY - startY) / cellSize;
+
+		std::string clickedType = "";
+
+		// Row 0
+		if (gridX == 0 && gridY == 0) {
+			clickedType = "pole"; // Swapped
+		} else if (gridX == 1 && gridY == 0) {
+			clickedType = "horizontal";
+		} else if (gridX == 2 && gridY == 0) {
+			clickedType = "horizontal";
+		}
+
+		// Row 1
+		else if (gridX == 0 && gridY == 1) {
+			clickedType = "vertical";
+		}
+		// (1,1) is empty
+		else if (gridX == 2 && gridY == 1) {
+			clickedType = "vertical";
+		}
+
+		// Row 2
+		else if (gridX == 0 && gridY == 2) {
+			clickedType = "vertical";
+		} else if (gridX == 1 && gridY == 2) {
+			clickedType = "horizontal";
+		} else if (gridX == 2 && gridY == 2) {
+			clickedType = "corner"; // Swapped
+		}
+
+		if (!clickedType.empty()) {
+			m_selectedType = clickedType;
+			Refresh();
+
+			wxCommandEvent evt(wxEVT_COMMAND_BUTTON_CLICKED, GetId());
+			evt.SetString(clickedType);
+			evt.SetEventObject(this);
+
+			// Find parent dialog and call callback directly
+			wxWindow* parent = GetParent();
+			while (parent && !dynamic_cast<BorderEditorPanel*>(parent)) {
+				parent = parent->GetParent();
+			}
+
+			if (BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(parent)) {
+				dialog->OnWallGridSelect(evt);
+			}
+		}
+	}
 }
 
 // ============================================================================
 // WallVisualPanel
 
 BEGIN_EVENT_TABLE(WallVisualPanel, wxPanel)
-    EVT_PAINT(WallVisualPanel::OnPaint)
+EVT_PAINT(WallVisualPanel::OnPaint)
 END_EVENT_TABLE()
 
 WallVisualPanel::WallVisualPanel(wxWindow* parent, wxWindowID id) :
-    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize)
-{
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
-    SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
+	wxPanel(parent, id, wxDefaultPosition, wxDefaultSize) {
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+	SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
 }
 
 WallVisualPanel::~WallVisualPanel() {
 }
 
-void WallVisualPanel::SetWallItems(const std::map<std::string, WallTypeData>& items) {
-    m_items = items;
-    Refresh();
+void WallVisualPanel::SetWallItems(const std::map<std::string, WallTypeData> &items) {
+	m_items = items;
+	Refresh();
 }
 
 void WallVisualPanel::Clear() {
-    m_items.clear();
-    Refresh();
+	m_items.clear();
+	Refresh();
 }
 
-void WallVisualPanel::OnPaint(wxPaintEvent& event) {
-    wxAutoBufferedPaintDC dc(this);
-    
-    // Get panel dimensions
-    wxRect rect = GetClientRect();
-    int panelWidth = rect.GetWidth();
-    int panelHeight = rect.GetHeight();
-    
-    // Use parent's background
-    if (GetParent()) {
-        dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
-    } else {
-        dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
-    }
-    dc.Clear();
-    
-    // 5x5 Test Pattern
-    const int GRID_SIZE = 5;
-    const int TITLE_HEIGHT = 20;
-    const int MARGIN = 5;
-    
-    int availableWidth = panelWidth - 2 * MARGIN;
-    int availableHeight = panelHeight - TITLE_HEIGHT - 2 * MARGIN;
-    
-    if (availableWidth <= 0 || availableHeight <= 0) return;
-    
-    // Calculate cell size
-    int cellSize = std::min(availableWidth, availableHeight) / GRID_SIZE;
-    if (cellSize < 16) cellSize = 16;
-    
-    // Limits
-    if (cellSize > 64) cellSize = 64; 
-    
-    int totalGridSize = GRID_SIZE * cellSize;
-    
-    // Center grid
-    int startX = (panelWidth - totalGridSize) / 2;
-    int startY = TITLE_HEIGHT + (availableHeight - totalGridSize) / 2;
-    if (startY < TITLE_HEIGHT) startY = TITLE_HEIGHT;
-    
-    // Draw "Preview" label
-    dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-    font.MakeBold();
-    dc.SetFont(font);
-    
-    wxString label = "Preview";
-    wxSize textSize = dc.GetTextExtent(label);
-    dc.DrawText(label, (panelWidth - textSize.GetWidth()) / 2, 2);
-    
-    // Background border
-    const int BORDER_WIDTH = 1;
-    wxRect gridBgRect(startX - BORDER_WIDTH, startY - BORDER_WIDTH, totalGridSize + 2 * BORDER_WIDTH, totalGridSize + 2 * BORDER_WIDTH);
-    dc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
-    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-    dc.DrawRectangle(gridBgRect);
-    
-    // Draw 5x5 grid lines
-    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-    for (int i = 0; i <= GRID_SIZE; i++) {
-        dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + totalGridSize);
-        dc.DrawLine(startX, startY + i * cellSize, startX + totalGridSize, startY + i * cellSize);
-    }
-    
-    // Mapping Logic: Grid Position -> Wall Type
-    auto getWallTypeAt = [](int x, int y) -> std::string {
-        // Layout Configured by User:
-        // R0: Pole, H, H, H, H
-        // R1: V, ., ., ., V
-        // R2: V, ., ., ., V
-        // R3: V, ., ., ., V
-        // R4: V, ., ., ., Corner
-        
-        if (y == 0) {
-            if (x == 0) return "pole";
-            return "horizontal"; // x=1..4
-        }
-        else if (y >= 1 && y <= 3) {
-            if (x == 0) return "vertical";
-            if (x == 4) return "vertical";
-            return ""; // Middle is empty
-        }
-        else if (y == 4) {
-            if (x == 0) return "vertical";
-            if (x == 4) return "corner";
-            return "horizontal"; // Middle is horizontal
-        }
-        return "";
-    };
+void WallVisualPanel::OnPaint(wxPaintEvent &event) {
+	wxAutoBufferedPaintDC dc(this);
 
-    const int spritePadding = 2;
-    
-    for (int y = 0; y < GRID_SIZE; y++) {
-        for (int x = 0; x < GRID_SIZE; x++) {
-            std::string typeName = getWallTypeAt(x, y);
-            if (typeName.empty()) continue;
-            
-            // Draw item
-            if (m_items.find(typeName) != m_items.end() && !m_items[typeName].items.empty()) {
-                uint16_t itemId = m_items[typeName].items[0].itemId;
-                if (itemId > 0) {
-                    int drawX = startX + x * cellSize;
-                    int drawY = startY + y * cellSize;
-                    
-                    const ItemType& itemType = g_items.getItemType(itemId);
-                    if (itemType.id != 0) {
-                        Sprite* sprite = g_gui.gfx.getSprite(itemType.clientID);
-                        if (sprite) {
-                             // Correctly scale 32x32 sprite to cell size
-                             int targetW = cellSize - 2 * spritePadding;
-                             int targetH = cellSize - 2 * spritePadding;
-                             
-                             // Draw internal uses raw coordinates, we can use DrawTo with scaling if supported
-                             // Or render to bitmap and scale.
-                             // Using the previous method: render to bitmap then draw
-                            wxMemoryDC tempDC;
-                            wxBitmap tempBitmap(32, 32);
-                            tempDC.SelectObject(tempBitmap);
-                            tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
-                            tempDC.Clear();
-                            sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
-                            tempDC.SelectObject(wxNullBitmap);
-                            
-                            wxImage img = tempBitmap.ConvertToImage();
-                            if (img.IsOk()) {
-                                img.Rescale(targetW, targetH, wxIMAGE_QUALITY_NEAREST);
-                                dc.DrawBitmap(wxBitmap(img), drawX + spritePadding, drawY + spritePadding, true);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-} 
+	// Get panel dimensions
+	wxRect rect = GetClientRect();
+	int panelWidth = rect.GetWidth();
+	int panelHeight = rect.GetHeight();
 
+	// Use parent's background
+	if (GetParent()) {
+		dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
+	} else {
+		dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+	}
+	dc.Clear();
+
+	// 5x5 Test Pattern
+	const int GRID_SIZE = 5;
+	const int TITLE_HEIGHT = 20;
+	const int MARGIN = 5;
+
+	int availableWidth = panelWidth - 2 * MARGIN;
+	int availableHeight = panelHeight - TITLE_HEIGHT - 2 * MARGIN;
+
+	if (availableWidth <= 0 || availableHeight <= 0) {
+		return;
+	}
+
+	// Calculate cell size
+	int cellSize = std::min(availableWidth, availableHeight) / GRID_SIZE;
+	if (cellSize < 16) {
+		cellSize = 16;
+	}
+
+	// Limits
+	if (cellSize > 64) {
+		cellSize = 64;
+	}
+
+	int totalGridSize = GRID_SIZE * cellSize;
+
+	// Center grid
+	int startX = (panelWidth - totalGridSize) / 2;
+	int startY = TITLE_HEIGHT + (availableHeight - totalGridSize) / 2;
+	if (startY < TITLE_HEIGHT) {
+		startY = TITLE_HEIGHT;
+	}
+
+	// Draw "Preview" label
+	dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+	wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+	font.MakeBold();
+	dc.SetFont(font);
+
+	wxString label = "Preview";
+	wxSize textSize = dc.GetTextExtent(label);
+	dc.DrawText(label, (panelWidth - textSize.GetWidth()) / 2, 2);
+
+	// Background border
+	const int BORDER_WIDTH = 1;
+	wxRect gridBgRect(startX - BORDER_WIDTH, startY - BORDER_WIDTH, totalGridSize + 2 * BORDER_WIDTH, totalGridSize + 2 * BORDER_WIDTH);
+	dc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+	dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+	dc.DrawRectangle(gridBgRect);
+
+	// Draw 5x5 grid lines
+	dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+	for (int i = 0; i <= GRID_SIZE; i++) {
+		dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + totalGridSize);
+		dc.DrawLine(startX, startY + i * cellSize, startX + totalGridSize, startY + i * cellSize);
+	}
+
+	// Mapping Logic: Grid Position -> Wall Type
+	auto getWallTypeAt = [](int x, int y) -> std::string {
+		// Layout Configured by User:
+		// R0: Pole, H, H, H, H
+		// R1: V, ., ., ., V
+		// R2: V, ., ., ., V
+		// R3: V, ., ., ., V
+		// R4: V, ., ., ., Corner
+
+		if (y == 0) {
+			if (x == 0) {
+				return "pole";
+			}
+			return "horizontal"; // x=1..4
+		} else if (y >= 1 && y <= 3) {
+			if (x == 0) {
+				return "vertical";
+			}
+			if (x == 4) {
+				return "vertical";
+			}
+			return ""; // Middle is empty
+		} else if (y == 4) {
+			if (x == 0) {
+				return "vertical";
+			}
+			if (x == 4) {
+				return "corner";
+			}
+			return "horizontal"; // Middle is horizontal
+		}
+		return "";
+	};
+
+	const int spritePadding = 2;
+
+	for (int y = 0; y < GRID_SIZE; y++) {
+		for (int x = 0; x < GRID_SIZE; x++) {
+			std::string typeName = getWallTypeAt(x, y);
+			if (typeName.empty()) {
+				continue;
+			}
+
+			// Draw item
+			if (m_items.find(typeName) != m_items.end() && !m_items[typeName].items.empty()) {
+				uint16_t itemId = m_items[typeName].items[0].itemId;
+				if (itemId > 0) {
+					int drawX = startX + x * cellSize;
+					int drawY = startY + y * cellSize;
+
+					const ItemType &itemType = g_items.getItemType(itemId);
+					if (itemType.id != 0) {
+						Sprite* sprite = g_gui.gfx.getSprite(itemType.clientID);
+						if (sprite) {
+							// Correctly scale 32x32 sprite to cell size
+							int targetW = cellSize - 2 * spritePadding;
+							int targetH = cellSize - 2 * spritePadding;
+
+							// Draw internal uses raw coordinates, we can use DrawTo with scaling if supported
+							// Or render to bitmap and scale.
+							// Using the previous method: render to bitmap then draw
+							wxMemoryDC tempDC;
+							wxBitmap tempBitmap(32, 32);
+							tempDC.SelectObject(tempBitmap);
+							tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+							tempDC.Clear();
+							sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
+							tempDC.SelectObject(wxNullBitmap);
+
+							wxImage img = tempBitmap.ConvertToImage();
+							if (img.IsOk()) {
+								img.Rescale(targetW, targetH, wxIMAGE_QUALITY_NEAREST);
+								dc.DrawBitmap(wxBitmap(img), drawX + spritePadding, drawY + spritePadding, true);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
 
 // ============================================================================
 // GroundGridPanel (Visual Copy of BorderGridPanel)
 // ============================================================================
 
 BEGIN_EVENT_TABLE(GroundGridPanel, wxPanel)
-    EVT_PAINT(GroundGridPanel::OnPaint)
-    EVT_LEFT_DOWN(GroundGridPanel::OnMouseClick)
-    EVT_LEFT_DCLICK(GroundGridPanel::OnLeftDClick)
-    EVT_RIGHT_DOWN(GroundGridPanel::OnRightClick)
+EVT_PAINT(GroundGridPanel::OnPaint)
+EVT_LEFT_DOWN(GroundGridPanel::OnMouseClick)
+EVT_LEFT_DCLICK(GroundGridPanel::OnLeftDClick)
+EVT_RIGHT_DOWN(GroundGridPanel::OnRightClick)
 END_EVENT_TABLE()
 
 GroundGridPanel::GroundGridPanel(wxWindow* parent, wxWindowID id) :
-    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE),
-    m_itemId(0),
-    m_chance(100),
-    m_isSelected(false)
-{
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
+	wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE),
+	m_itemId(0),
+	m_chance(100),
+	m_isSelected(false) {
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 // ============================================================================
@@ -4515,39 +4836,40 @@ GroundGridPanel::GroundGridPanel(wxWindow* parent, wxWindowID id) :
 // ============================================================================
 class ChanceEditDialog : public wxDialog {
 public:
-    ChanceEditDialog(wxWindow* parent, int initialValue) : 
-        wxDialog(parent, wxID_ANY, "Chance", wxDefaultPosition, wxSize(200, 120)) 
-    {
-        wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+	ChanceEditDialog(wxWindow* parent, int initialValue) :
+		wxDialog(parent, wxID_ANY, "Chance", wxDefaultPosition, wxSize(200, 120)) {
+		wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
-        m_spinCtrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(100, -1));
-        m_spinCtrl->SetRange(1, 1000000);
-        m_spinCtrl->SetValue(initialValue);
-        
-        // Center the spin control horizontally
-        wxBoxSizer* centerSizer = new wxBoxSizer(wxHORIZONTAL);
-        centerSizer->Add(m_spinCtrl, 1, wxALIGN_CENTER);
-        mainSizer->Add(centerSizer, 1, wxEXPAND | wxALL, 10);
+		m_spinCtrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(100, -1));
+		m_spinCtrl->SetRange(1, 1000000);
+		m_spinCtrl->SetValue(initialValue);
 
-        // Buttons
-        wxStdDialogButtonSizer* btnSizer = new wxStdDialogButtonSizer();
-        btnSizer->AddButton(new wxButton(this, wxID_OK));
-        btnSizer->AddButton(new wxButton(this, wxID_CANCEL));
-        btnSizer->Realize();
-        mainSizer->Add(btnSizer, 0, wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, 10);
+		// Center the spin control horizontally
+		wxBoxSizer* centerSizer = new wxBoxSizer(wxHORIZONTAL);
+		centerSizer->Add(m_spinCtrl, 1, wxALIGN_CENTER);
+		mainSizer->Add(centerSizer, 1, wxEXPAND | wxALL, 10);
 
-        SetSizer(mainSizer);
-        Layout();
-        CenterOnParent();
-        
-        m_spinCtrl->SetFocus();
-        m_spinCtrl->SetSelection(-1, -1); // Select all text
-    }
+		// Buttons
+		wxStdDialogButtonSizer* btnSizer = new wxStdDialogButtonSizer();
+		btnSizer->AddButton(new wxButton(this, wxID_OK));
+		btnSizer->AddButton(new wxButton(this, wxID_CANCEL));
+		btnSizer->Realize();
+		mainSizer->Add(btnSizer, 0, wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, 10);
 
-    int GetValue() const { return m_spinCtrl->GetValue(); }
+		SetSizer(mainSizer);
+		Layout();
+		CenterOnParent();
+
+		m_spinCtrl->SetFocus();
+		m_spinCtrl->SetSelection(-1, -1); // Select all text
+	}
+
+	int GetValue() const {
+		return m_spinCtrl->GetValue();
+	}
 
 private:
-    wxSpinCtrl* m_spinCtrl;
+	wxSpinCtrl* m_spinCtrl;
 };
 
 // ============================================================================
@@ -4555,344 +4877,355 @@ private:
 // ============================================================================
 
 BEGIN_EVENT_TABLE(GroundPreviewPanel, wxPanel)
-    EVT_PAINT(GroundPreviewPanel::OnPaint)
-    EVT_TIMER(wxID_ANY, GroundPreviewPanel::OnTimer)
+EVT_PAINT(GroundPreviewPanel::OnPaint)
+EVT_TIMER(wxID_ANY, GroundPreviewPanel::OnTimer)
 END_EVENT_TABLE()
 
 GroundPreviewPanel::GroundPreviewPanel(wxWindow* parent, wxWindowID id) :
-    wxPanel(parent, id, wxDefaultPosition, wxSize(110, 110), wxNO_BORDER),
-    m_currentIndex(0),
-    m_animationTimer(this),
-    m_lastCycleTime(0)
-{
-    // Use system default background
-    m_animationTimer.Start(50); // 20 FPS
+	wxPanel(parent, id, wxDefaultPosition, wxSize(110, 110), wxNO_BORDER),
+	m_currentIndex(0),
+	m_animationTimer(this),
+	m_lastCycleTime(0) {
+	// Use system default background
+	m_animationTimer.Start(50); // 20 FPS
 }
 
 GroundPreviewPanel::~GroundPreviewPanel() {
-    if (m_animationTimer.IsRunning()) {
-        m_animationTimer.Stop();
-    }
+	if (m_animationTimer.IsRunning()) {
+		m_animationTimer.Stop();
+	}
 }
 
-void GroundPreviewPanel::SetWeightedItems(const std::vector<std::pair<uint16_t, int>>& items) {
-    m_displayItems.clear();
-    for (const auto& pair : items) {
-        if (pair.first != 0) {
-            m_displayItems.push_back(pair.first);
-        }
-    }
-    m_currentIndex = 0;
-    Refresh();
+void GroundPreviewPanel::SetWeightedItems(const std::vector<std::pair<uint16_t, int>> &items) {
+	m_displayItems.clear();
+	for (const auto &pair : items) {
+		if (pair.first != 0) {
+			m_displayItems.push_back(pair.first);
+		}
+	}
+	m_currentIndex = 0;
+	Refresh();
 }
 
 void GroundPreviewPanel::UpdateFromContainer(GroundGridContainer* container) {
-    if (container) {
-        SetWeightedItems(container->GetAllItemsWithChance());
-    }
+	if (container) {
+		SetWeightedItems(container->GetAllItemsWithChance());
+	}
 }
 
-void GroundPreviewPanel::OnTimer(wxTimerEvent& event) {
-    // 1. Handle Animation Refresh (Redraw every tick)
-    Refresh();
+void GroundPreviewPanel::OnTimer(wxTimerEvent &event) {
+	// 1. Handle Animation Refresh (Redraw every tick)
+	Refresh();
 
-    // 2. Handle Item Cycling (Every 1000ms)
-    long currentTime = wxGetLocalTimeMillis().GetValue();
-    if (currentTime - m_lastCycleTime >= 1000) {
-        if (!m_displayItems.empty()) {
-            m_currentIndex = (m_currentIndex + 1) % m_displayItems.size();
-        }
-        m_lastCycleTime = currentTime;
-    }
+	// 2. Handle Item Cycling (Every 1000ms)
+	long currentTime = wxGetLocalTimeMillis().GetValue();
+	if (currentTime - m_lastCycleTime >= 1000) {
+		if (!m_displayItems.empty()) {
+			m_currentIndex = (m_currentIndex + 1) % m_displayItems.size();
+		}
+		m_lastCycleTime = currentTime;
+	}
 }
 
-void GroundPreviewPanel::OnPaint(wxPaintEvent& event) {
-    wxBufferedPaintDC dc(this);
-    // Use parent's background to be seamless
-    if (GetParent()) {
-        dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
-    } else {
-        dc.SetBackground(wxBrush(GetBackgroundColour()));
-    }
-    dc.Clear();
+void GroundPreviewPanel::OnPaint(wxPaintEvent &event) {
+	wxBufferedPaintDC dc(this);
+	// Use parent's background to be seamless
+	if (GetParent()) {
+		dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
+	} else {
+		dc.SetBackground(wxBrush(GetBackgroundColour()));
+	}
+	dc.Clear();
 
-    if (m_displayItems.empty()) return;
+	if (m_displayItems.empty()) {
+		return;
+	}
 
-    // Safety check for index
-    if (m_currentIndex >= m_displayItems.size()) m_currentIndex = 0;
+	// Safety check for index
+	if (m_currentIndex >= m_displayItems.size()) {
+		m_currentIndex = 0;
+	}
 
-    uint16_t itemId = m_displayItems[m_currentIndex];
-    if (itemId == 0) return;
+	uint16_t itemId = m_displayItems[m_currentIndex];
+	if (itemId == 0) {
+		return;
+	}
 
-    const ItemType& itemType = g_items.getItemType(itemId);
-    if (itemType.id == 0) return;
+	const ItemType &itemType = g_items.getItemType(itemId);
+	if (itemType.id == 0) {
+		return;
+	}
 
-    Sprite* sprite = g_gui.gfx.getSprite(itemType.clientID);
-    if (!sprite) return;
+	Sprite* sprite = g_gui.gfx.getSprite(itemType.clientID);
+	if (!sprite) {
+		return;
+	}
 
-    int panelW, panelH;
-    GetSize(&panelW, &panelH);
-    
-    // Draw scaled sprite
-    // Create temp bitmap 32x32
-    wxMemoryDC tempDC;
-    wxBitmap tempBitmap(32, 32);
-    tempDC.SelectObject(tempBitmap);
-    tempDC.SetBackground(*wxTRANSPARENT_BRUSH); // Transparent background
-    tempDC.Clear();
-    
-    // Draw sprite to temp DC (0,0)
-    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0, 32, 32);
-    tempDC.SelectObject(wxNullBitmap);
-    
-    // Convert to image and rescale
-    wxImage img = tempBitmap.ConvertToImage();
-    if (img.IsOk()) {
-        // Scale to fit panel minus padding
-        int padding = 4;
-        int targetSize = std::min(panelW, panelH) - (2 * padding);
-        if (targetSize < 32) targetSize = 32;
+	int panelW, panelH;
+	GetSize(&panelW, &panelH);
 
-        img.Rescale(targetSize, targetSize, wxIMAGE_QUALITY_NEAREST);
-        wxBitmap scaledBmp(img);
-        
-        // Center draw
-        int x = (panelW - targetSize) / 2;
-        int y = (panelH - targetSize) / 2;
-        dc.DrawBitmap(scaledBmp, x, y, true);
-    }
+	// Draw scaled sprite
+	// Create temp bitmap 32x32
+	wxMemoryDC tempDC;
+	wxBitmap tempBitmap(32, 32);
+	tempDC.SelectObject(tempBitmap);
+	tempDC.SetBackground(*wxTRANSPARENT_BRUSH); // Transparent background
+	tempDC.Clear();
+
+	// Draw sprite to temp DC (0,0)
+	sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0, 32, 32);
+	tempDC.SelectObject(wxNullBitmap);
+
+	// Convert to image and rescale
+	wxImage img = tempBitmap.ConvertToImage();
+	if (img.IsOk()) {
+		// Scale to fit panel minus padding
+		int padding = 4;
+		int targetSize = std::min(panelW, panelH) - (2 * padding);
+		if (targetSize < 32) {
+			targetSize = 32;
+		}
+
+		img.Rescale(targetSize, targetSize, wxIMAGE_QUALITY_NEAREST);
+		wxBitmap scaledBmp(img);
+
+		// Center draw
+		int x = (panelW - targetSize) / 2;
+		int y = (panelH - targetSize) / 2;
+		dc.DrawBitmap(scaledBmp, x, y, true);
+	}
 }
 
-GroundGridPanel::~GroundGridPanel() {}
+GroundGridPanel::~GroundGridPanel() { }
 
 void GroundGridPanel::SetItemId(uint16_t id) {
-    m_itemId = id;
-    Refresh();
+	m_itemId = id;
+	Refresh();
 }
 
 void GroundGridPanel::Clear() {
-    m_itemId = 0;
-    m_chance = 100;
-    SetSelected(false);
-    Refresh();
+	m_itemId = 0;
+	m_chance = 100;
+	SetSelected(false);
+	Refresh();
 }
 
 void GroundGridPanel::SetSelected(bool selected) {
-    if (m_isSelected != selected) {
-        m_isSelected = selected;
-        Refresh();
-    }
+	if (m_isSelected != selected) {
+		m_isSelected = selected;
+		Refresh();
+	}
 }
 
 void GroundGridPanel::SetChance(int chance) {
-    m_chance = chance;
+	m_chance = chance;
 }
 
 wxSize GroundGridPanel::DoGetBestSize() const {
-    // 64px cell + 5px margin on each side = 74x74
-    return wxSize(74, 74);
+	// 64px cell + 5px margin on each side = 74x74
+	return wxSize(74, 74);
 }
 
-void GroundGridPanel::OnLeftDClick(wxMouseEvent& event) {
-    if (m_itemId == 0) return; // Ignore empty cells
+void GroundGridPanel::OnLeftDClick(wxMouseEvent &event) {
+	if (m_itemId == 0) {
+		return; // Ignore empty cells
+	}
 
-    ChanceEditDialog dlg(this, m_chance);
-    if (dlg.ShowModal() == wxID_OK) {
-        int newChance = dlg.GetValue();
-        if (newChance != m_chance) {
-            m_chance = newChance;
-            Refresh(); // Redraw (maybe show tooltip with chance?)
-            // We could refresh tooltip if we had one
-            SetToolTip(wxString::Format("Item ID: %d\nChance: %d", m_itemId, m_chance));
-        }
-    }
+	ChanceEditDialog dlg(this, m_chance);
+	if (dlg.ShowModal() == wxID_OK) {
+		int newChance = dlg.GetValue();
+		if (newChance != m_chance) {
+			m_chance = newChance;
+			Refresh(); // Redraw (maybe show tooltip with chance?)
+			// We could refresh tooltip if we had one
+			SetToolTip(wxString::Format("Item ID: %d\nChance: %d", m_itemId, m_chance));
+		}
+	}
 }
 
-void GroundGridPanel::OnMouseClick(wxMouseEvent& event) {
-    wxSize size = GetClientSize();
-    int w = size.GetWidth();
-    int h = size.GetHeight();
-    int margin = 5;
-    
-    // Use fixed size for individual cells to avoid excessive spacing
-    int cellSize = 64;
-    
-    // Start at top-left with margin (documentation standard)
-    int gridX = margin;
-    int gridY = margin;
-    
-    int clickX = event.GetX();
-    int clickY = event.GetY();
-    
-    // Check if click is within the grid cell
-    if (clickX >= gridX && clickX < gridX + cellSize &&
-        clickY >= gridY && clickY < gridY + cellSize) {
-        
-        // Get the currently selected brush from the GUI
-        Brush* brush = g_gui.GetCurrentBrush();
-        if (brush && brush->isRaw()) {
-            RAWBrush* rawBrush = dynamic_cast<RAWBrush*>(brush);
-            if (rawBrush) {
-                m_itemId = rawBrush->getItemID();
-                Refresh();
-                
-                // No auto-append: a nova variação só é criada via botão "Add Variation"
-            }
-        }
-    }
+void GroundGridPanel::OnMouseClick(wxMouseEvent &event) {
+	wxSize size = GetClientSize();
+	int w = size.GetWidth();
+	int h = size.GetHeight();
+	int margin = 5;
+
+	// Use fixed size for individual cells to avoid excessive spacing
+	int cellSize = 64;
+
+	// Start at top-left with margin (documentation standard)
+	int gridX = margin;
+	int gridY = margin;
+
+	int clickX = event.GetX();
+	int clickY = event.GetY();
+
+	// Check if click is within the grid cell
+	if (clickX >= gridX && clickX < gridX + cellSize && clickY >= gridY && clickY < gridY + cellSize) {
+
+		// Get the currently selected brush from the GUI
+		Brush* brush = g_gui.GetCurrentBrush();
+		if (brush && brush->isRaw()) {
+			RAWBrush* rawBrush = dynamic_cast<RAWBrush*>(brush);
+			if (rawBrush) {
+				m_itemId = rawBrush->getItemID();
+				Refresh();
+
+				// No auto-append: a nova variação só é criada via botão "Add Variation"
+			}
+		}
+	}
 }
-void GroundGridPanel::OnRightClick(wxMouseEvent& event) {
-    wxSize size = GetClientSize();
-    int w = size.GetWidth();
-    int h = size.GetHeight();
-    int margin = 5;
-    
-    // Fixed cell size matching OnPaint
-    int cellSize = 64;
-    
-    // Start at top-left with margin (matching OnPaint)
-    int gridX = margin;
-    int gridY = margin;
-    
-    int clickX = event.GetX();
-    int clickY = event.GetY();
-    
-    // Check if click is within the grid cell
-    if (clickX >= gridX && clickX < gridX + cellSize &&
-        clickY >= gridY && clickY < gridY + cellSize) {
-        
-        // If the cell is not empty, request removal from container
-        if (!IsEmpty()) {
-            wxWindow* parent = GetParent();
-            GroundGridContainer* container = dynamic_cast<GroundGridContainer*>(parent);
-            if (container) {
-                container->RemoveCell(this);
-            }
-        }
-    }
+void GroundGridPanel::OnRightClick(wxMouseEvent &event) {
+	wxSize size = GetClientSize();
+	int w = size.GetWidth();
+	int h = size.GetHeight();
+	int margin = 5;
+
+	// Fixed cell size matching OnPaint
+	int cellSize = 64;
+
+	// Start at top-left with margin (matching OnPaint)
+	int gridX = margin;
+	int gridY = margin;
+
+	int clickX = event.GetX();
+	int clickY = event.GetY();
+
+	// Check if click is within the grid cell
+	if (clickX >= gridX && clickX < gridX + cellSize && clickY >= gridY && clickY < gridY + cellSize) {
+
+		// If the cell is not empty, request removal from container
+		if (!IsEmpty()) {
+			wxWindow* parent = GetParent();
+			GroundGridContainer* container = dynamic_cast<GroundGridContainer*>(parent);
+			if (container) {
+				container->RemoveCell(this);
+			}
+		}
+	}
 }
-void GroundGridPanel::OnPaint(wxPaintEvent& event) {
-    wxAutoBufferedPaintDC dc(this);
-    
-    // Use system background color like Border Editor
-    dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
-    dc.Clear();
+void GroundGridPanel::OnPaint(wxPaintEvent &event) {
+	wxAutoBufferedPaintDC dc(this);
 
-    wxSize size = GetClientSize();
-    int w = size.GetWidth();
-    int h = size.GetHeight();
-    int margin = 5;
-    
-    // Match sizing of individual grid cells (standard 64px)
-    int cellSize = 64;
-    
-    // Start at top-left with margin (documentation standard)
-    int x = margin;
-    int y = margin;
-    
-    // Use GraphicsContext for opacity (75% = 191 alpha)
-    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
-    if (gc) {
-        gc->SetAntialiasMode(wxANTIALIAS_NONE);
-        
-        // Draw grid lines (like Border Editor) with 75% opacity
-        wxColour grayText = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
-        gc->SetPen(wxPen(wxColour(grayText.Red(), grayText.Green(), grayText.Blue(), 191)));
-        gc->SetBrush(*wxTRANSPARENT_BRUSH);
-        
-        // Draw 1x1 grid (rectangle)
-        gc->DrawRectangle(x, y, cellSize, cellSize);
-        
-        // Draw the assigned item sprite if set
-        if (m_itemId > 0) {
-            const ItemType& type = g_items.getItemType(m_itemId);
-            if (type.id != 0) {
-                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
-                if (sprite) {
-                    // Sprite rendering with scaling to fit cell
-                    const int spritePadding = 2;
-                    const int spriteSize = cellSize - 2 * spritePadding;
-                    
-                    wxMemoryDC tempDC;
-                    wxBitmap tempBitmap(32, 32);
-                    tempDC.SelectObject(tempBitmap);
-                    tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
-                    tempDC.Clear();
-                    
-                    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
-                    tempDC.SelectObject(wxNullBitmap);
-                    
-                    wxImage img = tempBitmap.ConvertToImage();
-                    if (img.IsOk()) {
-                        img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
-                        wxBitmap scaledBmp(img);
-                        
-                        // Draw bitmap with 75% opacity
-                        gc->DrawBitmap(scaledBmp, x + spritePadding, y + spritePadding, spriteSize, spriteSize);
-                    }
-                }
-            }
-        }
-    } else {
-        // Fallback to normal DC if GC fails
-        dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(x, y, cellSize, cellSize);
-        
-        if (m_itemId > 0) {
-            const ItemType& type = g_items.getItemType(m_itemId);
-            if (type.id != 0) {
-                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
-                if (sprite) {
-                    const int spritePadding = 2;
-                    const int spriteSize = cellSize - 2 * spritePadding;
-                    
-                    wxMemoryDC tempDC;
-                    wxBitmap tempBitmap(32, 32);
-                    tempDC.SelectObject(tempBitmap);
-                    tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
-                    tempDC.Clear();
-                    
-                    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
-                    tempDC.SelectObject(wxNullBitmap);
-                    
-                    wxImage img = tempBitmap.ConvertToImage();
-                    if (img.IsOk()) {
-                        img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
-                        wxBitmap scaledBmp(img);
-                        dc.DrawBitmap(scaledBmp, x + spritePadding, y + spritePadding, true);
-                    }
-                }
-            }
-        }
-    }
+	// Use system background color like Border Editor
+	dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+	dc.Clear();
 
-    // Draw Chance Value Overlay (if item exists)
-    if (m_itemId > 0) {
-        wxString chanceText = wxString::Format("%d", m_chance);
-        wxFont font(8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD);
-        dc.SetFont(font);
-        
-        wxSize textSize = dc.GetTextExtent(chanceText);
-        // Position at bottom-right of the cell
-        int textX = x + cellSize - textSize.GetWidth() - 4;
-        int textY = y + cellSize - textSize.GetHeight() - 4;
-        
-        // Draw shadow (black)
-        dc.SetTextForeground(*wxBLACK);
-        dc.DrawText(chanceText, textX + 1, textY + 1);
-        
-        // Draw text (white)
-        dc.SetTextForeground(*wxWHITE);
-        dc.DrawText(chanceText, textX, textY);
-    }
+	wxSize size = GetClientSize();
+	int w = size.GetWidth();
+	int h = size.GetHeight();
+	int margin = 5;
 
-    // Draw selection border if selected
-    if (m_isSelected) {
-        dc.SetPen(wxPen(*wxBLUE, 3)); // Thick blue border
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-        dc.DrawRectangle(x, y, cellSize, cellSize);
-    }
+	// Match sizing of individual grid cells (standard 64px)
+	int cellSize = 64;
+
+	// Start at top-left with margin (documentation standard)
+	int x = margin;
+	int y = margin;
+
+	// Use GraphicsContext for opacity (75% = 191 alpha)
+	std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
+	if (gc) {
+		gc->SetAntialiasMode(wxANTIALIAS_NONE);
+
+		// Draw grid lines (like Border Editor) with 75% opacity
+		wxColour grayText = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+		gc->SetPen(wxPen(wxColour(grayText.Red(), grayText.Green(), grayText.Blue(), 191)));
+		gc->SetBrush(*wxTRANSPARENT_BRUSH);
+
+		// Draw 1x1 grid (rectangle)
+		gc->DrawRectangle(x, y, cellSize, cellSize);
+
+		// Draw the assigned item sprite if set
+		if (m_itemId > 0) {
+			const ItemType &type = g_items.getItemType(m_itemId);
+			if (type.id != 0) {
+				Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+				if (sprite) {
+					// Sprite rendering with scaling to fit cell
+					const int spritePadding = 2;
+					const int spriteSize = cellSize - 2 * spritePadding;
+
+					wxMemoryDC tempDC;
+					wxBitmap tempBitmap(32, 32);
+					tempDC.SelectObject(tempBitmap);
+					tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+					tempDC.Clear();
+
+					sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
+					tempDC.SelectObject(wxNullBitmap);
+
+					wxImage img = tempBitmap.ConvertToImage();
+					if (img.IsOk()) {
+						img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
+						wxBitmap scaledBmp(img);
+
+						// Draw bitmap with 75% opacity
+						gc->DrawBitmap(scaledBmp, x + spritePadding, y + spritePadding, spriteSize, spriteSize);
+					}
+				}
+			}
+		}
+	} else {
+		// Fallback to normal DC if GC fails
+		dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+		dc.SetBrush(*wxTRANSPARENT_BRUSH);
+		dc.DrawRectangle(x, y, cellSize, cellSize);
+
+		if (m_itemId > 0) {
+			const ItemType &type = g_items.getItemType(m_itemId);
+			if (type.id != 0) {
+				Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+				if (sprite) {
+					const int spritePadding = 2;
+					const int spriteSize = cellSize - 2 * spritePadding;
+
+					wxMemoryDC tempDC;
+					wxBitmap tempBitmap(32, 32);
+					tempDC.SelectObject(tempBitmap);
+					tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+					tempDC.Clear();
+
+					sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
+					tempDC.SelectObject(wxNullBitmap);
+
+					wxImage img = tempBitmap.ConvertToImage();
+					if (img.IsOk()) {
+						img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
+						wxBitmap scaledBmp(img);
+						dc.DrawBitmap(scaledBmp, x + spritePadding, y + spritePadding, true);
+					}
+				}
+			}
+		}
+	}
+
+	// Draw Chance Value Overlay (if item exists)
+	if (m_itemId > 0) {
+		wxString chanceText = wxString::Format("%d", m_chance);
+		wxFont font(8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD);
+		dc.SetFont(font);
+
+		wxSize textSize = dc.GetTextExtent(chanceText);
+		// Position at bottom-right of the cell
+		int textX = x + cellSize - textSize.GetWidth() - 4;
+		int textY = y + cellSize - textSize.GetHeight() - 4;
+
+		// Draw shadow (black)
+		dc.SetTextForeground(*wxBLACK);
+		dc.DrawText(chanceText, textX + 1, textY + 1);
+
+		// Draw text (white)
+		dc.SetTextForeground(*wxWHITE);
+		dc.DrawText(chanceText, textX, textY);
+	}
+
+	// Draw selection border if selected
+	if (m_isSelected) {
+		dc.SetPen(wxPen(*wxBLUE, 3)); // Thick blue border
+		dc.SetBrush(*wxTRANSPARENT_BRUSH);
+		dc.DrawRectangle(x, y, cellSize, cellSize);
+	}
 }
 
 // ============================================================================
@@ -4900,645 +5233,655 @@ void GroundGridPanel::OnPaint(wxPaintEvent& event) {
 // ============================================================================
 
 GroundGridContainer::GroundGridContainer(wxWindow* parent, wxWindowID id) :
-    wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxBORDER_NONE),
-    m_gridSizer(nullptr),
-    m_selectedCell(nullptr)
-{
-    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
-    
-    // Create horizontal sizer for the grid cells
-    m_gridSizer = new wxBoxSizer(wxHORIZONTAL);
-    SetSizer(m_gridSizer);
-    
-    // Set scroll rate
-    SetScrollRate(10, 0);  // Only horizontal scrolling
-    
-    // Create first empty cell
-    CreateNewCell();
+	wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxBORDER_NONE),
+	m_gridSizer(nullptr),
+	m_selectedCell(nullptr) {
+	SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
+
+	// Create horizontal sizer for the grid cells
+	m_gridSizer = new wxBoxSizer(wxHORIZONTAL);
+	SetSizer(m_gridSizer);
+
+	// Set scroll rate
+	SetScrollRate(10, 0); // Only horizontal scrolling
+
+	// Create first empty cell
+	CreateNewCell();
 }
 
 GroundGridContainer::~GroundGridContainer() {
-    m_gridCells.clear();
+	m_gridCells.clear();
 }
 
 void GroundGridContainer::CreateNewCell() {
-    GroundGridPanel* cell = new GroundGridPanel(this);
-    cell->SetMinSize(wxSize(74, 74));  // 64px cell + 10px margins
+	GroundGridPanel* cell = new GroundGridPanel(this);
+	cell->SetMinSize(wxSize(74, 74)); // 64px cell + 10px margins
 
-    m_gridSizer->Add(cell, 0, wxALL | wxALIGN_TOP, 1);
-    m_gridCells.push_back(cell);
+	m_gridSizer->Add(cell, 0, wxALL | wxALIGN_TOP, 1);
+	m_gridCells.push_back(cell);
 
-    FitInside();
-    Layout();
+	FitInside();
+	Layout();
 }
 
 void GroundGridContainer::EnsureEmptyCell() {
-    if (m_gridCells.empty()) {
-        CreateNewCell();
-    }
+	if (m_gridCells.empty()) {
+		CreateNewCell();
+	}
 }
 
 void GroundGridContainer::AppendEmptyCell() {
-    CreateNewCell();
-    FitInside();
-    Layout();
-    Refresh();
+	CreateNewCell();
+	FitInside();
+	Layout();
+	Refresh();
 }
 
 void GroundGridContainer::RemoveCell(GroundGridPanel* cell) {
-    if (!cell) return;
-    
-    // Don't remove the only cell if it's already empty
-    if (m_gridCells.size() == 1 && cell->IsEmpty()) {
-        return;
-    }
-    
-    // Find the cell in our list
-    auto it = std::find(m_gridCells.begin(), m_gridCells.end(), cell);
-    if (it != m_gridCells.end()) {
-        // Remove from sizer
-        m_gridSizer->Detach(cell);
-        
-        if (m_selectedCell == cell) {
-            m_selectedCell = nullptr;
-             // Notify dialog validation?
-        }
-        
-        // Remove from our list
-        m_gridCells.erase(it);
-        
-        // Destroy the window
-        cell->Destroy();
-        
-        // Ensure we still have an empty cell at the end
-        EnsureEmptyCell();
-        
-        // Refresh layout
-        FitInside();
-        Layout();
-        Refresh();
-        
-        // Notify parent that content changed
-        wxCommandEvent event(wxEVT_GROUND_CONTAINER_CHANGE, GetId());
-        event.SetEventObject(this);
-        wxPostEvent(GetParent(), event);
-    }
+	if (!cell) {
+		return;
+	}
+
+	// Don't remove the only cell if it's already empty
+	if (m_gridCells.size() == 1 && cell->IsEmpty()) {
+		return;
+	}
+
+	// Find the cell in our list
+	auto it = std::find(m_gridCells.begin(), m_gridCells.end(), cell);
+	if (it != m_gridCells.end()) {
+		// Remove from sizer
+		m_gridSizer->Detach(cell);
+
+		if (m_selectedCell == cell) {
+			m_selectedCell = nullptr;
+			// Notify dialog validation?
+		}
+
+		// Remove from our list
+		m_gridCells.erase(it);
+
+		// Destroy the window
+		cell->Destroy();
+
+		// Ensure we still have an empty cell at the end
+		EnsureEmptyCell();
+
+		// Refresh layout
+		FitInside();
+		Layout();
+		Refresh();
+
+		// Notify parent that content changed
+		wxCommandEvent event(wxEVT_GROUND_CONTAINER_CHANGE, GetId());
+		event.SetEventObject(this);
+		wxPostEvent(GetParent(), event);
+	}
 }
 
 void GroundGridContainer::AddItem(uint16_t itemId, int chance, bool allowAppend) {
-    if (itemId == 0) {
-        return;
-    }
+	if (itemId == 0) {
+		return;
+	}
 
-    for (GroundGridPanel* cell : m_gridCells) {
-        if (cell->IsEmpty()) {
-            cell->SetItemId(itemId);
-            cell->SetChance(chance);
-            return;
-        }
-    }
+	for (GroundGridPanel* cell : m_gridCells) {
+		if (cell->IsEmpty()) {
+			cell->SetItemId(itemId);
+			cell->SetChance(chance);
+			return;
+		}
+	}
 
-    if (!allowAppend) {
-        return;
-    }
+	if (!allowAppend) {
+		return;
+	}
 
-    CreateNewCell();
-    GroundGridPanel* last = m_gridCells.back();
-    last->SetItemId(itemId);
-    last->SetChance(chance);
+	CreateNewCell();
+	GroundGridPanel* last = m_gridCells.back();
+	last->SetItemId(itemId);
+	last->SetChance(chance);
 }
 
 void GroundGridContainer::Clear() {
-    while (m_gridCells.size() > 1) {
-        GroundGridPanel* cell = m_gridCells.back();
-        m_gridSizer->Detach(cell);
-        cell->Destroy();
-        m_gridCells.pop_back();
-    }
-    
-    if (!m_gridCells.empty()) {
-        m_gridCells[0]->Clear();
-    }
-    
-    FitInside();
-    Layout();
+	while (m_gridCells.size() > 1) {
+		GroundGridPanel* cell = m_gridCells.back();
+		m_gridSizer->Detach(cell);
+		cell->Destroy();
+		m_gridCells.pop_back();
+	}
+
+	if (!m_gridCells.empty()) {
+		m_gridCells[0]->Clear();
+	}
+
+	FitInside();
+	Layout();
 }
 
 std::vector<uint16_t> GroundGridContainer::GetAllItems() const {
-    std::vector<uint16_t> items;
-    for (const GroundGridPanel* cell : m_gridCells) {
-        if (!cell->IsEmpty()) {
-            items.push_back(cell->GetItemId());
-        }
-    }
-    return items;
+	std::vector<uint16_t> items;
+	for (const GroundGridPanel* cell : m_gridCells) {
+		if (!cell->IsEmpty()) {
+			items.push_back(cell->GetItemId());
+		}
+	}
+	return items;
 }
 
 std::vector<std::pair<uint16_t, int>> GroundGridContainer::GetAllItemsWithChance() const {
-    std::vector<std::pair<uint16_t, int>> items;
-    for (const GroundGridPanel* cell : m_gridCells) {
-        if (!cell->IsEmpty()) {
-            items.push_back({cell->GetItemId(), cell->GetChance()});
-        }
-    }
-    return items;
+	std::vector<std::pair<uint16_t, int>> items;
+	for (const GroundGridPanel* cell : m_gridCells) {
+		if (!cell->IsEmpty()) {
+			items.push_back({ cell->GetItemId(), cell->GetChance() });
+		}
+	}
+	return items;
 }
 
 size_t GroundGridContainer::GetFilledCount() const {
-    size_t count = 0;
-    for (const GroundGridPanel* cell : m_gridCells) {
-        if (!cell->IsEmpty()) count++;
-    }
-    return count;
+	size_t count = 0;
+	for (const GroundGridPanel* cell : m_gridCells) {
+		if (!cell->IsEmpty()) {
+			count++;
+		}
+	}
+	return count;
 }
 
 void GroundGridContainer::OnCellFilled(int index) {
-    EnsureEmptyCell();
+	EnsureEmptyCell();
 }
 
 void GroundGridContainer::RebuildGrids() {
-    FitInside();
-    Layout();
-    Refresh();
+	FitInside();
+	Layout();
+	Refresh();
 }
 
 void GroundGridContainer::SetSelectedCell(GroundGridPanel* cell) {
-    if (m_selectedCell != cell) {
-        if (m_selectedCell) {
-            m_selectedCell->SetSelected(false);
-        }
-        m_selectedCell = cell;
-        if (m_selectedCell) {
-            m_selectedCell->SetSelected(true);
-            
-            // Try to notify the dialog to update chance control
-            // We need to walk up to find the dialog
-            wxWindow* win = GetParent();
-            while (win) {
-                BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(win);
-                if (dialog) {
-                    wxCommandEvent evt(wxEVT_NULL); // Just update UI call
-                    // We can't easily fire an event to dialog from here without ID. 
-                    // Let's assume the dialog will poll or we can implement a callback system later if needed.
-                    // For now, let's just make sure m_groundItemChanceCtrl updates when user interacts.
-                    // Actually, simpler: Fire a custom event or reuse an existing one.
-                    // We can reuse wxEVT_COMMAND_LISTBOX_SELECTED on the container? No.
-                    
-                    // Direct update is easiest if we can access public method.
-                    // But we don't have public access.
-                    // Let's use a dummy event to trigger UI update.
-                    wxCommandEvent event(wxEVT_BUTTON, wxID_ANY); 
-                    event.SetEventObject(this); 
-                    // dialog->OnGridSelectionChanged(event); // If we had it.
-                    
-                    // Let's implement OnGridCellClicked properly in Dialog to handle this.
-                    // But Wait, GroundGridPanel::OnMouseClick is calling SetSelectedCell.
-                    // We should dispatch an event from container to parent.
-                    
-                    wxCommandEvent selEvent(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
-                    selEvent.SetEventObject(this);
-                    selEvent.SetInt(cell->GetChance()); // Pass chance as int
-                    win->GetEventHandler()->ProcessEvent(selEvent); // Send to parent (StaticBox) -> then to Dialog
-                    break;
-                }
-                win = win->GetParent();
-            }
-        }
-    }
+	if (m_selectedCell != cell) {
+		if (m_selectedCell) {
+			m_selectedCell->SetSelected(false);
+		}
+		m_selectedCell = cell;
+		if (m_selectedCell) {
+			m_selectedCell->SetSelected(true);
+
+			// Try to notify the dialog to update chance control
+			// We need to walk up to find the dialog
+			wxWindow* win = GetParent();
+			while (win) {
+				BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(win);
+				if (dialog) {
+					wxCommandEvent evt(wxEVT_NULL); // Just update UI call
+					// We can't easily fire an event to dialog from here without ID.
+					// Let's assume the dialog will poll or we can implement a callback system later if needed.
+					// For now, let's just make sure m_groundItemChanceCtrl updates when user interacts.
+					// Actually, simpler: Fire a custom event or reuse an existing one.
+					// We can reuse wxEVT_COMMAND_LISTBOX_SELECTED on the container? No.
+
+					// Direct update is easiest if we can access public method.
+					// But we don't have public access.
+					// Let's use a dummy event to trigger UI update.
+					wxCommandEvent event(wxEVT_BUTTON, wxID_ANY);
+					event.SetEventObject(this);
+					// dialog->OnGridSelectionChanged(event); // If we had it.
+
+					// Let's implement OnGridCellClicked properly in Dialog to handle this.
+					// But Wait, GroundGridPanel::OnMouseClick is calling SetSelectedCell.
+					// We should dispatch an event from container to parent.
+
+					wxCommandEvent selEvent(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
+					selEvent.SetEventObject(this);
+					selEvent.SetInt(cell->GetChance()); // Pass chance as int
+					win->GetEventHandler()->ProcessEvent(selEvent); // Send to parent (StaticBox) -> then to Dialog
+					break;
+				}
+				win = win->GetParent();
+			}
+		}
+	}
 }
 
 // DISABLE Old Event Handlers
-void BorderEditorPanel::OnAddVariation(wxCommandEvent& event) {
-    if (m_activeTab != 1) {
-        return;
-    }
-    if (!m_groundGridContainer) {
-        return;
-    }
+void BorderEditorPanel::OnAddVariation(wxCommandEvent &event) {
+	if (m_activeTab != 1) {
+		return;
+	}
+	if (!m_groundGridContainer) {
+		return;
+	}
 
-    m_groundGridContainer->AppendEmptyCell();
+	m_groundGridContainer->AppendEmptyCell();
 }
-void BorderEditorPanel::OnRemoveVariationBtn(wxCommandEvent& event) {}
-void BorderEditorPanel::OnPreviewTimer(wxTimerEvent& event) {}
-void BorderEditorPanel::RebuildVariationsList() {}
-void BorderEditorPanel::AddVariationRow(GroundVariation& variation, int index) {}
+void BorderEditorPanel::OnRemoveVariationBtn(wxCommandEvent &event) { }
+void BorderEditorPanel::OnPreviewTimer(wxTimerEvent &event) { }
+void BorderEditorPanel::RebuildVariationsList() { }
+void BorderEditorPanel::AddVariationRow(GroundVariation &variation, int index) { }
 
-void BorderEditorPanel::OnGroundPaletteSelect(wxCommandEvent& event) {
-    // When an item is selected from the palette, add it to the container
-    uint16_t itemId = static_cast<uint16_t>(event.GetInt());
-    if (itemId > 0 && m_groundGridContainer) {
-        m_groundGridContainer->AddItem(itemId, 100, false);
-        if (m_groundPreviewPanel) {
-            m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
-        }
-        SaveCurrentDraft(true);
-    }
+void BorderEditorPanel::OnGroundPaletteSelect(wxCommandEvent &event) {
+	// When an item is selected from the palette, add it to the container
+	uint16_t itemId = static_cast<uint16_t>(event.GetInt());
+	if (itemId > 0 && m_groundGridContainer) {
+		m_groundGridContainer->AddItem(itemId, 100, false);
+		if (m_groundPreviewPanel) {
+			m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+		}
+		SaveCurrentDraft(true);
+	}
 }
 
-void BorderEditorPanel::OnGroundContainerChange(wxCommandEvent& event) {
-    if (m_groundPreviewPanel && m_groundGridContainer) {
-        m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
-    }
-    SaveCurrentDraft(true);
+void BorderEditorPanel::OnGroundContainerChange(wxCommandEvent &event) {
+	if (m_groundPreviewPanel && m_groundGridContainer) {
+		m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+	}
+	SaveCurrentDraft(true);
 }
 
 void BorderEditorPanel::SaveGroundBrush() {
-    // Validate input
-    wxString name = m_groundNameCtrl->GetValue().Trim();
-    if (name.IsEmpty()) {
-        wxMessageBox("Please enter a name for the ground brush.", "Validation Error", wxOK | wxICON_WARNING);
-        return;
-    }
-    
-    std::vector<std::pair<uint16_t, int>> items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
-    if (items.empty()) {
-        wxMessageBox("Please add at least one item to the ground brush by clicking on tiles in the palette.", 
-                     "Validation Error", wxOK | wxICON_WARNING);
-        return;
-    }
-    
-    int preSave = wxMessageBox(
-        "This action will save the ground brush and reload data files (F5). Continue?",
-        "Confirm Save",
-        wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
-        this
-    );
-    if (preSave != wxYES) {
-        return;
-    }
+	// Validate input
+	wxString name = m_groundNameCtrl->GetValue().Trim();
+	if (name.IsEmpty()) {
+		wxMessageBox("Please enter a name for the ground brush.", "Validation Error", wxOK | wxICON_WARNING);
+		return;
+	}
 
-    // Get form values
-    const uint16_t mainTileId = (m_selectedBrowserTileId != 0)
-        ? m_selectedBrowserTileId
-        : (!items.empty() ? items.front().first : 0);
-    int zOrder = m_zOrderCtrl->GetValue();
-    wxString alignment = (m_borderAlignmentSelection == 1) ? "inner" : "outer";
-    bool includeToNone = m_includeToNoneCheck->GetValue();
-    bool includeInner = m_includeInnerCheck->GetValue();
-    
-    // Build XML path
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + 
-                          "materials" + wxFileName::GetPathSeparator() + 
-                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
-    
-    // Load existing file or create new structure
-    pugi::xml_document doc;
-    pugi::xml_node materials;
-    
-    if (wxFileExists(groundsFile)) {
-        pugi::xml_parse_result result = doc.load_file(nstr(groundsFile).c_str());
-        if (result) {
-            materials = doc.child("materials");
-        }
-    }
-    
-    if (!materials) {
-        materials = doc.append_child("materials");
-    }
-    
-    // Check if brush with this name already exists
-    pugi::xml_node existingBrush;
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        if (wxString(brushNode.attribute("name").as_string()) == name) {
-            existingBrush = brushNode;
-            break;
-        }
-    }
-    
-    // Create or update brush node
-    pugi::xml_node brushNode = existingBrush ? existingBrush : materials.append_child("brush");
-    
-    if (!existingBrush) {
-        brushNode.append_attribute("type") = "ground";
-    }
-    brushNode.attribute("name") = nstr(name).c_str();
-    if (!brushNode.attribute("name")) {
-        brushNode.append_attribute("name") = nstr(name).c_str();
-    }
-    
-    if (mainTileId != 0) {
-        if (brushNode.attribute("server_lookid")) {
-            brushNode.attribute("server_lookid") = mainTileId;
-        } else {
-            brushNode.append_attribute("server_lookid") = mainTileId;
-        }
-    }
-    
-    // Set z-order
-    if (brushNode.attribute("z-order")) {
-        brushNode.attribute("z-order") = zOrder;
-    } else {
-        brushNode.append_attribute("z-order") = zOrder;
-    }
-    
-    // Remove existing item children and add new ones
-    while (brushNode.child("item")) {
-        brushNode.remove_child("item");
-    }
-    
-    // Add all items from the container
-    int totalScale = 0;
-    
-    // First pass: Calculate total weight if needed, though we save raw values usually
-    // Canary format usually expects 'chance' as a relative weight or specific probability?
-    // Looking at brush loading code: total_chance += chance;
-    // So it's cumulative weight. We can save the raw int values user entered.
-    
-    for (const auto& itemPair : items) {
-        uint16_t itemId = itemPair.first;
-        int chance = itemPair.second;
-        
-        pugi::xml_node itemNode = brushNode.append_child("item");
-        itemNode.append_attribute("id") = itemId;
-        itemNode.append_attribute("chance") = chance;
-    }
-    
-    // Add border node if not exists
-    pugi::xml_node borderNode = brushNode.child("border");
-    if (!borderNode) {
-        borderNode = brushNode.append_child("border");
-    }
-    
-    // Set border attributes
-    if (borderNode.attribute("align")) {
-        borderNode.attribute("align") = nstr(alignment).c_str();
-    } else {
-        borderNode.append_attribute("align") = nstr(alignment).c_str();
-    }
-    
-    if (includeToNone) {
-        if (!borderNode.attribute("to")) {
-            borderNode.append_attribute("to") = "none";
-        } else {
-            borderNode.attribute("to") = "none";
-        }
-    }
-    
-    wxString xmlText;
-    if (wxFileExists(groundsFile)) {
-        ReadAllText(groundsFile, xmlText);
-    }
-    if (xmlText.IsEmpty()) {
-        xmlText = "<materials>\n</materials>\n";
-    }
+	std::vector<std::pair<uint16_t, int>> items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
+	if (items.empty()) {
+		wxMessageBox("Please add at least one item to the ground brush by clicking on tiles in the palette.", "Validation Error", wxOK | wxICON_WARNING);
+		return;
+	}
 
-    const wxString nl = DetectNewline(xmlText);
-    const wxString baseIndent = DetectChildIndent(xmlText, "brush");
-    const wxString newBlock = PrintNodeIndented(brushNode, baseIndent, nl);
-    const wxString attrNeedle = "name=\"" + name + "\"";
+	int preSave = wxMessageBox(
+		"This action will save the ground brush and reload data files (F5). Continue?",
+		"Confirm Save",
+		wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
+		this
+	);
+	if (preSave != wxYES) {
+		return;
+	}
 
-    wxString oldText = xmlText;
-    if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
-        wxMessageBox("Invalid grounds.xml file: missing '</materials>'", "Error", wxOK | wxICON_ERROR);
-        return;
-    }
+	// Get form values
+	const uint16_t mainTileId = (m_selectedBrowserTileId != 0)
+		? m_selectedBrowserTileId
+		: (!items.empty() ? items.front().first : 0);
+	int zOrder = m_zOrderCtrl->GetValue();
+	wxString alignment = (m_borderAlignmentSelection == 1) ? "inner" : "outer";
+	bool includeToNone = m_includeToNoneCheck->GetValue();
+	bool includeInner = m_includeInnerCheck->GetValue();
 
-    if (xmlText != oldText && !WriteAllText(groundsFile, xmlText)) {
-        wxMessageBox("Failed to save ground brush file.", "Error", wxOK | wxICON_ERROR);
-        return;
-    }
+	// Build XML path
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
 
-    DiscardDraft(1, mainTileId);
+	// Load existing file or create new structure
+	pugi::xml_document doc;
+	pugi::xml_node materials;
 
-    TriggerReloadDataFiles();
-    ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+	if (wxFileExists(groundsFile)) {
+		pugi::xml_parse_result result = doc.load_file(nstr(groundsFile).c_str());
+		if (result) {
+			materials = doc.child("materials");
+		}
+	}
 
-    wxMessageBox(
-        wxString::Format("Ground brush '%s' saved successfully.", name),
-        "Success",
-        wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP,
-        this
-    );
+	if (!materials) {
+		materials = doc.append_child("materials");
+	}
+
+	// Check if brush with this name already exists
+	pugi::xml_node existingBrush;
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		if (wxString(brushNode.attribute("name").as_string()) == name) {
+			existingBrush = brushNode;
+			break;
+		}
+	}
+
+	// Create or update brush node
+	pugi::xml_node brushNode = existingBrush ? existingBrush : materials.append_child("brush");
+
+	if (!existingBrush) {
+		brushNode.append_attribute("type") = "ground";
+	}
+	brushNode.attribute("name") = nstr(name).c_str();
+	if (!brushNode.attribute("name")) {
+		brushNode.append_attribute("name") = nstr(name).c_str();
+	}
+
+	if (mainTileId != 0) {
+		if (brushNode.attribute("server_lookid")) {
+			brushNode.attribute("server_lookid") = mainTileId;
+		} else {
+			brushNode.append_attribute("server_lookid") = mainTileId;
+		}
+	}
+
+	// Set z-order
+	if (brushNode.attribute("z-order")) {
+		brushNode.attribute("z-order") = zOrder;
+	} else {
+		brushNode.append_attribute("z-order") = zOrder;
+	}
+
+	// Remove existing item children and add new ones
+	while (brushNode.child("item")) {
+		brushNode.remove_child("item");
+	}
+
+	// Add all items from the container
+	int totalScale = 0;
+
+	// First pass: Calculate total weight if needed, though we save raw values usually
+	// Canary format usually expects 'chance' as a relative weight or specific probability?
+	// Looking at brush loading code: total_chance += chance;
+	// So it's cumulative weight. We can save the raw int values user entered.
+
+	for (const auto &itemPair : items) {
+		uint16_t itemId = itemPair.first;
+		int chance = itemPair.second;
+
+		pugi::xml_node itemNode = brushNode.append_child("item");
+		itemNode.append_attribute("id") = itemId;
+		itemNode.append_attribute("chance") = chance;
+	}
+
+	// Add border node if not exists
+	pugi::xml_node borderNode = brushNode.child("border");
+	if (!borderNode) {
+		borderNode = brushNode.append_child("border");
+	}
+
+	// Set border attributes
+	if (borderNode.attribute("align")) {
+		borderNode.attribute("align") = nstr(alignment).c_str();
+	} else {
+		borderNode.append_attribute("align") = nstr(alignment).c_str();
+	}
+
+	if (includeToNone) {
+		if (!borderNode.attribute("to")) {
+			borderNode.append_attribute("to") = "none";
+		} else {
+			borderNode.attribute("to") = "none";
+		}
+	}
+
+	wxString xmlText;
+	if (wxFileExists(groundsFile)) {
+		ReadAllText(groundsFile, xmlText);
+	}
+	if (xmlText.IsEmpty()) {
+		xmlText = "<materials>\n</materials>\n";
+	}
+
+	const wxString nl = DetectNewline(xmlText);
+	const wxString baseIndent = DetectChildIndent(xmlText, "brush");
+	const wxString newBlock = PrintNodeIndented(brushNode, baseIndent, nl);
+	const wxString attrNeedle = "name=\"" + name + "\"";
+
+	wxString oldText = xmlText;
+	if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
+		wxMessageBox("Invalid grounds.xml file: missing '</materials>'", "Error", wxOK | wxICON_ERROR);
+		return;
+	}
+
+	if (xmlText != oldText && !WriteAllText(groundsFile, xmlText)) {
+		wxMessageBox("Failed to save ground brush file.", "Error", wxOK | wxICON_ERROR);
+		return;
+	}
+
+	DiscardDraft(1, mainTileId);
+
+	TriggerReloadDataFiles();
+	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
+
+	wxMessageBox(
+		wxString::Format("Ground brush '%s' saved successfully.", name),
+		"Success",
+		wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP,
+		this
+	);
 }
 
 void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {
-    if (RestoreDraft(0, tileId)) {
-        return;
-    }
+	if (RestoreDraft(0, tileId)) {
+		return;
+	}
 
-    ClearItems(false);
-    if (tileId == 0) {
-        return;
-    }
+	ClearItems(false);
+	if (tileId == 0) {
+		return;
+	}
 
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
-                          "materials" + wxFileName::GetPathSeparator() +
-                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
 
-    if (!wxFileExists(groundsFile)) {
-        return;
-    }
+	if (!wxFileExists(groundsFile)) {
+		return;
+	}
 
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(groundsFile).c_str())) {
-        return;
-    }
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(groundsFile).c_str())) {
+		return;
+	}
 
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) {
-        return;
-    }
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
 
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute typeAttr = brushNode.attribute("type");
-        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
-            continue;
-        }
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute typeAttr = brushNode.attribute("type");
+		if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+			continue;
+		}
 
-        uint16_t mainTileId = 0;
-        if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
-            mainTileId = a.as_uint();
-        } else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
-            mainTileId = a.as_uint();
-        }
+		uint16_t mainTileId = 0;
+		if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+			mainTileId = a.as_uint();
+		} else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+			mainTileId = a.as_uint();
+		}
 
-        if (mainTileId != tileId) {
-            continue;
-        }
+		if (mainTileId != tileId) {
+			continue;
+		}
 
-        for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
-            pugi::xml_attribute idAttr = borderNode.attribute("id");
-            if (!idAttr) {
-                continue;
-            }
+		for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+			pugi::xml_attribute idAttr = borderNode.attribute("id");
+			if (!idAttr) {
+				continue;
+			}
 
-            wxString align = wxString(borderNode.attribute("align").as_string());
-            if (align.IsEmpty() || align == "outer") {
-                LoadBorderById(idAttr.as_int());
-                return;
-            }
-        }
+			wxString align = wxString(borderNode.attribute("align").as_string());
+			if (align.IsEmpty() || align == "outer") {
+				LoadBorderById(idAttr.as_int());
+				return;
+			}
+		}
 
-        return;
-    }
+		return;
+	}
 }
 
 void BorderEditorPanel::LoadGroundBrushByMainTileId(uint16_t tileId) {
-    if (RestoreDraft(1, tileId)) {
-        return;
-    }
+	if (RestoreDraft(1, tileId)) {
+		return;
+	}
 
-    ClearGroundItems(false);
-    if (tileId == 0) {
-        return;
-    }
+	ClearGroundItems(false);
+	if (tileId == 0) {
+		return;
+	}
 
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
-                          "materials" + wxFileName::GetPathSeparator() +
-                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
 
-    if (!wxFileExists(groundsFile)) {
-        return;
-    }
+	if (!wxFileExists(groundsFile)) {
+		return;
+	}
 
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(groundsFile).c_str())) {
-        return;
-    }
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(groundsFile).c_str())) {
+		return;
+	}
 
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) {
-        return;
-    }
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
 
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute typeAttr = brushNode.attribute("type");
-        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
-            continue;
-        }
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute typeAttr = brushNode.attribute("type");
+		if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+			continue;
+		}
 
-        pugi::xml_attribute nameAttr = brushNode.attribute("name");
-        if (!nameAttr) {
-            continue;
-        }
+		pugi::xml_attribute nameAttr = brushNode.attribute("name");
+		if (!nameAttr) {
+			continue;
+		}
 
-        uint16_t mainTileId = 0;
-        if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
-            mainTileId = a.as_uint();
-        } else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
-            mainTileId = a.as_uint();
-        }
+		uint16_t mainTileId = 0;
+		if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+			mainTileId = a.as_uint();
+		} else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+			mainTileId = a.as_uint();
+		}
 
-        if (mainTileId == tileId) {
-            LoadGroundBrushByName(wxString(nameAttr.as_string()));
-            return;
-        }
-    }
+		if (mainTileId == tileId) {
+			LoadGroundBrushByName(wxString(nameAttr.as_string()));
+			return;
+		}
+	}
 }
 
 void BorderEditorPanel::LoadWallBrushByMainTileId(uint16_t tileId) {
-    if (RestoreDraft(2, tileId)) {
-        return;
-    }
+	if (RestoreDraft(2, tileId)) {
+		return;
+	}
 
-    ClearWallItems(false);
-    if (tileId == 0) {
-        return;
-    }
+	ClearWallItems(false);
+	if (tileId == 0) {
+		return;
+	}
 
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() +
-                        "materials" + wxFileName::GetPathSeparator() +
-                        "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
 
-    if (!wxFileExists(wallsFile)) {
-        return;
-    }
+	if (!wxFileExists(wallsFile)) {
+		return;
+	}
 
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(wallsFile).c_str())) {
-        return;
-    }
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(wallsFile).c_str())) {
+		return;
+	}
 
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) {
-        return;
-    }
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
 
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute nameAttr = brushNode.attribute("name");
-        if (!nameAttr) {
-            continue;
-        }
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute nameAttr = brushNode.attribute("name");
+		if (!nameAttr) {
+			continue;
+		}
 
-        pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
-        if (lookIdAttr && lookIdAttr.as_uint() == tileId) {
-            LoadWallBrushByName(wxString(nameAttr.as_string()));
-            return;
-        }
-    }
+		pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
+		if (lookIdAttr && lookIdAttr.as_uint() == tileId) {
+			LoadWallBrushByName(wxString(nameAttr.as_string()));
+			return;
+		}
+	}
 }
 
-void BorderEditorPanel::LoadGroundBrushByName(const wxString& name) {
-    if (name.IsEmpty()) return;
-    
-    wxString dataDir = g_gui.GetDataDirectory();
-    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + 
-                          "materials" + wxFileName::GetPathSeparator() + 
-                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
-    
-    if (!wxFileExists(groundsFile)) return;
-    
-    pugi::xml_document doc;
-    if (!doc.load_file(nstr(groundsFile).c_str())) return;
-    
-    ClearGroundItems(false); // Don't clear browser selection logic
-    
-    pugi::xml_node materials = doc.child("materials");
-    if (!materials) return;
-    
-    // Find the brush by name
-    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
-        pugi::xml_attribute typeAttr = brushNode.attribute("type");
-        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") continue;
-        
-        pugi::xml_attribute nameAttr = brushNode.attribute("name");
-        if (!nameAttr || wxString(nameAttr.as_string()) != name) continue;
-        
-        // Found the brush - populate the form
-        m_groundNameCtrl->SetValue(name);
-        
-        // Z-order
-        pugi::xml_attribute zOrderAttr = brushNode.attribute("z-order");
-        m_zOrderCtrl->SetValue(zOrderAttr ? zOrderAttr.as_int() : 0);
-        
-        // Get first item ID and set in grid
-        // Load all items into the container
-        if (m_groundGridContainer) {
-            m_groundGridContainer->Clear();
-            for (pugi::xml_node itemNode = brushNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
-                uint16_t itemId = itemNode.attribute("id").as_uint();
-                int chance = itemNode.attribute("chance").as_int();
-                if (chance <= 0) chance = 100; // Default
-                
-                if (itemId > 0) {
-                    m_groundGridContainer->AddItem(itemId, chance, true);
-                }
-            }
-        }
-        
-        // Border settings
-        pugi::xml_node borderNode = brushNode.child("border");
-        if (borderNode) {
-            wxString align = wxString(borderNode.attribute("align").as_string());
-            if (align == "inner") {
-                m_borderAlignmentSelection = 1;
-                if(m_borderAlignmentButton) m_borderAlignmentButton->SetLabel("Inner \u25BC");
-            } else {
-                m_borderAlignmentSelection = 0;
-                if(m_borderAlignmentButton) m_borderAlignmentButton->SetLabel("Outer \u25BC");
-            }
-            
-            wxString toValue = wxString(borderNode.attribute("to").as_string());
-            m_includeToNoneCheck->SetValue(toValue == "none");
-        }
-        
-        if (m_groundPreviewPanel && m_groundGridContainer) {
-            m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
-        }
-        break;
-    }
+void BorderEditorPanel::LoadGroundBrushByName(const wxString &name) {
+	if (name.IsEmpty()) {
+		return;
+	}
+
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+
+	if (!wxFileExists(groundsFile)) {
+		return;
+	}
+
+	pugi::xml_document doc;
+	if (!doc.load_file(nstr(groundsFile).c_str())) {
+		return;
+	}
+
+	ClearGroundItems(false); // Don't clear browser selection logic
+
+	pugi::xml_node materials = doc.child("materials");
+	if (!materials) {
+		return;
+	}
+
+	// Find the brush by name
+	for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+		pugi::xml_attribute typeAttr = brushNode.attribute("type");
+		if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+			continue;
+		}
+
+		pugi::xml_attribute nameAttr = brushNode.attribute("name");
+		if (!nameAttr || wxString(nameAttr.as_string()) != name) {
+			continue;
+		}
+
+		// Found the brush - populate the form
+		m_groundNameCtrl->SetValue(name);
+
+		// Z-order
+		pugi::xml_attribute zOrderAttr = brushNode.attribute("z-order");
+		m_zOrderCtrl->SetValue(zOrderAttr ? zOrderAttr.as_int() : 0);
+
+		// Get first item ID and set in grid
+		// Load all items into the container
+		if (m_groundGridContainer) {
+			m_groundGridContainer->Clear();
+			for (pugi::xml_node itemNode = brushNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
+				uint16_t itemId = itemNode.attribute("id").as_uint();
+				int chance = itemNode.attribute("chance").as_int();
+				if (chance <= 0) {
+					chance = 100; // Default
+				}
+
+				if (itemId > 0) {
+					m_groundGridContainer->AddItem(itemId, chance, true);
+				}
+			}
+		}
+
+		// Border settings
+		pugi::xml_node borderNode = brushNode.child("border");
+		if (borderNode) {
+			wxString align = wxString(borderNode.attribute("align").as_string());
+			if (align == "inner") {
+				m_borderAlignmentSelection = 1;
+				if (m_borderAlignmentButton) {
+					m_borderAlignmentButton->SetLabel("Inner \u25BC");
+				}
+			} else {
+				m_borderAlignmentSelection = 0;
+				if (m_borderAlignmentButton) {
+					m_borderAlignmentButton->SetLabel("Outer \u25BC");
+				}
+			}
+
+			wxString toValue = wxString(borderNode.attribute("to").as_string());
+			m_includeToNoneCheck->SetValue(toValue == "none");
+		}
+
+		if (m_groundPreviewPanel && m_groundGridContainer) {
+			m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+		}
+		break;
+	}
 }

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -1616,10 +1616,6 @@ void BorderEditorPanel::CreateGUIControls() {
 	m_browserPaletteCategoryButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserPaletteCategoryButtonClick, this);
 	browserSizer->Add(m_browserPaletteCategoryButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-	m_browserTilesetFilterButton = new wxButton(this, wxID_ANY, "Tileset: All ▼", wxDefaultPosition, wxSize(240, -1), wxBU_LEFT);
-	m_browserTilesetFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserTilesetFilterButtonClick, this);
-	browserSizer->Add(m_browserTilesetFilterButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
-
 	m_browserBrushesViewBtn = nullptr;
 	m_browserPalettesViewBtn = nullptr;
 
@@ -4319,9 +4315,6 @@ void BorderEditorPanel::ApplyBrowserPaletteFilter(const wxString &paletteName) {
 	}
 	m_browserTilesetFilter = newTilesetFilter;
 	m_browserTilesetFiltersByTab[m_activeTab] = m_browserTilesetFilter;
-	if (m_browserTilesetFilterButton) {
-		m_browserTilesetFilterButton->SetLabel(m_browserTilesetFilter.IsEmpty() ? "Tileset: Select ▼" : "Tileset: " + m_browserTilesetFilter + " ▼");
-	}
 	if (!m_tabInitialized[m_activeTab]) {
 		PopulateUnifiedList();
 	}
@@ -4821,9 +4814,6 @@ void BorderEditorPanel::OnModeSwitch(wxCommandEvent &event) {
 	m_browserPaletteCategoryFilter = m_browserPaletteCategoriesByTab[m_activeTab].IsEmpty() ? "Terrain" : m_browserPaletteCategoriesByTab[m_activeTab];
 	m_browserPaletteListDirty = true;
 	m_browserTilesetFilter = m_browserTilesetFiltersByTab[m_activeTab];
-	if (m_browserTilesetFilterButton) {
-		m_browserTilesetFilterButton->SetLabel(m_browserTilesetFilter.IsEmpty() ? "Tileset: Select ▼" : "Tileset: " + m_browserTilesetFilter + " ▼");
-	}
 	if (m_browserSearchCtrl) {
 		m_browserSearchCtrl->ChangeValue(m_browserSearchQueriesByTab[m_activeTab]);
 	}
@@ -5096,10 +5086,6 @@ void BorderEditorPanel::UpdateBrowserViewButtons() {
 		m_browserPalettesViewBtn->Hide();
 		m_browserPalettesViewBtn->SetValue(false);
 	}
-	if (m_browserTilesetFilterButton) {
-		m_browserTilesetFilterButton->Hide();
-		m_browserTilesetFilterButton->Enable(false);
-	}
 }
 
 void BorderEditorPanel::PopulateUnifiedList() {
@@ -5281,58 +5267,6 @@ void BorderEditorPanel::OnBrowserPaletteCategoryButtonClick(wxCommandEvent &even
 	PopupMenu(&menu);
 }
 
-void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event) {
-	wxMenu menu;
-
-	const auto &options = GetBrowserTilesetOptionsCached();
-	if (options.empty()) {
-		return;
-	}
-
-	auto addRadio = [&](const wxString &shown, const wxString &value) {
-		wxMenuItem* item = menu.AppendRadioItem(wxID_ANY, shown);
-		if (value == m_browserTilesetFilter) {
-			item->Check(true);
-		}
-		menu.Bind(wxEVT_MENU, [this, shown, value](wxCommandEvent &) {
-			const wxString keepSelectionKey = GetSelectionKeyForTab(m_activeTab);
-			if (value == m_browserTilesetFilter) {
-				return;
-			}
-
-			m_browserTilesetFilter = value;
-			if (m_browserTilesetFilterButton) {
-				m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
-			}
-
-			if (!m_tabInitialized[m_activeTab]) {
-				PopulateUnifiedList();
-			}
-			FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
-
-			bool restored = false;
-			if (!keepSelectionKey.IsEmpty()) {
-				restored = RestoreBrowserSelection(keepSelectionKey);
-			}
-
-			if (restored) {
-				LoadSelectionForTab(m_activeTab, keepSelectionKey);
-			} else {
-				switch (m_activeTab) {
-					case 0: ClearItems(false); break;
-					case 1: ClearGroundItems(false); break;
-					case 2: ClearWallItems(false); break;
-				}
-			}
-		}, item->GetId());
-	};
-
-	for (const auto &opt : options) {
-		addRadio(opt.first, opt.second);
-	}
-
-	PopupMenu(&menu);
-}
 
 void BorderEditorPanel::FilterBrowserList(const wxString &query) {
 	if (!m_borderBrowserList) {

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -5482,13 +5482,13 @@ void BorderEditorPanel::SaveGroundBrush() {
 	// Validate input
 	wxString name = m_groundNameCtrl->GetValue().Trim();
 	if (name.IsEmpty()) {
-		wxMessageBox("Please enter a name for the ground brush.", "Validation Error", wxOK | wxICON_WARNING);
+		ShowErrorDialog("Please enter a name for the ground brush.", ErrorSeverity::Warning);
 		return;
 	}
 
 	std::vector<std::pair<uint16_t, int>> items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
 	if (items.empty()) {
-		wxMessageBox("Please add at least one item to the ground brush by clicking on tiles in the palette.", "Validation Error", wxOK | wxICON_WARNING);
+		ShowErrorDialog("Please add at least one item to the ground brush by clicking on tiles in the palette.", ErrorSeverity::Warning);
 		return;
 	}
 
@@ -5623,12 +5623,12 @@ void BorderEditorPanel::SaveGroundBrush() {
 
 	wxString oldText = xmlText;
 	if (!ReplaceOrInsertChildSimple(xmlText, "brush", attrNeedle, newBlock, false)) {
-		wxMessageBox("Invalid grounds.xml file: missing '</materials>'", "Error", wxOK | wxICON_ERROR);
+		ShowErrorDialog("Invalid grounds.xml file: missing '</materials>'", ErrorSeverity::Error);
 		return;
 	}
 
 	if (xmlText != oldText && !WriteAllText(groundsFile, xmlText)) {
-		wxMessageBox("Failed to save ground brush file.", "Error", wxOK | wxICON_ERROR);
+		ShowErrorDialog("Failed to save ground brush file.", ErrorSeverity::Error);
 		return;
 	}
 
@@ -5637,11 +5637,9 @@ void BorderEditorPanel::SaveGroundBrush() {
 	TriggerReloadDataFiles();
 	ReloadCurrentBrushEditorXml(wxString::Format("%u", (unsigned)mainTileId));
 
-	wxMessageBox(
+	ShowErrorDialog(
 		wxString::Format("Ground brush '%s' saved successfully.", name),
-		"Success",
-		wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP,
-		this
+		ErrorSeverity::Info
 	);
 }
 

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -2453,7 +2453,7 @@ void BorderEditorPanel::SaveBorder() {
 
 	wxString oldText = xmlText;
 	if (!ReplaceOrInsertChildSimple(xmlText, "border", attrNeedle, newBlock, true)) {
-		wxMessageBox("Invalid borders.xml file: missing '</materials>'", "Error", wxICON_ERROR);
+		ShowErrorDialog("Invalid borders.xml file: missing '</materials>'", ErrorSeverity::Error);
 		return;
 	}
 
@@ -2467,7 +2467,7 @@ void BorderEditorPanel::SaveBorder() {
 	TriggerReloadDataFiles();
 	ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
 
-	wxMessageBox("Border saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
+	ShowErrorDialog("Border saved successfully.", ErrorSeverity::Info);
 }
 
 void BorderEditorPanel::OnSave(wxCommandEvent &event) {

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -3968,7 +3968,7 @@ void BorderEditorPanel::PopulateUnifiedList() {
 
 	if (wxFileExists(groundsFile)) {
 		pugi::xml_document doc;
-		if (doc.load_file(nstr(groundsFile).c_str())) {
+		if (LoadXmlWithCache(groundsFile, doc)) {
 			pugi::xml_node materials = doc.child("materials");
 			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
 				pugi::xml_attribute typeAttr = brushNode.attribute("type");
@@ -4013,7 +4013,7 @@ void BorderEditorPanel::PopulateUnifiedList() {
 
 	if (wxFileExists(wallsFile)) {
 		pugi::xml_document doc;
-		if (doc.load_file(nstr(wallsFile).c_str())) {
+		if (LoadXmlWithCache(wallsFile, doc)) {
 			pugi::xml_node materials = doc.child("materials");
 			for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
 				pugi::xml_attribute nameAttr = brushNode.attribute("name");

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -167,6 +167,32 @@ void BorderEditorPanel::ShowErrorDialog(const wxString &message, ErrorSeverity s
 	wxMessageBox(message, "Brush Editor", style, this);
 }
 
+bool BorderEditorPanel::LoadXmlWithCache(const wxString &path, pugi::xml_document &doc) {
+	wxFileName fn(path);
+	wxDateTime lastModified = fn.GetModificationTime();
+
+	auto it = m_xmlCache.find(path);
+	if (it != m_xmlCache.end() && it->second.lastModified == lastModified) {
+		doc.reset(it->second.doc);
+		return true;
+	}
+
+	pugi::xml_parse_result result = doc.load_file(nstr(path).c_str());
+	if (!result) {
+		return false;
+	}
+
+	XmlCacheEntry entry;
+	entry.doc.reset(doc);
+	entry.lastModified = lastModified;
+	m_xmlCache[path] = std::move(entry);
+	return true;
+}
+
+void BorderEditorPanel::InvalidateXmlCache(const wxString &path) {
+	m_xmlCache.erase(path);
+}
+
 static wxString DetectNewline(const wxString &text) {
 	return (text.Find("\r\n") != wxNOT_FOUND) ? "\r\n" : "\n";
 }

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -2195,7 +2195,7 @@ void BorderEditorPanel::OnPositionSelected(wxCommandEvent &event) {
 		*/
 		wxLogDebug("No valid item ID found from current brush: %s", currentBrush ? wxString(currentBrush->getName()).c_str() : wxT("NULL"));
 
-		wxMessageBox("Could not get a valid item ID from the current brush. Please select an item brush or use the Browse button to select an item manually.", "Invalid Brush", wxICON_INFORMATION);
+		ShowErrorDialog("Could not get a valid item ID from the current brush. Please select an item brush or use the Browse button to select an item manually.", ErrorSeverity::Info);
 		// }
 	}
 }
@@ -2203,7 +2203,7 @@ void BorderEditorPanel::OnPositionSelected(wxCommandEvent &event) {
 void BorderEditorPanel::OnAddItem(wxCommandEvent &event) {
 	// This function is now obsolete as manual add buttons and m_itemIdCtrl are removed.
 	// If it were to be used, it would need to get the item ID from the currently selected brush.
-	wxMessageBox("This 'Add Item' functionality is no longer available. Please select an item brush and click on the grid to add items.", "Information", wxICON_INFORMATION);
+	ShowErrorDialog("This 'Add Item' functionality is no longer available. Please select an item brush and click on the grid to add items.", ErrorSeverity::Info);
 	return;
 
 	/*

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -181,6 +181,43 @@ static const char* GetPaletteCategoryXmlNodeName(TilesetCategoryType type) {
 	}
 }
 
+static wxArrayString BuildFallbackPaletteLabelsFromTilesets(int activeTab, const wxString &categoryFilter) {
+	wxArrayString labels;
+	std::set<wxString> seen;
+	const TilesetCategoryType activeCategoryType = GetPaletteCategoryTypeFromLabel(categoryFilter);
+
+	for (const auto &pair : g_materials.tilesets) {
+		Tileset* tileset = pair.second;
+		if (!tileset) continue;
+		const wxString tilesetName = wxString(pair.first);
+		if (activeTab == 2 && tilesetName.Lower().Contains("tiny borders")) continue;
+
+		auto appendPaletteLabel = [&](TilesetCategory* category) {
+			if (!category || category->getType() == TILESET_UNKNOWN || category->brushlist.empty()) return;
+			const wxString paletteLabel = tilesetName + " [" + GetPaletteCategoryLabel(category->getType()) + "]";
+			if (seen.insert(paletteLabel).second) labels.Add(paletteLabel);
+		};
+
+		if (activeCategoryType != TILESET_UNKNOWN) {
+			appendPaletteLabel(tileset->getCategory(activeCategoryType));
+			continue;
+		}
+
+		for (TilesetCategory* category : tileset->categories) appendPaletteLabel(category);
+	}
+
+	labels.Sort();
+	return labels;
+}
+
+static bool ItemIdBelongsToTileset(uint16_t itemId, const wxString &tilesetName) {
+	if (itemId == 0 || tilesetName.IsEmpty()) return false;
+	const ItemType &type = g_items.getItemType(itemId);
+	if (type.id == 0) return false;
+	const std::string tsName = nstr(tilesetName);
+	return g_materials.isInTileset(type.brush, tsName) || g_materials.isInTileset(type.doodad_brush, tsName) || g_materials.isInTileset(type.raw_brush, tsName);
+}
+
 static bool BrushHasPaletteMembership(const BrushEditorBrushDefinition &brush, const wxString &paletteName) {
 	for (const BrushEditorPaletteMembership &membership : brush.memberships) {
 		if (membership.tilesetName.IsEmpty()) continue;
@@ -701,8 +738,6 @@ BorderEditorPanel::BorderEditorPanel(wxWindow* parent) :
 	m_selectedBrowserTileId(0),
 	m_lastInteractionTime(0) {
 
-	// Load saved filter configuration (before creating UI)
-	LoadFilterConfig();
 	m_browserPaletteCategoryFilter = "Terrain";
 
 	CreateGUIControls();
@@ -724,14 +759,17 @@ BorderEditorPanel::BorderEditorPanel(wxWindow* parent) :
 
 	CallAfter([this]() {
 		Layout();
-		if (!m_tabInitialized[m_activeTab]) {
-			PopulateUnifiedList();
-		}
-		RefreshBrowserPaletteList();
 		UpdateBrowserLabel();
 		CallAfter([this]() {
+			LoadFilterConfig();
+			InvalidateTilesetCache();
 			LoadTilesets();
+			CallAfter([this]() {
+			PopulateUnifiedList();
+			RefreshBrowserPaletteList();
+			UpdateBrowserActionButtons();
 			UpdateBrowserLabel();
+		});
 		});
 	});
 }
@@ -826,7 +864,107 @@ void BorderEditorPanel::MarkBrushCatalogDirty() {
 		m_cachedBrowserLists[i].Clear();
 		m_cachedBrowserIds[i].Clear();
 		m_cachedBrowserPreviewIds[i].clear();
+		m_cachedBrowserTilesetOptions[i].clear();
+		m_browserTilesetOptionsDirty[i] = true;
 	}
+}
+
+void BorderEditorPanel::InvalidateTilesetCache(int tab) {
+	if (tab >= 0 && tab < 3) {
+		m_cachedTilesetListData[tab].Clear();
+		m_tilesetListDirty[tab] = true;
+		return;
+	}
+	for (int i = 0; i < 3; ++i) {
+		m_cachedTilesetListData[i].Clear();
+		m_tilesetListDirty[i] = true;
+	}
+}
+
+void BorderEditorPanel::EnsureActiveTabBrowserLoaded() {
+	if (!m_tabInitialized[m_activeTab]) {
+		m_fullBrowserList.Clear();
+		m_fullBrowserIds.Clear();
+		m_fullBrowserPreviewIds.clear();
+		if (m_borderBrowserList) {
+			m_borderBrowserList->Clear();
+		}
+		if (m_browserGrid) {
+			std::vector<BrushBrowserGridPanel::Entry> emptyEntries;
+			m_browserGrid->SetEntries(std::move(emptyEntries));
+			m_browserGrid->SetSelectionByKey(wxString());
+		}
+	}
+	RefreshBrowserPaletteList();
+}
+
+void BorderEditorPanel::EnsureActiveTabPaletteLoaded() {
+	LoadTilesets();
+	if (m_activeTab == 0 && m_itemPalettePanel && !m_tilesetListData.IsEmpty()) {
+		int selection = (m_rawCategorySelection >= 0 && m_rawCategorySelection < (int)m_tilesetListData.GetCount()) ? m_rawCategorySelection : 0;
+		m_rawCategorySelection = selection;
+		m_itemPalettePanel->LoadTileset(m_tilesetListData[selection]);
+	} else if (m_activeTab == 1 && m_groundPalette && !m_tilesetListData.IsEmpty()) {
+		if (m_groundTilesetSelection < 0 || m_groundTilesetSelection >= (int)m_tilesetListData.GetCount()) m_groundTilesetSelection = 0;
+		m_groundPalette->LoadTileset(m_tilesetListData[m_groundTilesetSelection], FILTER_GROUND);
+	} else if (m_activeTab == 2 && m_wallPalette && !m_tilesetListData.IsEmpty()) {
+		if (m_wallTilesetSelection < 0 || m_wallTilesetSelection >= (int)m_tilesetListData.GetCount()) m_wallTilesetSelection = 0;
+		m_wallPalette->LoadTileset(m_tilesetListData[m_wallTilesetSelection], FILTER_WALL);
+	}
+}
+
+const std::vector<std::pair<wxString, wxString>>& BorderEditorPanel::GetBrowserTilesetOptionsCached() {
+	const int tab = std::max(0, std::min(m_activeTab, 2));
+	if (m_browserTilesetOptionsDirty[tab]) {
+		const BrushEditorCatalog* catalog = (tab == 0 || m_catalogDirty) ? nullptr : &m_catalog;
+		m_cachedBrowserTilesetOptions[tab] = GetBrowserTilesetOptions(tab, catalog);
+		m_browserTilesetOptionsDirty[tab] = false;
+	}
+	return m_cachedBrowserTilesetOptions[tab];
+}
+
+bool BorderEditorPanel::ApplyWallBrushFromCatalog(const wxString &name) {
+	if (m_catalogDirty) {
+		return false;
+	}
+	const BrushEditorBrushDefinition* brushDef = m_catalog.FindBrushByName(name);
+	if (!brushDef || brushDef->kind != BrushEditorBrushKind::Wall || brushDef->wallParts.empty()) return false;
+	ClearWallItems(false);
+	if (m_wallNameCtrl) m_wallNameCtrl->SetValue(name);
+	m_wallTypes.clear();
+	for (const auto &entry : brushDef->wallParts) {
+		WallTypeData typeData; typeData.typeName = nstr(entry.first);
+		for (const auto &item : entry.second.items) typeData.items.push_back(GroundItem(item.first, item.second));
+		m_wallTypes[entry.first.ToStdString()] = typeData;
+	}
+	const wxString selectedType = brushDef->wallParts.count("vertical") ? "vertical" : brushDef->wallParts.begin()->first;
+	if (m_wallGridPanel) { m_wallGridPanel->SetWallTypes(m_wallTypes); m_wallGridPanel->SetSelectedType(nstr(selectedType)); }
+	UpdateWallItemsList();
+	if (m_wallVisualPanel) m_wallVisualPanel->SetWallItems(m_wallTypes);
+	UpdateBrowserLabel();
+	return true;
+}
+
+bool BorderEditorPanel::ApplyGroundBrushFromCatalog(const wxString &name) {
+	if (m_catalogDirty) {
+		return false;
+	}
+	const BrushEditorBrushDefinition* brushDef = m_catalog.FindBrushByName(name);
+	if (!brushDef || brushDef->kind != BrushEditorBrushKind::Ground) return false;
+	ClearGroundItems(false);
+	if (m_groundNameCtrl) m_groundNameCtrl->SetValue(name);
+	if (m_zOrderCtrl) m_zOrderCtrl->SetValue(brushDef->zOrder);
+	if (m_groundGridContainer) for (const BrushEditorVariation &variation : brushDef->variations) if (variation.tiles.size() == 1 && variation.tiles.front().itemId != 0) m_groundGridContainer->AddItem(variation.tiles.front().itemId, std::max(1, variation.chance), true);
+	if (!brushDef->borders.empty()) {
+		const BrushEditorBorderConfig &border = brushDef->borders.front();
+		m_borderAlignmentSelection = border.alignment == "inner" ? 1 : 0;
+		if (m_borderAlignmentButton) m_borderAlignmentButton->SetLabel(m_borderAlignmentSelection == 1 ? "Inner ▼" : "Outer ▼");
+		if (m_includeToNoneCheck) m_includeToNoneCheck->SetValue(border.includeToNone);
+		if (m_includeInnerCheck) m_includeInnerCheck->SetValue(border.includeInner);
+	}
+	if (m_groundPreviewPanel && m_groundGridContainer) m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+	UpdateBrowserLabel();
+	return true;
 }
 
 void BorderEditorPanel::CacheBrowserDataForActiveTab() {
@@ -1583,7 +1721,10 @@ void BorderEditorPanel::CreateGUIControls() {
 
 void BorderEditorPanel::OnRawCategoryButtonClick(wxCommandEvent &event) {
 	if (m_rawCategoryNames.IsEmpty()) {
-		return;
+		EnsureActiveTabPaletteLoaded();
+		if (m_rawCategoryNames.IsEmpty()) {
+			return;
+		}
 	}
 
 	wxMenu menu;
@@ -1619,7 +1760,10 @@ void BorderEditorPanel::OnRawCategoryMenuSelect(wxCommandEvent &event) {
 
 void BorderEditorPanel::OnGroundTilesetButtonClick(wxCommandEvent &event) {
 	if (m_tilesetListData.IsEmpty()) {
-		return;
+		EnsureActiveTabPaletteLoaded();
+		if (m_tilesetListData.IsEmpty()) {
+			return;
+		}
 	}
 
 	wxMenu menu;
@@ -1655,7 +1799,10 @@ void BorderEditorPanel::OnGroundTilesetMenuSelect(wxCommandEvent &event) {
 
 void BorderEditorPanel::OnWallTilesetButtonClick(wxCommandEvent &event) {
 	if (m_tilesetListData.IsEmpty()) {
-		return;
+		EnsureActiveTabPaletteLoaded();
+		if (m_tilesetListData.IsEmpty()) {
+			return;
+		}
 	}
 
 	wxMenu menu;
@@ -1786,6 +1933,7 @@ void BorderEditorPanel::OnOpenTilesetFilter(wxCommandEvent &event) {
 	if (dlg.ShowModal() == wxID_OK) {
 		currentWhitelist = dlg.GetEnabledTilesets();
 		SaveFilterConfig(); // Save to file immediately
+		InvalidateTilesetCache(m_activeTab);
 		LoadTilesets(); // Refresh the ComboBox with filtered list
 	}
 
@@ -1880,6 +2028,9 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
 	if (RestoreDraft(2, name)) {
 		return;
 	}
+	if (ApplyWallBrushFromCatalog(name)) {
+		return;
+	}
 
 	EnsureBrushCatalogUpToDate();
 	const BrushEditorBrushDefinition* brushDef = m_catalog.FindBrushByName(name);
@@ -1963,7 +2114,7 @@ void BorderEditorPanel::SaveWallBrush() {
 	}
 
 	int preSave = wxMessageBox(
-		"This action will save the wall brush and reload data files (F5). Continue?",
+		"This action will save the wall brush. Continue?",
 		"Confirm Save",
 		wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
 		this
@@ -2067,8 +2218,7 @@ void BorderEditorPanel::SaveWallBrush() {
 	InvalidateXmlCache(wallsFile);
 
 	DiscardDraft(2, name);
-
-	TriggerReloadDataFiles();
+	MarkBrushCatalogDirty();
 	ReloadCurrentBrushEditorXml(name);
 }
 
@@ -2642,7 +2792,7 @@ void BorderEditorPanel::SaveBorder() {
 	}
 
 	int preSave = wxMessageBox(
-		"This action will save the border and reload data files (F5). Continue?",
+		"This action will save the border. Continue?",
 		"Confirm Save",
 		wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
 		this
@@ -2769,8 +2919,7 @@ void BorderEditorPanel::SaveBorder() {
 	InvalidateXmlCache(bordersFile);
 
 	DiscardDraft(0, m_selectedBrowserTileId);
-
-	TriggerReloadDataFiles();
+	MarkBrushCatalogDirty();
 	ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
 }
 
@@ -4000,7 +4149,6 @@ bool BorderEditorPanel::PersistPaletteDefinition(const wxString &tilesetName, Ti
 		return false;
 	}
 	InvalidateXmlCache(filePath);
-	TriggerReloadDataFiles();
 	MarkBrushCatalogDirty();
 	return true;
 }
@@ -4067,7 +4215,7 @@ bool BorderEditorPanel::PersistBrushPaletteMembership(const wxString &brushName,
 	if (!doc.save_file(nstr(filePath).c_str(), PUGIXML_TEXT("\t"))) {
 		return false;
 	}
-	TriggerReloadDataFiles();
+	InvalidateXmlCache(filePath);
 	MarkBrushCatalogDirty();
 	return true;
 }
@@ -4108,6 +4256,22 @@ void BorderEditorPanel::RefreshBrowserPaletteList() {
 	if (m_browserPaletteCategoryButton) {
 		m_browserPaletteCategoryButton->Enable(true);
 		m_browserPaletteCategoryButton->SetLabel(m_browserPaletteCategoryFilter.IsEmpty() ? "Category: All ▼" : "Category: " + m_browserPaletteCategoryFilter + " ▼");
+	}
+	if (m_catalogDirty) {
+		const wxArrayString fallbackPalettes = BuildFallbackPaletteLabelsFromTilesets(m_activeTab, m_browserPaletteCategoryFilter);
+		if (fallbackPalettes.IsEmpty()) {
+			m_browserPaletteList->Append("No palettes available");
+			m_browserPaletteList->Enable(false);
+			m_browserPaletteList->SetSelection(wxNOT_FOUND);
+		} else {
+			m_browserPaletteList->Append(fallbackPalettes);
+			restoreSelection();
+		}
+		m_browserPaletteListDirty = false;
+		m_browserPaletteListBuiltForTab = m_activeTab;
+		m_browserPaletteListBuiltForCategory = m_browserPaletteCategoryFilter;
+		UpdateBrowserActionButtons();
+		return;
 	}
 	const BrushEditorBrushKind wantedKind = (m_activeTab == 2) ? BrushEditorBrushKind::Wall : BrushEditorBrushKind::Ground;
 	const TilesetCategoryType activeCategoryType = GetPaletteCategoryTypeFromLabel(m_browserPaletteCategoryFilter);
@@ -4157,6 +4321,9 @@ void BorderEditorPanel::ApplyBrowserPaletteFilter(const wxString &paletteName) {
 	m_browserTilesetFiltersByTab[m_activeTab] = m_browserTilesetFilter;
 	if (m_browserTilesetFilterButton) {
 		m_browserTilesetFilterButton->SetLabel(m_browserTilesetFilter.IsEmpty() ? "Tileset: Select ▼" : "Tileset: " + m_browserTilesetFilter + " ▼");
+	}
+	if (!m_tabInitialized[m_activeTab]) {
+		PopulateUnifiedList();
 	}
 	FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 	const wxString selectionKey = GetSelectionKeyForTab(m_activeTab);
@@ -4381,7 +4548,7 @@ void BorderEditorPanel::OnBrowserDeleteEntity(wxCommandEvent &event) {
 		pugi::xml_document doc; if (!doc.load_file(nstr(bordersFile).c_str())) { ShowErrorDialog("Failed to load borders.xml", ErrorSeverity::Error); return; }
 		for (pugi::xml_node n = doc.child("materials").child("border"); n; n = n.next_sibling("border")) if (n.attribute("id").as_int() == m_currentBorderId) { doc.child("materials").remove_child(n); break; }
 		if (!doc.save_file(nstr(bordersFile).c_str(), PUGIXML_TEXT("\t"))) { ShowErrorDialog("Failed to save borders.xml", ErrorSeverity::Error); return; }
-		InvalidateXmlCache(bordersFile); TriggerReloadDataFiles(); MarkBrushCatalogDirty(); ClearItems(); PopulateUnifiedList(); return;
+		InvalidateXmlCache(bordersFile); MarkBrushCatalogDirty(); ClearItems(); PopulateUnifiedList(); return;
 	}
 	const BrushEditorBrushDefinition* brush = m_catalog.FindBrushByName(selectionKey);
 	if (brush && !brush->memberships.empty()) {
@@ -4402,7 +4569,7 @@ void BorderEditorPanel::OnBrowserDeleteEntity(wxCommandEvent &event) {
 	bool removed = false; for (pugi::xml_node n = doc.child("materials").child("brush"); n; n = n.next_sibling("brush")) if (wxString(n.attribute("name").as_string()) == selectionKey) { doc.child("materials").remove_child(n); removed = true; break; }
 	if (!removed) { ShowErrorDialog("The selected brush was not found in its source XML.", ErrorSeverity::Warning); return; }
 	if (!doc.save_file(nstr(filePath).c_str(), PUGIXML_TEXT("\t"))) { ShowErrorDialog("Failed to save source XML after deletion.", ErrorSeverity::Error); return; }
-	InvalidateXmlCache(filePath); DiscardDraft(m_activeTab, selectionKey); TriggerReloadDataFiles(); MarkBrushCatalogDirty(); if (m_activeTab == 1) ClearGroundItems(); else ClearWallItems(); PopulateUnifiedList();
+	InvalidateXmlCache(filePath); DiscardDraft(m_activeTab, selectionKey); MarkBrushCatalogDirty(); if (m_activeTab == 1) ClearGroundItems(); else ClearWallItems(); PopulateUnifiedList();
 }
 
 void BorderEditorPanel::OnBrowserViewModeChanged(wxCommandEvent &event) {
@@ -4415,6 +4582,11 @@ void BorderEditorPanel::OnBrowserPaletteSelection(wxCommandEvent &event) {
 	const wxString paletteName = GetSelectedPaletteKey();
 	m_browserPaletteSelections[m_activeTab] = (paletteName == "No palettes available") ? wxString() : paletteName;
 	if (!paletteName.IsEmpty() && paletteName != "No palettes available") {
+		if (m_fullBrowserIds.IsEmpty()) {
+			if (m_activeTab == 0) PopulateBorderList();
+			else if (m_activeTab == 1) PopulateGroundList();
+			else if (m_activeTab == 2) PopulateWallList();
+		}
 		ApplyBrowserPaletteFilter(paletteName);
 	}
 	UpdateBrowserLabel();
@@ -4572,6 +4744,11 @@ void BorderEditorPanel::SetActiveInspectorSection(int section) {
 	m_activeInspectorSection = section;
 	m_browserViewMode = 0;
 	UpdateInspectorSectionButtons();
+	if (section == 1) {
+		EnsureActiveTabBrowserLoaded();
+	} else if (section == 2) {
+		EnsureActiveTabPaletteLoaded();
+	}
 	if (section == 0) {
 		if (m_activeTab == 0 && m_groupCheck) m_groupCheck->SetFocus();
 		else if (m_activeTab == 2 && m_wallNameCtrl) m_wallNameCtrl->SetFocus();
@@ -4651,7 +4828,8 @@ void BorderEditorPanel::OnModeSwitch(wxCommandEvent &event) {
 		m_browserSearchCtrl->ChangeValue(m_browserSearchQueriesByTab[m_activeTab]);
 	}
 	LoadTilesets();
-	if (!RestoreCachedBrowserDataForTab(m_activeTab)) {
+	const bool restoredBrowserData = RestoreCachedBrowserDataForTab(m_activeTab);
+	if (!restoredBrowserData) {
 		PopulateUnifiedList();
 	}
 	RefreshBrowserPaletteList();
@@ -4668,15 +4846,25 @@ void BorderEditorPanel::OnModeSwitch(wxCommandEvent &event) {
 	}
 
 	const wxString paletteSelection = m_browserPaletteSelections[m_activeTab];
+	bool restoredPaletteSelection = false;
 	if (!paletteSelection.IsEmpty() && m_browserPaletteList) {
 		for (unsigned int i = 0; i < m_browserPaletteList->GetCount(); ++i) {
 			if (m_browserPaletteList->GetString(i) == paletteSelection) {
 				m_browserPaletteList->SetSelection(i);
-				ApplyBrowserPaletteFilter(paletteSelection);
-				UpdateBrowserLabel();
-				return;
+				restoredPaletteSelection = true;
+				if (m_tabInitialized[m_activeTab]) {
+					ApplyBrowserPaletteFilter(paletteSelection);
+					UpdateBrowserLabel();
+					return;
+				}
+				break;
 			}
 		}
+	}
+
+	if (restoredPaletteSelection) {
+		UpdateBrowserLabel();
+		UpdateBrowserActionButtons();
 	}
 
 	switch (m_activeTab) {
@@ -4698,31 +4886,46 @@ void BorderEditorPanel::PopulateBorderList() {
 	m_fullBrowserPreviewIds.clear();
 	m_borderBrowserList->Clear();
 
-	EnsureBrushCatalogUpToDate();
-
 	int maxId = 0;
-	for (const BrushEditorBrushDefinition &brush : m_catalog.brushes) {
-		if (brush.kind != BrushEditorBrushKind::Border) {
-			continue;
+	wxString dataDir = g_gui.GetDataDirectory();
+	wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+	pugi::xml_document groundsDoc;
+	std::set<wxString> seen;
+	if (LoadXmlWithCache(groundsFile, groundsDoc)) {
+		for (pugi::xml_node brushNode = groundsDoc.child("materials").child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+			if (std::string(brushNode.attribute("type").as_string()) != "ground") continue;
+			const uint16_t mainTileId = brushNode.attribute("server_lookid").as_uint(brushNode.attribute("lookid").as_uint());
+			if (mainTileId == 0) continue;
+			const wxString brushName = wxString(brushNode.attribute("name").as_string());
+			for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+				const int borderId = borderNode.attribute("id").as_int();
+				const wxString align = wxString(borderNode.attribute("align").as_string());
+				if (borderId <= 0 || (!align.IsEmpty() && align != "outer")) continue;
+				maxId = std::max(maxId, borderId);
+				const wxString dedupe = wxString::Format("%u|%d", mainTileId, borderId);
+				if (!seen.insert(dedupe).second) continue;
+				const wxString label = wxString::Format("%s -> Border #%d", brushName.IsEmpty() ? wxString::Format("Ground %u", mainTileId) : brushName, borderId);
+				m_fullBrowserList.Add(label);
+				m_fullBrowserIds.Add(wxString::Format("%d", borderId));
+				m_fullBrowserPreviewIds.push_back(mainTileId);
+			}
 		}
+	}
 
-		const BrushEditorStorageLocation* storage = brush.GetPrimaryStorage();
-		if (!storage) {
-			continue;
+	if (m_fullBrowserList.IsEmpty()) {
+		wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + "materials" + wxFileName::GetPathSeparator() + "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+		pugi::xml_document bordersDoc;
+		if (LoadXmlWithCache(bordersFile, bordersDoc)) {
+			for (pugi::xml_node borderNode = bordersDoc.child("materials").child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+				const int borderId = borderNode.attribute("id").as_int();
+				if (borderId <= 0) continue;
+				maxId = std::max(maxId, borderId);
+				const wxString borderName = wxString(borderNode.attribute("name").as_string());
+				m_fullBrowserList.Add(wxString::Format("%d - %s", borderId, borderName.IsEmpty() ? wxString::Format("Border %d", borderId) : borderName));
+				m_fullBrowserIds.Add(wxString::Format("%d", borderId));
+				m_fullBrowserPreviewIds.push_back(0);
+			}
 		}
-
-		const int borderId = wxAtoi(storage->logicalId);
-		if (borderId <= 0) {
-			continue;
-		}
-
-		maxId = std::max(maxId, borderId);
-		const uint16_t previewId = brush.previewItemId != 0 ? brush.previewItemId : brush.serverLookId;
-		const wxString label = wxString::Format("%d - %s", borderId, BuildCatalogBrowserLabel(brush));
-
-		m_fullBrowserList.Add(label);
-		m_fullBrowserIds.Add(wxString::Format("%d", borderId));
-		m_fullBrowserPreviewIds.push_back(previewId);
 	}
 
 	m_nextBorderId = maxId + 1;
@@ -4908,12 +5111,22 @@ void BorderEditorPanel::PopulateUnifiedList() {
 	}
 	m_browserViewMode = 0;
 	UpdateBrowserViewButtons();
-	EnsureBrushCatalogUpToDate();
-	PopulateUnifiedListFromCatalog();
+	if (m_catalogDirty) {
+		if (m_activeTab == 1) {
+			PopulateGroundList();
+		} else {
+			PopulateWallList();
+		}
+	} else {
+		PopulateUnifiedListFromCatalog();
+	}
 	CacheBrowserDataForActiveTab();
 }
 
 void BorderEditorPanel::OnBrowserSearch(wxCommandEvent &event) {
+	if (!m_tabInitialized[m_activeTab]) {
+		PopulateUnifiedList();
+	}
 	FilterBrowserList(m_browserSearchCtrl->GetValue());
 }
 
@@ -5071,7 +5284,7 @@ void BorderEditorPanel::OnBrowserPaletteCategoryButtonClick(wxCommandEvent &even
 void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event) {
 	wxMenu menu;
 
-	const auto options = GetBrowserTilesetOptions(m_activeTab, m_activeTab == 0 ? nullptr : &m_catalog);
+	const auto &options = GetBrowserTilesetOptionsCached();
 	if (options.empty()) {
 		return;
 	}
@@ -5082,32 +5295,36 @@ void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent &event)
 			item->Check(true);
 		}
 		menu.Bind(wxEVT_MENU, [this, shown, value](wxCommandEvent &) {
-            const wxString keepSelectionKey = GetSelectionKeyForTab(m_activeTab);
-            if (value == m_browserTilesetFilter) {
-                return;
-            }
+			const wxString keepSelectionKey = GetSelectionKeyForTab(m_activeTab);
+			if (value == m_browserTilesetFilter) {
+				return;
+			}
 
-            m_browserTilesetFilter = value;
-            if (m_browserTilesetFilterButton) {
-                m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
-            }
+			m_browserTilesetFilter = value;
+			if (m_browserTilesetFilterButton) {
+				m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
+			}
 
-            FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+			if (!m_tabInitialized[m_activeTab]) {
+				PopulateUnifiedList();
+			}
+			FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
 
-            bool restored = false;
-            if (!keepSelectionKey.IsEmpty()) {
-                restored = RestoreBrowserSelection(keepSelectionKey);
-            }
+			bool restored = false;
+			if (!keepSelectionKey.IsEmpty()) {
+				restored = RestoreBrowserSelection(keepSelectionKey);
+			}
 
-            if (restored) {
-                LoadSelectionForTab(m_activeTab, keepSelectionKey);
-            } else {
-                switch (m_activeTab) {
-                    case 0: ClearItems(false); break;
-                    case 1: ClearGroundItems(false); break;
-                    case 2: ClearWallItems(false); break;
-                }
-            } }, item->GetId());
+			if (restored) {
+				LoadSelectionForTab(m_activeTab, keepSelectionKey);
+			} else {
+				switch (m_activeTab) {
+					case 0: ClearItems(false); break;
+					case 1: ClearGroundItems(false); break;
+					case 2: ClearWallItems(false); break;
+				}
+			}
+		}, item->GetId());
 	};
 
 	for (const auto &opt : options) {
@@ -5126,7 +5343,7 @@ void BorderEditorPanel::FilterBrowserList(const wxString &query) {
 	wxString lowerQuery = query.Lower();
 
 	const bool useTilesetFilter = !m_browserTilesetFilter.IsEmpty();
-	const auto filterOptions = useTilesetFilter ? GetBrowserTilesetOptions(m_activeTab, &m_catalog) : std::vector<std::pair<wxString, wxString>>();
+	const auto &filterOptions = useTilesetFilter ? GetBrowserTilesetOptionsCached() : m_cachedBrowserTilesetOptions[m_activeTab];
 	wxString selectedTilesetShown;
 	if (useTilesetFilter) {
 		for (const auto &opt : filterOptions) {
@@ -5156,7 +5373,11 @@ void BorderEditorPanel::FilterBrowserList(const wxString &query) {
 				if (!CatalogBrushHasTileset(*catalogBrush, m_browserTilesetFilter)) {
 					continue;
 				}
-			} else {
+			} else if (previewId != 0 && (m_activeTab != 0 || m_catalogDirty)) {
+				if (!ItemIdBelongsToTileset(previewId, m_browserTilesetFilter)) {
+					continue;
+				}
+			} else if (m_activeTab == 0) {
 				const int borderId = wxAtoi(m_fullBrowserIds[i]);
 				if (borderId <= 0 || !CatalogBorderHasTileset(m_catalog, borderId, m_browserTilesetFilter)) {
 					continue;
@@ -5229,14 +5450,8 @@ void BorderEditorPanel::LoadTilesets() {
 			m_rawCategorySelection = selection;
 			m_rawCategoryButton->SetLabel(m_tilesetListData[selection] + " \u25BC");
 
-			if (m_itemPalettePanel) {
-				m_itemPalettePanel->LoadTileset(m_tilesetListData[selection]);
-			}
 		} else {
 			m_rawCategoryButton->SetLabel("Select \u25BC");
-			if (m_itemPalettePanel) {
-				m_itemPalettePanel->LoadTileset("");
-			}
 		}
 	} else if (m_activeTab == 1 && m_groundTilesetButton) {
 		// Ground tab
@@ -5244,9 +5459,6 @@ void BorderEditorPanel::LoadTilesets() {
 			if (m_groundTilesetSelection < 0 || m_groundTilesetSelection >= (int)m_tilesetListData.GetCount()) m_groundTilesetSelection = 0;
 			m_groundTilesetButton->SetLabel(m_tilesetListData[m_groundTilesetSelection] + " \u25BC");
 
-			if (m_groundPalette) {
-				m_groundPalette->LoadTileset(m_tilesetListData[m_groundTilesetSelection], FILTER_GROUND);
-			}
 		} else {
 			m_groundTilesetButton->SetLabel("Select \u25BC");
 		}
@@ -5256,9 +5468,6 @@ void BorderEditorPanel::LoadTilesets() {
 			if (m_wallTilesetSelection < 0 || m_wallTilesetSelection >= (int)m_tilesetListData.GetCount()) m_wallTilesetSelection = 0;
 			m_wallTilesetButton->SetLabel(m_tilesetListData[m_wallTilesetSelection] + " \u25BC");
 
-			if (m_wallPalette) {
-				m_wallPalette->LoadTileset(m_tilesetListData[m_wallTilesetSelection], FILTER_WALL);
-			}
 		} else {
 			m_wallTilesetButton->SetLabel("Select \u25BC");
 		}
@@ -5384,6 +5593,7 @@ void BorderEditorPanel::LoadFilterConfig() {
 	m_borderEnabledTilesets = parseArray("border_enabled");
 	m_groundEnabledTilesets = parseArray("ground_enabled");
 	m_wallEnabledTilesets = parseArray("wall_enabled");
+	InvalidateTilesetCache();
 }
 
 // ============================================================================
@@ -6430,7 +6640,7 @@ void BorderEditorPanel::SaveGroundBrush() {
 	}
 
 	int preSave = wxMessageBox(
-		"This action will save the ground brush and reload data files (F5). Continue?",
+		"This action will save the ground brush. Continue?",
 		"Confirm Save",
 		wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
 		this
@@ -6569,8 +6779,7 @@ void BorderEditorPanel::SaveGroundBrush() {
 	InvalidateXmlCache(groundsFile);
 
 	DiscardDraft(1, name);
-
-	TriggerReloadDataFiles();
+	MarkBrushCatalogDirty();
 	ReloadCurrentBrushEditorXml(name);
 }
 
@@ -6715,6 +6924,9 @@ void BorderEditorPanel::LoadGroundBrushByName(const wxString &name) {
 		return;
 	}
 	if (RestoreDraft(1, name)) {
+		return;
+	}
+	if (ApplyGroundBrushFromCatalog(name)) {
 		return;
 	}
 

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -1593,7 +1593,7 @@ void BorderEditorPanel::LoadWallBrushByName(const wxString &name) {
 
 	// Load XML
 	pugi::xml_document doc;
-	if (!doc.load_file(nstr(wallsFile).c_str())) {
+	if (!LoadXmlWithCache(wallsFile, doc)) {
 		return;
 	}
 
@@ -1901,8 +1901,7 @@ void BorderEditorPanel::LoadExistingBorders() {
 
 	// Load XML
 	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
-	if (!result) {
+	if (!LoadXmlWithCache(bordersFile, doc)) {
 		return;
 	}
 
@@ -2390,10 +2389,8 @@ void BorderEditorPanel::SaveBorder() {
 
 	// Load the XML file
 	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
-
-	if (!result) {
-		ShowErrorDialog("Failed to load borders.xml: " + wxString(result.description()), ErrorSeverity::Error);
+	if (!LoadXmlWithCache(bordersFile, doc)) {
+		ShowErrorDialog("Failed to load borders.xml", ErrorSeverity::Error);
 		return;
 	}
 
@@ -2487,6 +2484,7 @@ void BorderEditorPanel::SaveBorder() {
 		ShowErrorDialog("Failed to save changes to borders.xml", ErrorSeverity::Error);
 		return;
 	}
+	InvalidateXmlCache(bordersFile);
 
 	DiscardDraft(0, m_selectedBrowserTileId);
 
@@ -3717,8 +3715,8 @@ void BorderEditorPanel::PopulateBorderList() {
 
 	{
 		pugi::xml_document doc;
-		pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
-		if (!result) {
+		pugi::xml_document doc;
+		if (!LoadXmlWithCache(bordersFile, doc)) {
 			return;
 		}
 
@@ -3771,7 +3769,7 @@ void BorderEditorPanel::PopulateBorderList() {
 
 	{
 		pugi::xml_document doc;
-		if (!doc.load_file(nstr(groundsFile).c_str())) {
+		if (!LoadXmlWithCache(groundsFile, doc)) {
 			return;
 		}
 
@@ -3867,7 +3865,7 @@ void BorderEditorPanel::PopulateGroundList() {
 	}
 
 	pugi::xml_document doc;
-	if (!doc.load_file(nstr(groundsFile).c_str())) {
+	if (!LoadXmlWithCache(groundsFile, doc)) {
 		return;
 	}
 
@@ -5690,7 +5688,7 @@ void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {
 	}
 
 	pugi::xml_document doc;
-	if (!doc.load_file(nstr(groundsFile).c_str())) {
+	if (!LoadXmlWithCache(groundsFile, doc)) {
 		return;
 	}
 
@@ -5751,7 +5749,7 @@ void BorderEditorPanel::LoadGroundBrushByMainTileId(uint16_t tileId) {
 	}
 
 	pugi::xml_document doc;
-	if (!doc.load_file(nstr(groundsFile).c_str())) {
+	if (!LoadXmlWithCache(groundsFile, doc)) {
 		return;
 	}
 
@@ -5839,7 +5837,7 @@ void BorderEditorPanel::LoadGroundBrushByName(const wxString &name) {
 	}
 
 	pugi::xml_document doc;
-	if (!doc.load_file(nstr(groundsFile).c_str())) {
+	if (!LoadXmlWithCache(groundsFile, doc)) {
 		return;
 	}
 

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -1,0 +1,5157 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+// Remere's Map Editor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Remere's Map Editor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//////////////////////////////////////////////////////////////////////
+
+#include "main.h"
+#include "palette_window.h" // For BrushPalettePanel
+#include "palette_brushlist.h" // For full BrushPalettePanel definition
+#include "materials.h" // For g_materials
+
+#include "brush_editor_window.h"
+#include "brush_browser_grid_panel.h"
+#include "browse_tile_window.h"
+#include "find_item_window.h"
+#include "common_windows.h"
+#include "graphics.h"
+#include "gui.h"
+#include "artprovider.h"
+#include "items.h"
+#include "brush.h"
+#include "raw_brush.h"
+#include "ground_brush.h"
+#include "client_assets.h"
+#include "main_menubar.h"
+#include "gui_ids.h"
+#include <wx/graphics.h>
+#include <wx/sizer.h>
+#include <wx/gbsizer.h>
+#include <wx/statline.h>
+#include <wx/tglbtn.h>
+#include <wx/dcbuffer.h>
+#include <wx/filename.h>
+#include <wx/wrapsizer.h>
+#include <wx/settings.h>
+#include <pugixml.hpp>
+#include <wx/file.h>
+#include <wx/stdpaths.h>
+
+#define BorderEditorPanel BrushEditorPanel
+
+#ifndef SPRITE_SIZE_32x32_SCALED
+	#define SPRITE_SIZE_32x32_SCALED SPRITE_SIZE_32x32
+#endif
+
+// Helper to calculate grid metrics (Shared between BorderGridPanel and WallGridPanel)
+struct GridMetrics {
+    int cellSize;
+    int spacing;
+    int startX;
+    int startY;
+    int normalX, normalY;
+    int cornerX, cornerY;
+    int diagX, diagY;
+    
+    GridMetrics(const wxSize& size) {
+        int w = size.GetWidth();
+        int h = size.GetHeight();
+        int margin = 5;
+        
+        // We have 3 blocks of 2x2. 
+        // Width = 6 * cell + 2 * spacing. 
+        // Let spacing = cell / 2.
+        // Total width units = 7.
+        // Height = 2 * cell.
+        
+        cellSize = std::min((w - 2 * margin) / 7, (h - 2 * margin) / 2);
+        if (cellSize < 16) cellSize = 16; // Minimum size
+        
+        spacing = cellSize / 2;
+        int totalWidth = (2 * cellSize) * 3 + 2 * spacing;
+        
+        startX = (w - totalWidth) / 2;
+        startY = (h - 2 * cellSize) / 2;
+        
+        normalX = startX;
+        normalY = startY;
+        
+        cornerX = normalX + 2 * cellSize + spacing;
+        cornerY = startY;
+        
+        diagX = cornerX + 2 * cellSize + spacing;
+        diagY = startY;
+    }
+
+};
+
+#define BORDER_GRID_SIZE 32
+#define BORDER_PREVIEW_SIZE 192
+#define BORDER_GRID_CELL_SIZE 32
+#define ID_BORDER_GRID_SELECT wxID_HIGHEST + 1
+#define ID_GROUND_ITEM_LIST wxID_HIGHEST + 2
+
+static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions();
+
+// Utility functions for edge string/position conversion
+BorderEdgePosition edgeStringToPosition(const std::string& edgeStr) {
+    if (edgeStr == "n") return EDGE_N;
+    if (edgeStr == "e") return EDGE_E;
+    if (edgeStr == "s") return EDGE_S;
+    if (edgeStr == "w") return EDGE_W;
+    if (edgeStr == "cnw") return EDGE_CNW;
+    if (edgeStr == "cne") return EDGE_CNE;
+    if (edgeStr == "cse") return EDGE_CSE;
+    if (edgeStr == "csw") return EDGE_CSW;
+    if (edgeStr == "dnw") return EDGE_DNW;
+    if (edgeStr == "dne") return EDGE_DNE;
+    if (edgeStr == "dse") return EDGE_DSE;
+    if (edgeStr == "dsw") return EDGE_DSW;
+    return EDGE_NONE;
+}
+
+std::string edgePositionToString(BorderEdgePosition pos) {
+    switch (pos) {
+        case EDGE_N: return "n";
+        case EDGE_E: return "e";
+        case EDGE_S: return "s";
+        case EDGE_W: return "w";
+        case EDGE_CNW: return "cnw";
+        case EDGE_CNE: return "cne";
+        case EDGE_CSE: return "cse";
+        case EDGE_CSW: return "csw";
+        case EDGE_DNW: return "dnw";
+        case EDGE_DNE: return "dne";
+        case EDGE_DSE: return "dse";
+        case EDGE_DSW: return "dsw";
+        default: return "";
+    }
+}
+
+// Add a helper function at the top of the file to get item ID from brush
+uint16_t GetItemIDFromBrush(Brush* brush) {
+    if (!brush) {
+        wxLogDebug("GetItemIDFromBrush: Brush is null");
+
+        return 0;
+    }
+    
+    uint16_t id = 0;
+    
+    wxLogDebug("GetItemIDFromBrush: Checking brush type: %s", wxString(brush->getName()).c_str());
+
+    
+    // First prioritize RAW brush - this is the most direct approach
+    if (brush->isRaw()) {
+        RAWBrush* rawBrush = brush->asRaw();
+        if (rawBrush) {
+            id = rawBrush->getItemID();
+            wxLogDebug("GetItemIDFromBrush: Found RAW brush ID: %d", id);
+
+            if (id > 0) {
+                return id;
+            }
+        }
+    } 
+    
+    // Then try getID which sometimes works directly
+    id = brush->getID();
+    if (id > 0) {
+        wxLogDebug("GetItemIDFromBrush: Got ID from brush->getID(): %d", id);
+
+        return id;
+    }
+    
+    // Try getLookID which works for most other brush types
+    id = brush->getLookID();
+    if (id > 0) {
+        wxLogDebug("GetItemIDFromBrush: Got ID from getLookID(): %d", id);
+
+        return id;
+    }
+    
+    // Try specific brush type methods - when all else fails
+    if (brush->isGround()) {
+        wxLogDebug("GetItemIDFromBrush: Detected Ground brush");
+
+        GroundBrush* groundBrush = brush->asGround();
+        if (groundBrush) {
+            // For ground brush, id is usually the server_lookid from grounds.xml
+            // Try to find something else
+            wxLogDebug("GetItemIDFromBrush: Failed to get ID for Ground brush");
+
+        }
+    }
+    else if (brush->isWall()) {
+        wxLogDebug("GetItemIDFromBrush: Detected Wall brush");
+
+        WallBrush* wallBrush = brush->asWall();
+        if (wallBrush) {
+            wxLogDebug("GetItemIDFromBrush: Failed to get ID for Wall brush");
+
+        }
+    }
+    else if (brush->isDoodad()) {
+        wxLogDebug("GetItemIDFromBrush: Detected Doodad brush");
+
+        DoodadBrush* doodadBrush = brush->asDoodad();
+        if (doodadBrush) {
+            wxLogDebug("GetItemIDFromBrush: Failed to get ID for Doodad brush");
+
+        }
+    }
+    
+    if (id == 0) {
+        wxLogDebug("GetItemIDFromBrush: Failed to get item ID from brush %s", wxString(brush->getName()).c_str());
+
+    }
+    
+    return id;
+}
+
+// Event table for BorderEditorPanel
+wxDEFINE_EVENT(wxEVT_GROUND_CONTAINER_CHANGE, wxCommandEvent);
+
+static void TriggerReloadDataFiles() {
+    if (!g_gui.root) {
+        return;
+    }
+
+    wxCommandEvent reloadEvent(
+        wxEVT_COMMAND_MENU_SELECTED,
+        MAIN_FRAME_MENU + MenuBar::RELOAD_DATA
+    );
+    g_gui.root->GetEventHandler()->ProcessEvent(reloadEvent);
+}
+
+bool BorderEditorPanel::RestoreBrowserSelection(const wxString& selectionKey) {
+    if (!m_borderBrowserList) {
+        return false;
+    }
+
+    if (selectionKey.IsEmpty()) {
+        m_borderBrowserList->SetSelection(wxNOT_FOUND);
+        if (m_browserGrid) {
+            m_browserGrid->SetSelectionByKey(wxString());
+        }
+        return false;
+    }
+
+    const int wanted = wxAtoi(selectionKey);
+
+    for (unsigned int i = 0; i < m_borderBrowserList->GetCount(); ++i) {
+        wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(i));
+        if (!data) {
+            continue;
+        }
+
+        if (wxAtoi(data->GetData()) == wanted) {
+            m_borderBrowserList->SetSelection(i);
+            if (m_browserGrid) {
+                m_browserGrid->SetSelectionByKey(selectionKey);
+            }
+            return true;
+        }
+    }
+
+    m_borderBrowserList->SetSelection(wxNOT_FOUND);
+    if (m_browserGrid) {
+        m_browserGrid->SetSelectionByKey(wxString());
+    }
+    return false;
+}
+
+void BorderEditorPanel::ReloadCurrentBrushEditorXml(const wxString& selectionKey) {
+    if (m_browserSearchCtrl) {
+        m_browserSearchCtrl->Clear();
+    }
+
+    LoadTilesets();
+    PopulateUnifiedList();
+
+    RestoreBrowserSelection(selectionKey);
+
+    const uint16_t tileId = static_cast<uint16_t>(wxAtoi(selectionKey));
+    switch (m_activeTab) {
+        case 0: LoadBorderByMainTileId(tileId); break;
+        case 1: LoadGroundBrushByMainTileId(tileId); break;
+        case 2: LoadWallBrushByMainTileId(tileId); break;
+    }
+
+    Layout();
+    Refresh();
+    Update();
+}
+
+BEGIN_EVENT_TABLE(BorderEditorPanel, wxPanel)
+    EVT_BUTTON(wxID_ADD, BorderEditorPanel::OnAddItem)
+    EVT_BUTTON(wxID_CLEAR, BorderEditorPanel::OnClear)
+    EVT_BUTTON(wxID_SAVE, BorderEditorPanel::OnSave)
+    EVT_BUTTON(wxID_CLOSE, BorderEditorPanel::OnClose)
+    EVT_BUTTON(wxID_FIND, BorderEditorPanel::OnBrowse)
+    EVT_COMBOBOX(wxID_ANY, BorderEditorPanel::OnLoadBorder)
+    EVT_NOTEBOOK_PAGE_CHANGED(wxID_ANY, BorderEditorPanel::OnPageChanged)
+END_EVENT_TABLE()
+
+// Event table for BorderItemButton
+BEGIN_EVENT_TABLE(BorderItemButton, wxButton)
+    EVT_PAINT(BorderItemButton::OnPaint)
+END_EVENT_TABLE()
+
+// Event table for BorderGridPanel
+BEGIN_EVENT_TABLE(BorderGridPanel, wxPanel)
+    EVT_PAINT(BorderGridPanel::OnPaint)
+    EVT_LEFT_UP(BorderGridPanel::OnMouseClick)
+    EVT_LEFT_DOWN(BorderGridPanel::OnMouseDown)
+END_EVENT_TABLE()
+
+// Event table for BorderPreviewPanel
+BEGIN_EVENT_TABLE(BorderPreviewPanel, wxPanel)
+    EVT_PAINT(BorderPreviewPanel::OnPaint)
+END_EVENT_TABLE()
+
+BorderEditorPanel::BorderEditorPanel(wxWindow* parent) :
+    wxPanel(parent, wxID_ANY),
+    m_nextBorderId(1),
+    m_activeTab(1),
+    m_selectedBrowserTileId(0),
+    m_lastInteractionTime(0) {
+    
+    // Load saved filter configuration (before creating UI)
+    LoadFilterConfig();
+    
+    CreateGUIControls();
+    
+    // Default to Ground tab
+    m_notebook->SetSelection(1);
+    if (m_borderModeBtn) m_borderModeBtn->SetValue(false);
+    if (m_groundModeBtn) m_groundModeBtn->SetValue(true);
+    if (m_wallModeBtn) m_wallModeBtn->SetValue(false);
+    
+    // Explicitly populate the sidebar (unified list) for the initial tab
+    // (OnPageChanged may not fire for the initial selection on all platforms)
+    PopulateUnifiedList();
+    UpdateBrowserLabel();
+    
+    // Set initial border ID
+    m_currentBorderId = m_nextBorderId;
+    
+    Layout();
+}
+
+BorderEditorPanel::~BorderEditorPanel() {
+    // Nothing to destroy manually
+}
+
+void BorderEditorPanel::CreateGUIControls() {
+    wxBoxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
+    
+    
+    // Create simplebook (no visible tabs - switching via sidebar buttons)
+    m_notebook = new wxSimplebook(this, wxID_ANY);
+    
+    // ========== BORDER TAB ==========
+    m_borderPanel = new wxPanel(m_notebook);
+    wxBoxSizer* borderSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // --- Top Toolbar: Name + Checkboxes (Merged) ---
+    wxBoxSizer* toolbarSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // Name Field (Left side of toolbar)
+    toolbarSizer->Add(new wxStaticText(m_borderPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_nameCtrl = new wxTextCtrl(m_borderPanel, wxID_ANY);
+    m_nameCtrl->SetToolTip("Descriptive name for the border/brush");
+    toolbarSizer->Add(m_nameCtrl, 1, wxEXPAND | wxRIGHT, 15);
+    
+    // Checkboxes (Right side of toolbar)
+    m_groupCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Group");
+    m_groupCheck->SetToolTip("Check to assign this border to a group");
+    toolbarSizer->Add(m_groupCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+    
+    m_isOptionalCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Optional");
+    m_isOptionalCheck->SetToolTip("Marks this border as optional");
+    toolbarSizer->Add(m_isOptionalCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+    
+    m_isGroundCheck = new wxCheckBox(m_borderPanel, wxID_ANY, "Ground");
+    m_isGroundCheck->SetToolTip("Marks this border as a ground border");
+    toolbarSizer->Add(m_isGroundCheck, 0, wxALIGN_CENTER_VERTICAL);
+    
+    borderSizer->Add(toolbarSizer, 0, wxEXPAND | wxALL, 5);
+    
+    // --- Main Content: Palette (Left) + Editor/Preview (Right) ---
+    wxBoxSizer* borderContentSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // === Left Column: Raw Item Palette (takes full height) ===
+    wxBoxSizer* leftColumnSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Raw Item Palette - shows all raw items for selection    // Raw Item Palette - shows all raw items for selection
+    // Category Selector Row (ComboBox + Filter Button)
+    wxBoxSizer* borderTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    wxArrayString categories;
+    for (const auto& pair : g_materials.tilesets) {
+        categories.Add(wxstr(pair.first));
+    }
+    m_rawCategoryNames = categories; // Store for menu
+    m_rawCategoryButton = new wxButton(m_borderPanel, wxID_ANY, "Category ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+    m_rawCategoryButton->SetToolTip("Filter by Tileset Category");
+    m_rawCategoryButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnRawCategoryButtonClick, this);
+    borderTilesetRowSizer->Add(m_rawCategoryButton, 1, wxEXPAND | wxRIGHT, 2);
+    
+    // Filter button with Cut icon (scissors)
+    wxBitmapButton* borderFilterBtn = new wxBitmapButton(m_borderPanel, wxID_ANY, 
+        wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+    borderFilterBtn->SetToolTip("Filter visible tilesets");
+    borderFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
+    borderTilesetRowSizer->Add(borderFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
+    
+    leftColumnSizer->Add(borderTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+    
+    m_itemPalettePanel = new SimpleRawPalettePanel(m_borderPanel);
+    // m_itemPalettePanel->SetListType(BRUSHLIST_LARGE_ICONS);
+    m_itemPalettePanel->SetMinSize(wxSize(220, 300));
+    leftColumnSizer->Add(m_itemPalettePanel, 1, wxEXPAND | wxALL, 5);
+    
+    borderContentSizer->Add(leftColumnSizer, 0, wxEXPAND);
+    
+    // === Right Column: Editor + Preview ===
+    wxBoxSizer* rightColumnSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Editor inside StaticBoxSizer
+    wxStaticBoxSizer* editorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Editor");
+    m_gridPanel = new BorderGridPanel(editorBoxSizer->GetStaticBox());
+    editorBoxSizer->Add(m_gridPanel, 0, wxALIGN_CENTER | wxALL, 5);
+    rightColumnSizer->Add(editorBoxSizer, 0, wxEXPAND | wxALL, 5);
+    
+    // Preview inside StaticBoxSizer
+    wxStaticBoxSizer* previewBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_borderPanel, "Preview");
+    m_previewPanel = new BorderPreviewPanel(previewBoxSizer->GetStaticBox());
+    m_previewPanel->SetMinSize(wxSize(200, 200));
+    previewBoxSizer->Add(m_previewPanel, 1, wxEXPAND | wxALL, 5);
+    rightColumnSizer->Add(previewBoxSizer, 1, wxEXPAND | wxALL, 5);
+    
+    borderContentSizer->Add(rightColumnSizer, 1, wxEXPAND | wxLEFT, 5);
+    
+    // Add main content to border sizer (takes most vertical space)
+    borderSizer->Add(borderContentSizer, 1, wxEXPAND | wxALL, 5);
+    
+    // --- Bottom Action Bar ---
+    wxBoxSizer* borderButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+    borderButtonSizer->AddStretchSpacer(1);
+    
+    m_newButton = new wxButton(m_borderPanel, wxID_CLEAR, "New Border");
+    m_newButton->SetToolTip("Start creating a new border (clears current form)");
+    borderButtonSizer->Add(m_newButton, 0, wxRIGHT, 5);
+    
+    borderButtonSizer->Add(new wxButton(m_borderPanel, wxID_SAVE, "Save Changes"), 0, wxRIGHT, 5);
+    borderButtonSizer->Add(new wxButton(m_borderPanel, wxID_CLOSE, "Close"), 0);
+    
+    borderSizer->Add(borderButtonSizer, 0, wxEXPAND | wxALL, 5);
+    
+    m_borderPanel->SetSizer(borderSizer);
+    
+    // ========== GROUND TAB ==========
+    m_groundPanel = new wxPanel(m_notebook);
+    wxBoxSizer* groundSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // === Left Column: Form Controls ===
+    wxBoxSizer* groundLeftSizer = new wxBoxSizer(wxVERTICAL);
+    
+    wxBoxSizer* row1 = new wxBoxSizer(wxHORIZONTAL);
+    row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_groundNameCtrl = new wxTextCtrl(m_groundPanel, wxID_ANY, "");
+    row1->Add(m_groundNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+
+    row1->Add(new wxStaticText(m_groundPanel, wxID_ANY, "ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_serverLookIdCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "", wxDefaultPosition, wxSize(80, -1));
+    m_serverLookIdCtrl->SetRange(0, 99999);
+    m_serverLookIdCtrl->SetToolTip("Server-side item ID");
+    row1->Add(m_serverLookIdCtrl, 0, wxALIGN_CENTER_VERTICAL);
+    groundLeftSizer->Add(row1, 0, wxEXPAND | wxBOTTOM, 5);
+
+    wxBoxSizer* row2 = new wxBoxSizer(wxHORIZONTAL);
+    row2->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Z-Order:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_zOrderCtrl = new wxSpinCtrl(m_groundPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(60, -1));
+    m_zOrderCtrl->SetRange(-100, 100);
+    row2->Add(m_zOrderCtrl, 0);
+    groundLeftSizer->Add(row2, 0, wxEXPAND | wxBOTTOM, 5);
+    
+    // Item Palette / Selection
+    wxBoxSizer* row3 = new wxBoxSizer(wxHORIZONTAL);
+    // Chance control removed
+    groundLeftSizer->Add(row3, 0, wxEXPAND | wxBOTTOM, 5);
+
+    // Preview Panel moved to right column
+    wxBoxSizer* tilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    tilesetRowSizer->Add(new wxStaticText(m_groundPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    
+    // --- Main Body: Palette (Left) + Editor (Right) ---
+    wxBoxSizer* groundContentSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // === Left Column: Raw Item Palette ===
+    // Tileset selector row (ComboBox + Gear button)
+    
+    m_groundTilesetButton = new wxButton(m_groundPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+    m_groundTilesetButton->SetToolTip("Select Tileset");
+    m_groundTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnGroundTilesetButtonClick, this);
+    tilesetRowSizer->Add(m_groundTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
+    
+    // Filter button with Cut icon (scissors)
+    m_tilesetFilterBtn = new wxBitmapButton(m_groundPanel, wxID_ANY, 
+        wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+    m_tilesetFilterBtn->SetToolTip("Filter visible tilesets");
+    m_tilesetFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
+    tilesetRowSizer->Add(m_tilesetFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
+    
+    groundLeftSizer->Add(tilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+
+    m_groundPalette = new SimpleRawPalettePanel(m_groundPanel);
+    m_groundPalette->SetMinSize(wxSize(220, 200));
+    m_groundPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundPaletteSelect, this);
+    groundLeftSizer->Add(m_groundPalette, 1, wxEXPAND | wxALL, 5);
+    groundContentSizer->Add(groundLeftSizer, 0, wxEXPAND);
+    
+    // === Right Column: Editor Controls (Scrollable List) ===
+    // === Right Column: Editor Controls (Scrollable List) ===
+    wxBoxSizer* groundRightSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Preview (Directly in sizer for seamless look)
+    m_groundPreviewPanel = new GroundPreviewPanel(m_groundPanel, wxID_ANY);
+    // m_groundPreviewPanel size is set in constructor (96x96)
+    groundRightSizer->Add(m_groundPreviewPanel, 0, wxALIGN_CENTER | wxALL, 10);
+
+    wxStaticBoxSizer* groundEditorBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Variations");
+    
+    m_groundGridContainer = new GroundGridContainer(groundEditorBoxSizer->GetStaticBox(), wxID_ANY + 1); // Added ID
+    m_groundGridContainer->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnGroundGridSelect, this);
+    // Bind change event to update preview
+    Bind(wxEVT_GROUND_CONTAINER_CHANGE, &BorderEditorPanel::OnGroundContainerChange, this);
+    
+    groundEditorBoxSizer->Add(m_groundGridContainer, 1, wxEXPAND | wxALL, 5);
+
+    wxBoxSizer* addVarSizer = new wxBoxSizer(wxHORIZONTAL);
+    addVarSizer->AddStretchSpacer(1);
+    m_addVariationBtn = new wxButton(groundEditorBoxSizer->GetStaticBox(), wxID_ANY, "Add Variation");
+    m_addVariationBtn->SetToolTip("Add a new empty variation at the end");
+    m_addVariationBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnAddVariation, this);
+    addVarSizer->Add(m_addVariationBtn, 0);
+    groundEditorBoxSizer->Add(addVarSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+    
+    groundRightSizer->Add(groundEditorBoxSizer, 1, wxEXPAND | wxALL, 5);
+    
+    // Border Options inside StaticBox
+    wxStaticBoxSizer* borderOptionsBoxSizer = new wxStaticBoxSizer(wxVERTICAL, m_groundPanel, "Border Options");
+    
+    wxBoxSizer* borderOptionsRow = new wxBoxSizer(wxHORIZONTAL);
+    
+    borderOptionsRow->Add(new wxStaticText(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Alignment:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_borderAlignmentButton = new wxButton(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Outer ▼", wxDefaultPosition, wxSize(80, -1), wxBU_LEFT);
+    m_borderAlignmentButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBorderAlignmentButtonClick, this);
+    borderOptionsRow->Add(m_borderAlignmentButton, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+    
+    m_includeToNoneCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "To None");
+    m_includeToNoneCheck->SetValue(true);
+    borderOptionsRow->Add(m_includeToNoneCheck, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
+    
+    m_includeInnerCheck = new wxCheckBox(borderOptionsBoxSizer->GetStaticBox(), wxID_ANY, "Inner Border");
+    borderOptionsRow->Add(m_includeInnerCheck, 0, wxALIGN_CENTER_VERTICAL);
+    
+    borderOptionsBoxSizer->Add(borderOptionsRow, 0, wxEXPAND | wxALL, 5);
+    groundRightSizer->Add(borderOptionsBoxSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+    
+    groundContentSizer->Add(groundRightSizer, 1, wxEXPAND | wxLEFT, 5);
+    groundSizer->Add(groundContentSizer, 1, wxEXPAND | wxALL, 5);
+    
+    // --- Footer: Right-aligned buttons ---
+    wxBoxSizer* groundButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+    groundButtonSizer->AddStretchSpacer(1);
+    
+    wxButton* groundNewButton = new wxButton(m_groundPanel, wxID_CLEAR, "New Ground");
+    groundNewButton->SetToolTip("Start creating a new ground brush (clears current form)");
+    groundButtonSizer->Add(groundNewButton, 0, wxRIGHT, 5);
+    
+    groundButtonSizer->Add(new wxButton(m_groundPanel, wxID_SAVE, "Save Changes"), 0, wxRIGHT, 5);
+    groundButtonSizer->Add(new wxButton(m_groundPanel, wxID_CLOSE, "Close"), 0);
+    
+    groundSizer->Add(groundButtonSizer, 0, wxEXPAND | wxALL, 5);
+    
+    m_groundPanel->SetSizer(groundSizer);
+    
+    // Add pages to simplebook (no visible tabs)
+    m_notebook->AddPage(m_borderPanel, "Border");
+    m_notebook->AddPage(m_groundPanel, "Ground");
+    
+    // Notebook pages "Border Loop" and "Ground Brush" removed as they were duplicate pointers
+
+    // ========== WALL TAB ==========
+    m_wallPanel = new wxPanel(m_notebook);
+    wxBoxSizer* wallSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // --- Header: Name + ID (Single Row) ---
+    wxBoxSizer* wallHeaderSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // Name Field (Expand)
+    wallHeaderSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_wallNameCtrl = new wxTextCtrl(m_wallPanel, wxID_ANY);
+    wallHeaderSizer->Add(m_wallNameCtrl, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 15);
+    
+    // wallHeaderSizer->AddStretchSpacer(1); // Spacer usage adjustments if needed, but 1 expand on Name is good.
+    
+    // Server Look ID
+    wallHeaderSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    m_wallServerLookIdCtrl = new wxSpinCtrl(m_wallPanel, wxID_ANY, "0", wxDefaultPosition, wxSize(70, -1), wxSP_ARROW_KEYS, 0, 65535);
+    m_wallServerLookIdCtrl->SetToolTip("Server-side item ID");
+    wallHeaderSizer->Add(m_wallServerLookIdCtrl, 0, wxALIGN_CENTER_VERTICAL);
+    
+    wallSizer->Add(wallHeaderSizer, 0, wxEXPAND | wxALL, 5);
+    
+    // --- Main Body: Palette (Left) + Editor (Right) ---
+    wxBoxSizer* wallContentSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // === Left Column: Raw Item Palette ===
+    // === Left Column: Raw Item Palette ===
+    wxBoxSizer* wallLeftSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Tileset selector row (ComboBox + Filter button)
+    wxBoxSizer* wallTilesetRowSizer = new wxBoxSizer(wxHORIZONTAL);
+    wallTilesetRowSizer->Add(new wxStaticText(m_wallPanel, wxID_ANY, "Source:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    
+    m_wallTilesetButton = new wxButton(m_wallPanel, wxID_ANY, "Select Tileset ▼", wxDefaultPosition, wxDefaultSize, wxBU_LEFT);
+    m_wallTilesetButton->SetToolTip("Select Tileset");
+    m_wallTilesetButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnWallTilesetButtonClick, this);
+    wallTilesetRowSizer->Add(m_wallTilesetButton, 1, wxEXPAND | wxRIGHT, 2);
+    
+    // Filter button
+    wxBitmapButton* wallFilterBtn = new wxBitmapButton(m_wallPanel, wxID_ANY, 
+        wxArtProvider::GetBitmap(wxART_CUT, wxART_BUTTON, wxSize(16, 16)));
+    wallFilterBtn->SetToolTip("Filter visible tilesets");
+    wallFilterBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnOpenTilesetFilter, this);
+    wallTilesetRowSizer->Add(wallFilterBtn, 0, wxALIGN_CENTER_VERTICAL);
+    
+    wallLeftSizer->Add(wallTilesetRowSizer, 0, wxEXPAND | wxBOTTOM, 5);
+
+    m_wallPalette = new SimpleRawPalettePanel(m_wallPanel);
+    m_wallPalette->SetMinSize(wxSize(220, 300));
+    m_wallPalette->Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnWallPaletteSelect, this);
+    wallLeftSizer->Add(m_wallPalette, 1, wxEXPAND | wxALL, 5);
+    
+    wallContentSizer->Add(wallLeftSizer, 0, wxEXPAND);
+    
+    // === Right Column: Editor Controls ===
+    wxBoxSizer* wallRightSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Wall Structure inside StaticBox
+    wxStaticBoxSizer* structureSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Wall Structure");
+    
+    // Logic Type Selector (Visual Grid)
+    wxBoxSizer* wallTypeSizer = new wxBoxSizer(wxVERTICAL);
+    // wallTypeSizer->Add(new wxStaticText(structureSizer->GetStaticBox(), wxID_ANY, "Select Type to Edit:"), 0, wxALIGN_LEFT | wxBOTTOM, 5); // Removed to save space
+    
+    m_wallGridPanel = new WallGridPanel(structureSizer->GetStaticBox(), wxID_ANY);
+    m_wallGridPanel->SetMinSize(wxSize(280, 200)); // Increased height for 3x3 grid
+    
+    // Bind click event (reusing BUTTON_CLICKED)
+    m_wallGridPanel->Bind(wxEVT_COMMAND_BUTTON_CLICKED, &BorderEditorPanel::OnWallGridSelect, this);
+    
+    wallTypeSizer->Add(m_wallGridPanel, 0, wxEXPAND | wxBOTTOM, 5);
+    structureSizer->Add(wallTypeSizer, 0, wxEXPAND | wxALL, 5);
+    
+    // List of items for this type (REMOVED per user request)
+    // m_wallItemsList = new wxListBox(structureSizer->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(-1, 80));
+    // structureSizer->Add(m_wallItemsList, 1, wxEXPAND | wxLEFT | wxRIGHT, 5);
+    m_wallItemsList = nullptr;
+    
+    // Add Item Controls row (REMOVED per user request)
+    // wxBoxSizer* wallItemInputSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // wallItemInputSizer->Add(new wxStaticText(structureSizer->GetStaticBox(), wxID_ANY, "Item ID:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 5);
+    // m_wallItemIdCtrl = new wxSpinCtrl(structureSizer->GetStaticBox(), wxID_ANY, "0", wxDefaultPosition, wxSize(70, -1), wxSP_ARROW_KEYS, 0, 65535);
+    // wallItemInputSizer->Add(m_wallItemIdCtrl, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 10);
+    m_wallItemIdCtrl = nullptr;
+    
+    // wxButton* addWallItemBtn = new wxButton(structureSizer->GetStaticBox(), wxID_ANY, "Add", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+    // addWallItemBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnAddWallItem, this);
+    // wallItemInputSizer->Add(addWallItemBtn, 0, wxRIGHT, 5);
+    
+    // wxButton* remWallItemBtn = new wxButton(structureSizer->GetStaticBox(), wxID_ANY, "Remove", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+    // remWallItemBtn->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnRemoveWallItem, this);
+    // wallItemInputSizer->Add(remWallItemBtn, 0);
+    
+    // structureSizer->Add(wallItemInputSizer, 0, wxEXPAND | wxALL, 5);
+    wallRightSizer->Add(structureSizer, 1, wxEXPAND | wxALL, 5);
+    
+    // Preview inside StaticBox
+    wxStaticBoxSizer* wallVisualSizer = new wxStaticBoxSizer(wxVERTICAL, m_wallPanel, "Preview");
+    m_wallVisualPanel = new WallVisualPanel(wallVisualSizer->GetStaticBox());
+    m_wallVisualPanel->SetMinSize(wxSize(150, 150));
+    wallVisualSizer->Add(m_wallVisualPanel, 1, wxEXPAND | wxALL, 5);
+    wallRightSizer->Add(wallVisualSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+    
+    wallContentSizer->Add(wallRightSizer, 1, wxEXPAND | wxLEFT, 5);
+    wallSizer->Add(wallContentSizer, 1, wxEXPAND | wxALL, 5);
+    
+    // --- Footer: Right-aligned buttons ---
+    wxBoxSizer* wallButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+    wallButtonSizer->AddStretchSpacer(1);
+    
+    wxButton* wallNewButton = new wxButton(m_wallPanel, wxID_ANY, "New Wall");
+    wallNewButton->SetToolTip("Start creating a new wall brush (clears current form)");
+    wallNewButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent& ev) { 
+        ClearWallItems();
+        m_nameCtrl->SetValue("");
+        if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(0);
+        if (m_borderBrowserList) m_borderBrowserList->SetSelection(wxNOT_FOUND);
+    });
+    wallButtonSizer->Add(wallNewButton, 0, wxRIGHT, 5);
+    
+    wxButton* saveWallButton = new wxButton(m_wallPanel, wxID_ANY, "Save Changes");
+    saveWallButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent& ev) { SaveWallBrush(); });
+    wallButtonSizer->Add(saveWallButton, 0, wxRIGHT, 5);
+    wallButtonSizer->Add(new wxButton(m_wallPanel, wxID_CLOSE, "Close"), 0);
+    
+    wallSizer->Add(wallButtonSizer, 0, wxEXPAND | wxALL, 5);
+    
+    m_wallPanel->SetSizer(wallSizer);
+    m_notebook->AddPage(m_wallPanel, "Wall");
+    
+    // ========== HORIZONTAL LAYOUT: Content (Left) + Browser (Right) ==========
+    wxBoxSizer* mainHorizSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    // LEFT: Add notebook (existing content)
+    mainHorizSizer->Add(m_notebook, 1, wxEXPAND | wxALL, 5);
+    
+    // RIGHT: Browser Sidebar
+    wxBoxSizer* browserSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Mode Switcher Buttons (replaces m_browserLabel)
+    wxBoxSizer* modeSwitcherSizer = new wxBoxSizer(wxHORIZONTAL);
+    
+    m_groundModeBtn = new wxToggleButton(this, wxID_ANY, "Variation", wxDefaultPosition, wxDefaultSize);
+    m_groundModeBtn->SetValue(true); // Default to Ground mode
+    m_groundModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
+    modeSwitcherSizer->Add(m_groundModeBtn, 1, wxEXPAND | wxRIGHT, 2);
+    
+    m_wallModeBtn = new wxToggleButton(this, wxID_ANY, "Structure", wxDefaultPosition, wxDefaultSize);
+    m_wallModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
+    modeSwitcherSizer->Add(m_wallModeBtn, 1, wxEXPAND | wxRIGHT, 2);
+    
+    m_borderModeBtn = new wxToggleButton(this, wxID_ANY, "Border", wxDefaultPosition, wxDefaultSize);
+    m_borderModeBtn->SetValue(false);
+    m_borderModeBtn->Bind(wxEVT_TOGGLEBUTTON, &BorderEditorPanel::OnModeSwitch, this);
+    modeSwitcherSizer->Add(m_borderModeBtn, 1, wxEXPAND);
+    
+    browserSizer->Add(modeSwitcherSizer, 0, wxEXPAND | wxALL, 5);
+
+    m_browserTilesetFilterButton = new wxButton(this, wxID_ANY, "Tileset: Select ▼", wxDefaultPosition, wxSize(280, -1), wxBU_LEFT);
+    m_browserTilesetFilterButton->Bind(wxEVT_BUTTON, &BorderEditorPanel::OnBrowserTilesetFilterButtonClick, this);
+    browserSizer->Add(m_browserTilesetFilterButton, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+    
+    // Search control
+    m_browserSearchCtrl = new wxSearchCtrl(this, wxID_ANY, "", wxDefaultPosition, wxSize(280, -1));
+    m_browserSearchCtrl->SetDescriptiveText("Search...");
+    m_browserSearchCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &BorderEditorPanel::OnBrowserSearch, this);
+    m_browserSearchCtrl->Bind(wxEVT_TEXT, &BorderEditorPanel::OnBrowserSearch, this);
+    browserSizer->Add(m_browserSearchCtrl, 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
+    
+    m_borderBrowserList = new wxListBox(this, wxID_ANY, wxDefaultPosition, wxSize(280, -1), 0, nullptr, wxLB_SINGLE | wxBORDER_NONE);
+    m_borderBrowserList->Hide();
+    m_borderBrowserList->Bind(wxEVT_LISTBOX, &BorderEditorPanel::OnBorderBrowserSelection, this);
+
+    m_browserGrid = new BrushBrowserGridPanel(this, wxID_ANY);
+    m_browserGrid->SetToolTip("Click an item to load it for editing");
+    Bind(wxEVT_COMMAND_LISTBOX_SELECTED, &BorderEditorPanel::OnBrowserGridSelection, this, m_browserGrid->GetId());
+    browserSizer->Add(m_browserGrid, 1, wxEXPAND | wxALL, 5);
+    
+    mainHorizSizer->Add(browserSizer, 0, wxEXPAND);
+    
+    // Add horizontal layout to top sizer
+    topSizer->Add(mainHorizSizer, 1, wxEXPAND);
+    
+    SetSizer(topSizer);
+    Layout();
+    
+    // Initialize Category Combo (Select Borders if available)
+    // Initialize Category Button (Select Borders if available)
+    if (!m_rawCategoryNames.IsEmpty()) {
+        int defaults = m_rawCategoryNames.Index("Borders");
+        if (defaults != wxNOT_FOUND) {
+            m_rawCategorySelection = defaults;
+        } else {
+            m_rawCategorySelection = 0;
+        }
+        
+        if (m_rawCategoryButton) {
+            m_rawCategoryButton->SetLabel(m_rawCategoryNames[m_rawCategorySelection] + " \u25BC");
+        }
+        
+        // Trigger load
+        if (m_itemPalettePanel) {
+            m_itemPalettePanel->LoadTileset(m_rawCategoryNames[m_rawCategorySelection]);
+        }
+    }
+
+    // Initialize Tileset Choice (Ground Tab)
+    LoadTilesets(); // Ensure m_tilesetListData is populated
+    
+    // Select first tileset if any
+    if (!m_tilesetListData.IsEmpty()) {
+        m_groundTilesetSelection = 0;
+        if (m_groundTilesetButton) {
+            m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+        }
+        
+        // Trigger load for ground
+        if (m_groundPalette) {
+             m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
+        }
+    }
+
+    {
+        const auto options = GetBrowserTilesetOptions();
+        if (!options.empty() && m_browserTilesetFilter.IsEmpty()) {
+            m_browserTilesetFilter = options.front().second;
+            if (m_browserTilesetFilterButton) {
+                m_browserTilesetFilterButton->SetLabel("Tileset: " + options.front().first + " ▼");
+            }
+        }
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::OnRawCategoryButtonClick(wxCommandEvent& event) {
+    if (m_rawCategoryNames.IsEmpty()) return;
+    
+    wxMenu menu;
+    for (size_t i = 0; i < m_rawCategoryNames.GetCount(); ++i) {
+        menu.AppendCheckItem(1000 + i, m_rawCategoryNames[i]);
+        if ((int)i == m_rawCategorySelection) {
+            menu.Check(1000 + i, true);
+        }
+    }
+    
+    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnRawCategoryMenuSelect, this);
+    const wxSize btnSize = m_rawCategoryButton->GetSize();
+    m_rawCategoryButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+}
+
+void BorderEditorPanel::OnRawCategoryMenuSelect(wxCommandEvent& event) {
+    int id = event.GetId() - 1000;
+    if (id < 0 || id >= (int)m_rawCategoryNames.GetCount()) return;
+    
+    m_rawCategorySelection = id;
+    if (m_rawCategoryButton) {
+        m_rawCategoryButton->SetLabel(m_rawCategoryNames[id] + " \u25BC");
+    }
+    
+    if (m_itemPalettePanel) {
+        m_itemPalettePanel->LoadTileset(m_rawCategoryNames[id]);
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::OnGroundTilesetButtonClick(wxCommandEvent& event) {
+    if (m_tilesetListData.IsEmpty()) return;
+    
+    wxMenu menu;
+    for (size_t i = 0; i < m_tilesetListData.GetCount(); ++i) {
+        menu.AppendCheckItem(2000 + i, m_tilesetListData[i]);
+        if ((int)i == m_groundTilesetSelection) {
+            menu.Check(2000 + i, true);
+        }
+    }
+    
+    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnGroundTilesetMenuSelect, this);
+    const wxSize btnSize = m_groundTilesetButton->GetSize();
+    m_groundTilesetButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+}
+
+void BorderEditorPanel::OnGroundTilesetMenuSelect(wxCommandEvent& event) {
+    int id = event.GetId() - 2000;
+    if (id < 0 || id >= (int)m_tilesetListData.GetCount()) return;
+    
+    m_groundTilesetSelection = id;
+    if (m_groundTilesetButton) {
+        m_groundTilesetButton->SetLabel(m_tilesetListData[id] + " \u25BC");
+    }
+    
+    if (m_groundPalette) {
+        m_groundPalette->LoadTileset(m_tilesetListData[id], FILTER_GROUND);
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::OnWallTilesetButtonClick(wxCommandEvent& event) {
+    if (m_tilesetListData.IsEmpty()) return;
+    
+    wxMenu menu;
+    for (size_t i = 0; i < m_tilesetListData.GetCount(); ++i) {
+        menu.AppendCheckItem(3000 + i, m_tilesetListData[i]);
+        if ((int)i == m_wallTilesetSelection) {
+            menu.Check(3000 + i, true);
+        }
+    }
+    
+    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnWallTilesetMenuSelect, this);
+    const wxSize btnSize = m_wallTilesetButton->GetSize();
+    m_wallTilesetButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+}
+
+void BorderEditorPanel::OnWallTilesetMenuSelect(wxCommandEvent& event) {
+    int id = event.GetId() - 3000;
+    if (id < 0 || id >= (int)m_tilesetListData.GetCount()) return;
+    
+    m_wallTilesetSelection = id;
+    if (m_wallTilesetButton) {
+        m_wallTilesetButton->SetLabel(m_tilesetListData[id] + " \u25BC");
+    }
+    
+    if (m_wallPalette) {
+        m_wallPalette->LoadTileset(m_tilesetListData[id], FILTER_WALL);
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::OnBorderAlignmentButtonClick(wxCommandEvent& event) {
+    wxMenu menu;
+    menu.AppendCheckItem(4000, "Outer");
+    menu.AppendCheckItem(4001, "Inner");
+    
+    menu.Check(4000 + m_borderAlignmentSelection, true);
+    
+    menu.Bind(wxEVT_MENU, &BorderEditorPanel::OnBorderAlignmentMenuSelect, this);
+    const wxSize btnSize = m_borderAlignmentButton->GetSize();
+    m_borderAlignmentButton->PopupMenu(&menu, 0, btnSize.GetHeight());
+}
+
+void BorderEditorPanel::OnBorderAlignmentMenuSelect(wxCommandEvent& event) {
+    int id = event.GetId() - 4000;
+    if (id < 0 || id > 1) return;
+    
+    m_borderAlignmentSelection = id;
+    if (m_borderAlignmentButton) {
+        m_borderAlignmentButton->SetLabel((id == 0 ? "Outer" : "Inner") + wxString(" \u25BC"));
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::OnWallPaletteSelect(wxCommandEvent& event) {
+    int itemId = event.GetInt();
+    if (itemId > 0) {
+        m_currentWallItemId = itemId;
+        // if (m_wallItemIdCtrl) m_wallItemIdCtrl->SetValue(itemId); // Ctrl removed
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+
+void BorderEditorPanel::OnWallGridSelect(wxCommandEvent& event) {
+    std::string type = event.GetString().ToStdString();
+    if (type.empty()) return;
+
+    // Select the type
+    m_wallGridPanel->SetSelectedType(type);
+    
+    // If we have a valid item selected in palette, add it to this type!
+    if (m_currentWallItemId > 0) {
+        WallTypeData& data = m_wallTypes[type];
+        data.typeName = type;
+        
+        // Check if item already exists to avoid duplicates (optional, but good UX)
+        bool exists = false;
+        for (const auto& item : data.items) {
+            if (item.itemId == m_currentWallItemId) {
+                exists = true;
+                break;
+            }
+        }
+        
+        if (!exists) {
+            data.items.push_back(GroundItem(m_currentWallItemId, 10)); // Default chance
+            
+            // Refresh previews
+            m_wallVisualPanel->SetWallItems(m_wallTypes);
+            m_wallGridPanel->SetWallTypes(m_wallTypes); // Updates the grid icons
+        }
+    }
+    
+    UpdateWallItemsList(); // Keeps internal logic sync if needed (pointer null checked inside)
+}
+
+
+
+
+void BorderEditorPanel::OnOpenTilesetFilter(wxCommandEvent& event) {
+    // Get all available tilesets
+    wxArrayString allTilesets;
+    for (const auto& pair : g_materials.tilesets) {
+        if (pair.second) {
+            allTilesets.Add(wxString(pair.first));
+        }
+    }
+    allTilesets.Sort();
+    
+    // Get the appropriate whitelist for the current mode
+    std::set<wxString>& currentWhitelist = 
+        (m_activeTab == 0) ? m_borderEnabledTilesets :
+        (m_activeTab == 1) ? m_groundEnabledTilesets :
+                             m_wallEnabledTilesets;
+    
+    wxString modeLabel = (m_activeTab == 0) ? "Border" :
+                         (m_activeTab == 1) ? "Ground" : "Wall";
+    
+    TilesetFilterDialog dlg(this, allTilesets, currentWhitelist, modeLabel);
+    if (dlg.ShowModal() == wxID_OK) {
+        currentWhitelist = dlg.GetEnabledTilesets();
+        SaveFilterConfig();  // Save to file immediately
+        LoadTilesets();  // Refresh the ComboBox with filtered list
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+// ============================================================================
+// TilesetFilterDialog Implementation
+
+TilesetFilterDialog::TilesetFilterDialog(wxWindow* parent,
+                                         const wxArrayString& allTilesets,
+                                         const std::set<wxString>& enabledTilesets,
+                                         const wxString& modeLabel)
+    : wxDialog(parent, wxID_ANY, "Filter Tilesets - " + modeLabel, 
+               wxDefaultPosition, wxSize(350, 450),
+               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+      m_allTilesets(allTilesets)
+{
+    wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+    
+    // Instructions
+    mainSizer->Add(new wxStaticText(this, wxID_ANY, 
+        "Select tilesets to show (click anywhere on row):"), 0, wxALL, 10);
+    
+    // Checklist
+    m_tilesetList = new wxCheckListBox(this, wxID_ANY, wxDefaultPosition, 
+                                        wxDefaultSize, allTilesets);
+    
+    // Check only items that ARE in the enabled set (whitelist)
+    // If whitelist is empty, all stay unchecked (default empty)
+    for (unsigned int i = 0; i < allTilesets.GetCount(); ++i) {
+        bool isEnabled = (enabledTilesets.find(allTilesets[i]) != enabledTilesets.end());
+        m_tilesetList->Check(i, isEnabled);
+    }
+    
+    // Bind click-anywhere toggle (clicking the label toggles the checkbox)
+    // REMOVED: Triggers on auto-selection (focus) in GTK, causing first item to be checked automatically
+    // m_tilesetList->Bind(wxEVT_LISTBOX, &TilesetFilterDialog::OnListItemClick, this);
+    
+    mainSizer->Add(m_tilesetList, 1, wxEXPAND | wxLEFT | wxRIGHT, 10);
+    
+    // Select All / None buttons
+    wxBoxSizer* selectBtnSizer = new wxBoxSizer(wxHORIZONTAL);
+    wxButton* selectAllBtn = new wxButton(this, wxID_ANY, "Select All");
+    wxButton* selectNoneBtn = new wxButton(this, wxID_ANY, "Select None");
+    selectAllBtn->Bind(wxEVT_BUTTON, &TilesetFilterDialog::OnSelectAll, this);
+    selectNoneBtn->Bind(wxEVT_BUTTON, &TilesetFilterDialog::OnSelectNone, this);
+    selectBtnSizer->Add(selectAllBtn, 0, wxRIGHT, 5);
+    selectBtnSizer->Add(selectNoneBtn, 0);
+    mainSizer->Add(selectBtnSizer, 0, wxALL, 10);
+    
+    // Save / Cancel buttons
+    wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
+    btnSizer->AddStretchSpacer(1);
+    wxButton* saveBtn = new wxButton(this, wxID_OK, "Save");
+    wxButton* cancelBtn = new wxButton(this, wxID_CANCEL, "Cancel");
+    btnSizer->Add(saveBtn, 0, wxRIGHT, 5);
+    btnSizer->Add(cancelBtn, 0);
+    mainSizer->Add(btnSizer, 0, wxEXPAND | wxALL, 10);
+    
+    SetSizer(mainSizer);
+    CenterOnParent();
+}
+
+std::set<wxString> TilesetFilterDialog::GetEnabledTilesets() const {
+    std::set<wxString> enabled;
+    for (unsigned int i = 0; i < m_allTilesets.GetCount(); ++i) {
+        if (m_tilesetList->IsChecked(i)) {
+            enabled.insert(m_allTilesets[i]);
+        }
+    }
+    return enabled;
+}
+
+void TilesetFilterDialog::OnListItemClick(wxCommandEvent& event) {
+    // Toggle checkbox when clicking anywhere on the row
+    int sel = m_tilesetList->GetSelection();
+    if (sel != wxNOT_FOUND) {
+        m_tilesetList->Check(sel, !m_tilesetList->IsChecked(sel));
+    }
+}
+
+void TilesetFilterDialog::OnSelectAll(wxCommandEvent& event) {
+    for (unsigned int i = 0; i < m_tilesetList->GetCount(); ++i) {
+        m_tilesetList->Check(i, true);
+    }
+}
+
+void TilesetFilterDialog::OnSelectNone(wxCommandEvent& event) {
+    for (unsigned int i = 0; i < m_tilesetList->GetCount(); ++i) {
+        m_tilesetList->Check(i, false);
+    }
+}
+
+void BorderEditorPanel::LoadWallBrushByName(const wxString& name) {
+    if (name.IsEmpty()) {
+        // Clear all fields for new brush
+        if (m_wallServerLookIdCtrl) m_wallServerLookIdCtrl->SetValue(0);
+        if (m_wallIsOptionalCheck) m_wallIsOptionalCheck->SetValue(false);
+        if (m_wallIsGroundCheck) m_wallIsGroundCheck->SetValue(false);
+        ClearWallItems();
+        return;
+    }
+    
+    // Find the walls.xml file
+    wxString dataDir = g_gui.GetDataDirectory();
+    
+    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + 
+                        "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+    
+    // Load XML
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(wallsFile).c_str())) return;
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) return;
+    
+    // Find the brush
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute nameAttr = brushNode.attribute("name");
+        if (nameAttr && wxString(nameAttr.as_string()) == name) {
+            // Found it! Load properties
+            if (m_wallNameCtrl) m_wallNameCtrl->SetValue(name);
+            
+            // Server look ID
+            pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
+            if (lookIdAttr && m_wallServerLookIdCtrl) {
+                m_wallServerLookIdCtrl->SetValue(lookIdAttr.as_int());
+            }
+            
+            // Clear existing items
+            ClearWallItems(false);
+            m_wallTypes.clear();
+            
+            // Iterate over children to find <wall> nodes
+            for (pugi::xml_node wallNode = brushNode.child("wall"); wallNode; wallNode = wallNode.next_sibling("wall")) {
+                pugi::xml_attribute typeAttr = wallNode.attribute("type");
+                if (typeAttr) {
+                    std::string typeName = typeAttr.as_string();
+                    WallTypeData typeData;
+                    typeData.typeName = typeName;
+                    
+                    // Helper to parse items from a node
+                    auto parseItems = [&](pugi::xml_node parentNode) {
+                        for (pugi::xml_node itemNode = parentNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
+                            pugi::xml_attribute idAttr = itemNode.attribute("id");
+                            pugi::xml_attribute chanceAttr = itemNode.attribute("chance");
+                            
+                            if (idAttr) {
+                                uint16_t itemId = idAttr.as_uint();
+                                int chance = chanceAttr ? chanceAttr.as_int() : 10;
+                                typeData.items.push_back(GroundItem(itemId, chance));
+                            }
+                        }
+                    };
+                    
+                    // Parse direct items
+                    parseItems(wallNode);
+                    
+                    // Parse items inside <alternate>
+                    for (pugi::xml_node altNode = wallNode.child("alternate"); altNode; altNode = altNode.next_sibling("alternate")) {
+                         parseItems(altNode);
+                    }
+                    
+                    m_wallTypes[typeName] = typeData;
+                }
+            }
+            
+            // Update UI to reflect loaded data
+            m_wallGridPanel->SetWallTypes(m_wallTypes);
+            m_wallGridPanel->SetSelectedType("vertical"); // Default
+            UpdateWallItemsList();
+            m_wallVisualPanel->SetWallItems(m_wallTypes);
+            
+            break;
+        }
+    }
+} 
+
+
+
+void BorderEditorPanel::SaveWallBrush() {
+    wxString name;
+    if (m_wallNameCtrl) name = m_wallNameCtrl->GetValue();
+    
+    if (name.IsEmpty()) {
+        wxMessageBox("Please enter a name for the wall brush.", "Error", wxICON_ERROR);
+        return;
+    }
+    
+    int preSave = wxMessageBox(
+        "This action will save the wall brush and reload data files (F5). Continue?",
+        "Confirm Save",
+        wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
+        this
+    );
+    if (preSave != wxYES) {
+        return;
+    }
+
+    int serverLookId = m_wallServerLookIdCtrl->GetValue();
+    
+    // Find walls.xml
+    wxString dataDir = g_gui.GetDataDirectory();
+    
+    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + 
+                        "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+                        
+    pugi::xml_document doc;
+    bool loaded = doc.load_file(nstr(wallsFile).c_str());
+    if (!loaded) {
+        // Create new if not exists?
+        // Usually we expect it to exist.
+        // If not, maybe create simple structure
+        pugi::xml_node root = doc.append_child("materials");
+    }
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) materials = doc.append_child("materials");
+    
+    // Check if exists and remove OLD entry to replace it completely
+    pugi::xml_node existingNode;
+    for (pugi::xml_node node = materials.child("brush"); node; node = node.next_sibling("brush")) {
+        if (wxString(node.attribute("name").as_string()) == name) {
+            existingNode = node;
+            break;
+        }
+    }
+    
+    if (existingNode) {
+        if (wxMessageBox("Wall brush '" + name + "' already exists. Overwrite?", "Confirm Overwrite", wxYES_NO | wxICON_QUESTION) != wxYES) {
+            return;
+        }
+        materials.remove_child(existingNode);
+    }
+    
+    // Create NEW brush node
+    pugi::xml_node brushNode = materials.append_child("brush");
+    brushNode.append_attribute("name").set_value(nstr(name).c_str());
+    brushNode.append_attribute("type").set_value("wall");
+    brushNode.append_attribute("server_lookid").set_value(serverLookId);
+    
+    // Iterate over our map and save <wall> nodes
+    for (const auto& pair : m_wallTypes) {
+        const WallTypeData& typeData = pair.second;
+        if (typeData.items.empty()) continue; // Skip empty types
+        
+        pugi::xml_node wallNode = brushNode.append_child("wall");
+        wallNode.append_attribute("type").set_value(typeData.typeName.c_str());
+        
+        for (const GroundItem& item : typeData.items) {
+            pugi::xml_node itemNode = wallNode.append_child("item");
+            itemNode.append_attribute("id").set_value(item.itemId);
+            itemNode.append_attribute("chance").set_value(item.chance);
+        }
+    }
+    
+    // Save
+    if (doc.save_file(nstr(wallsFile).c_str())) {
+        TriggerReloadDataFiles();
+        ReloadCurrentBrushEditorXml(name);
+
+        wxMessageBox("Wall brush saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
+    } else {
+        wxMessageBox("Failed to save walls.xml", "Error", wxICON_ERROR);
+    }
+}
+
+void BorderEditorPanel::LoadExistingWallBrushes() {
+    // Legacy method - wall brushes are now populated via PopulateWallList()
+    // Called from constructor for compatibility, actual population happens on tab change
+}
+
+bool BorderEditorPanel::ValidateWallBrush() {
+    return true;
+}
+
+// Helper to get current selected type string
+
+
+void BorderEditorPanel::ClearWallItems(bool clearBrowser) {
+    if (m_wallVisualPanel) {
+        m_wallVisualPanel->Clear();
+    }
+
+    if (m_wallGridPanel) {
+        m_wallGridPanel->SetWallTypes({});
+        m_wallGridPanel->SetSelectedType(std::string());
+    }
+
+    m_wallTypes.clear();
+    m_currentWallItemId = 0;
+
+    if (m_wallNameCtrl) {
+        m_wallNameCtrl->SetValue("");
+    }
+
+    if (m_wallServerLookIdCtrl) {
+        m_wallServerLookIdCtrl->SetValue(0);
+    }
+
+    if (clearBrowser && m_borderBrowserList) {
+        m_borderBrowserList->SetSelection(wxNOT_FOUND);
+    }
+}
+
+void BorderEditorPanel::UpdateWallItemsList() {
+    if (!m_wallItemsList || !m_wallGridPanel) return;
+    
+    m_wallItemsList->Clear();
+    std::string type = m_wallGridPanel->GetSelectedType();
+    if (type.empty()) type = "vertical"; // Fallback
+    
+    if (m_wallTypes.find(type) != m_wallTypes.end()) {
+        const WallTypeData& data = m_wallTypes[type];
+        for (const GroundItem& item : data.items) {
+            m_wallItemsList->Append(wxString::Format("Item ID: %d", item.itemId));
+        }
+    }
+}
+
+void BorderEditorPanel::OnWallBrowse(wxCommandEvent& event) {
+    // Reuse Ground Browse Logic or create new dialog
+    // implementation pending... using manual ID for now
+}
+
+void BorderEditorPanel::OnAddWallItem(wxCommandEvent& event) {
+    if (!m_wallItemIdCtrl) return;
+    int id = m_wallItemIdCtrl->GetValue();
+    if (id <= 0) return;
+    
+    std::string type = m_wallGridPanel->GetSelectedType();
+    if (type.empty()) type = "vertical";
+    
+    WallTypeData& data = m_wallTypes[type];
+    data.typeName = type;
+    data.items.push_back(GroundItem(id, 10)); // Default chance 10
+    
+    m_wallItemsList->Append(wxString::Format("Item ID: %d", id));
+    m_wallVisualPanel->SetWallItems(m_wallTypes); // Update preview
+    m_wallGridPanel->SetWallTypes(m_wallTypes); // Update visual selector
+}
+
+void BorderEditorPanel::OnRemoveWallItem(wxCommandEvent& event) {
+    if (!m_wallItemsList) return;
+    int sel = m_wallItemsList->GetSelection();
+    if (sel == wxNOT_FOUND) return;
+    
+    std::string type = m_wallGridPanel->GetSelectedType();
+    if (type.empty()) type = "vertical";
+    
+    if (m_wallTypes.find(type) != m_wallTypes.end()) {
+         WallTypeData& data = m_wallTypes[type];
+         if (sel >= 0 && sel < (int)data.items.size()) {
+             data.items.erase(data.items.begin() + sel);
+             UpdateWallItemsList();
+             m_wallVisualPanel->SetWallItems(m_wallTypes);
+             m_wallGridPanel->SetWallTypes(m_wallTypes);
+         }
+    }
+}
+
+
+void BorderEditorPanel::LoadExistingBorders() {
+    // Clear the browser list
+    if (!m_borderBrowserList) return;
+    m_borderBrowserList->Clear();
+    
+    // Find borders.xml file - actual borders are in the borders/ subfolder
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + 
+                          "materials" + wxFileName::GetPathSeparator() + 
+                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+    
+    if (!wxFileExists(bordersFile)) {
+        return; // Silently fail - no borders yet
+    }
+    
+    // Load XML
+    pugi::xml_document doc;
+    pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
+    if (!result) return;
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) return;
+    
+    int maxId = 0;
+    
+    // Parse all borders
+    for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+        pugi::xml_attribute idAttr = borderNode.attribute("id");
+        if (!idAttr) continue;
+        
+        int id = idAttr.as_int();
+        if (id > maxId) {
+            maxId = id;
+        }
+        
+        // Get name attribute
+        wxString name;
+        pugi::xml_attribute nameAttr = borderNode.attribute("name");
+        if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
+            name = wxString(nameAttr.as_string());
+        } else {
+            name = "(no name)";
+        }
+        
+        // Add to browser list: "ID - Name"
+        wxString label = wxString::Format("%d - %s", id, name);
+        m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", id)));
+    }
+    
+    // Set next border ID
+    m_nextBorderId = maxId + 1;
+    m_currentBorderId = m_nextBorderId;
+}
+
+// Helper method to load a border by ID
+void BorderEditorPanel::LoadBorderById(int borderId) {
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + 
+                          "materials" + wxFileName::GetPathSeparator() + 
+                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+    
+    if (!wxFileExists(bordersFile)) return;
+    
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(bordersFile).c_str())) return;
+    
+    ClearItems(false); // Don't clear browser selection logic
+    
+    pugi::xml_node materials = doc.child("materials");
+    for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+        pugi::xml_attribute idAttr = borderNode.attribute("id");
+        if (!idAttr || idAttr.as_int() != borderId) continue;
+        
+        m_currentBorderId = borderId; // Store the loaded ID
+        
+        // Name
+        pugi::xml_attribute nameAttr = borderNode.attribute("name");
+        m_nameCtrl->SetValue(nameAttr ? wxString(nameAttr.as_string()) : "");
+        
+        // Type
+        pugi::xml_attribute typeAttr = borderNode.attribute("type");
+        m_isOptionalCheck->SetValue(typeAttr && std::string(typeAttr.as_string()) == "optional");
+        
+        // Ground
+        pugi::xml_attribute groundAttr = borderNode.attribute("ground");
+        m_isGroundCheck->SetValue(groundAttr && groundAttr.as_bool());
+        
+        // Group (Checkbox now)
+        pugi::xml_attribute groupAttr = borderNode.attribute("group");
+        m_groupCheck->SetValue(groupAttr ? groupAttr.as_int() > 0 : false);
+        
+        // Border items
+        for (pugi::xml_node itemNode = borderNode.child("borderitem"); itemNode; itemNode = itemNode.next_sibling("borderitem")) {
+            pugi::xml_attribute edgeAttr = itemNode.attribute("edge");
+            pugi::xml_attribute itemAttr = itemNode.attribute("item");
+            if (!edgeAttr || !itemAttr) continue;
+            
+            BorderEdgePosition pos = edgeStringToPosition(edgeAttr.as_string());
+            uint16_t itemId = itemAttr.as_uint();
+            if (pos != EDGE_NONE && itemId > 0) {
+                m_borderItems.push_back(BorderItem(pos, itemId));
+                m_gridPanel->SetItemId(pos, itemId);
+            }
+        }
+        break;
+    }
+    UpdatePreview();
+}
+
+// Browser sidebar selection handler - dispatches based on active tab
+void BorderEditorPanel::OnBorderBrowserSelection(wxCommandEvent& event) {
+    if (!m_borderBrowserList) return;
+
+    int selection = m_borderBrowserList->GetSelection();
+    if (selection == wxNOT_FOUND) return;
+
+    wxStringClientData* data = static_cast<wxStringClientData*>(m_borderBrowserList->GetClientObject(selection));
+    if (!data) return;
+
+    const uint16_t tileId = static_cast<uint16_t>(wxAtoi(data->GetData()));
+    if (tileId == 0) {
+        return;
+    }
+
+    m_selectedBrowserTileId = tileId;
+
+    switch (m_activeTab) {
+        case 0: LoadBorderByMainTileId(tileId); break;
+        case 1: LoadGroundBrushByMainTileId(tileId); break;
+        case 2: LoadWallBrushByMainTileId(tileId); break;
+    }
+}
+
+void BorderEditorPanel::OnBrowserGridSelection(wxCommandEvent& event) {
+    const wxString key = event.GetString();
+    if (key.IsEmpty()) {
+        return;
+    }
+
+    RestoreBrowserSelection(key);
+
+    const uint16_t tileId = static_cast<uint16_t>(wxAtoi(key));
+    if (tileId == 0) {
+        return;
+    }
+
+    m_selectedBrowserTileId = tileId;
+
+    switch (m_activeTab) {
+        case 0: LoadBorderByMainTileId(tileId); break;
+        case 1: LoadGroundBrushByMainTileId(tileId); break;
+        case 2: LoadWallBrushByMainTileId(tileId); break;
+    }
+}
+
+void BorderEditorPanel::OnLoadBorder(wxCommandEvent& event) {
+    // Old combo box handler - now unused as browser list handles loading
+}
+
+void BorderEditorPanel::OnItemIdChanged(wxCommandEvent& event) {
+    // This event handler would update the display when an item ID is entered manually
+    // but we're handling this directly in OnAddItem instead
+}
+
+void BorderEditorPanel::OnBrowse(wxCommandEvent& event) {
+    // Open the Find Item dialog instead
+    FindItemDialog dialog(this, "Select Border Item");
+    
+    if (dialog.ShowModal() == wxID_OK) {
+        // Get the selected item ID
+        uint16_t itemId = dialog.getResultID();
+        
+        // Find the item ID spin control
+        // This logic is now obsolete as m_itemIdCtrl is removed.
+        // The item ID should be set in the context of the current operation (e.g., OnPositionSelected).
+        // For now, this function might need a different approach or be removed if no longer needed.
+        // Keeping it as is for now, assuming m_itemIdCtrl might be re-introduced or handled differently.
+        wxSpinCtrl* itemIdCtrl = nullptr;
+        wxWindowList& children = GetChildren();
+        for (wxWindowList::iterator it = children.begin(); it != children.end(); ++it) {
+            wxSpinCtrl* spinCtrl = dynamic_cast<wxSpinCtrl*>(*it);
+            if (spinCtrl /*&& spinCtrl != m_idCtrl*/) { // m_idCtrl is removed
+                itemIdCtrl = spinCtrl;
+                break;
+            }
+        }
+        
+        if (itemIdCtrl && itemId > 0) {
+            itemIdCtrl->SetValue(itemId);
+        }
+    }
+}
+
+void BorderEditorPanel::OnPositionSelected(wxCommandEvent& event) {
+    // Get the position from the event
+    BorderEdgePosition pos = static_cast<BorderEdgePosition>(event.GetInt());
+    wxLogDebug("OnPositionSelected: Position %s selected", wxstr(edgePositionToString(pos)).c_str());
+
+    
+    // Get the item ID from the current brush
+    Brush* currentBrush = g_gui.GetCurrentBrush();
+    uint16_t itemId = 0;
+    
+    if (currentBrush) {
+        wxLogDebug("OnPositionSelected: Using brush: %s", wxString(currentBrush->getName()).c_str());
+        
+        // Try to get the item ID directly - check if it's a RAW brush first
+        if (currentBrush->isRaw()) {
+            RAWBrush* rawBrush = currentBrush->asRaw();
+            if (rawBrush) {
+                itemId = rawBrush->getItemID();
+                wxLogDebug("OnPositionSelected: Got item ID %d directly from RAW brush", itemId);
+            }
+        } 
+        
+        // If we didn't get an ID from the RAW brush method, try the generic method
+        if (itemId == 0) {
+            itemId = GetItemIDFromBrush(currentBrush);
+            wxLogDebug("OnPositionSelected: Got item ID %d from GetItemIDFromBrush", itemId);
+        }
+    } else {
+        wxLogDebug("OnPositionSelected: No current brush selected");
+    }
+    
+    // If no valid ID from brush, check the manual input control
+    // m_itemIdCtrl is removed, so this block is now obsolete.
+    // The user is expected to select an item brush.
+    /*
+    if (itemId == 0 && m_itemIdCtrl) {
+        itemId = m_itemIdCtrl->GetValue();
+        if (itemId > 0) {
+            wxLogDebug("OnPositionSelected: Using item ID %d from manual control", itemId);
+        }
+    }
+    */
+
+    if (itemId > 0) {
+        // Update the item ID control - keeps the UI in sync with our selection
+        // m_itemIdCtrl is removed, so this block is now obsolete.
+        /*
+        if (m_itemIdCtrl) {
+            m_itemIdCtrl->SetValue(itemId);
+        }
+        */
+        
+        // Add or update the border item
+        bool updated = false;
+        for (size_t i = 0; i < m_borderItems.size(); i++) {
+            if (m_borderItems[i].position == pos) {
+                m_borderItems[i].itemId = itemId;
+                updated = true;
+                wxLogDebug("OnPositionSelected: Updated existing border item at position %s", wxstr(edgePositionToString(pos)).c_str());
+
+                break;
+            }
+        }
+        
+        if (!updated) {
+            m_borderItems.push_back(BorderItem(pos, itemId));
+            wxLogDebug("OnPositionSelected: Added new border item at position %s", wxstr(edgePositionToString(pos)).c_str());
+
+        }
+        
+        // Update the grid panel
+        m_gridPanel->SetItemId(pos, itemId);
+        wxLogDebug("OnPositionSelected: Set grid panel item ID for position %s to %d", wxstr(edgePositionToString(pos)).c_str(), itemId);
+
+        
+        // Update the preview
+        UpdatePreview();
+        
+        // Log the addition
+        wxLogDebug("Added border item at position %s with item ID %d", 
+                  wxstr(edgePositionToString(pos)).c_str(), itemId);
+
+    } else {
+        // If we couldn't get an item ID from the brush, check if there's a value in the item ID control
+        // m_itemIdCtrl is removed, so this block is now obsolete.
+        /*
+        itemId = m_itemIdCtrl->GetValue();
+        
+        if (itemId > 0) {
+            // Use the value from the control to update/add the border item
+            bool updated = false;
+            for (size_t i = 0; i < m_borderItems.size(); i++) {
+                if (m_borderItems[i].position == pos) {
+                    m_borderItems[i].itemId = itemId;
+                    updated = true;
+                    break;
+                }
+            }
+            
+            if (!updated) {
+                m_borderItems.push_back(BorderItem(pos, itemId));
+            }
+            
+            // Update the grid panel
+            m_gridPanel->SetItemId(pos, itemId);
+            
+            // Update the preview
+            UpdatePreview();
+            
+            wxLogDebug("Used item ID %d from control for position %s", 
+                       itemId, wxstr(edgePositionToString(pos)).c_str());
+
+        } else {
+        */
+            wxLogDebug("No valid item ID found from current brush: %s", currentBrush ? wxString(currentBrush->getName()).c_str() : wxT("NULL"));
+
+            wxMessageBox("Could not get a valid item ID from the current brush. Please select an item brush or use the Browse button to select an item manually.", "Invalid Brush", wxICON_INFORMATION);
+        // }
+    }
+}
+
+void BorderEditorPanel::OnAddItem(wxCommandEvent& event) {
+    // This function is now obsolete as manual add buttons and m_itemIdCtrl are removed.
+    // If it were to be used, it would need to get the item ID from the currently selected brush.
+    wxMessageBox("This 'Add Item' functionality is no longer available. Please select an item brush and click on the grid to add items.", "Information", wxICON_INFORMATION);
+    return;
+
+    /*
+    // Get the currently selected position in the grid panel
+    static BorderEdgePosition lastSelectedPos = EDGE_NONE;
+    BorderEdgePosition selectedPos = m_gridPanel->GetSelectedPosition();
+    
+    // If no position is currently selected, use the last selected position
+    if (selectedPos == EDGE_NONE) {
+        selectedPos = lastSelectedPos;
+    }
+    
+    if (selectedPos == EDGE_NONE) {
+        wxMessageBox("Please select a position on the grid first by clicking on it.", "Error", wxICON_ERROR);
+        return;
+    }
+    
+    // Save this position for future use
+    lastSelectedPos = selectedPos;
+    
+    // Get the item ID from the control (now using the class member)
+    uint16_t itemId = m_itemIdCtrl->GetValue();
+    
+    if (itemId == 0) {
+        wxMessageBox("Please enter a valid item ID or use the Browse button.", "Error", wxICON_ERROR);
+        return;
+    }
+    
+    // Add or update the border item
+    bool updated = false;
+    for (size_t i = 0; i < m_borderItems.size(); i++) {
+        if (m_borderItems[i].position == selectedPos) {
+            m_borderItems[i].itemId = itemId;
+            updated = true;
+            break;
+        }
+    }
+    
+    if (!updated) {
+        m_borderItems.push_back(BorderItem(selectedPos, itemId));
+    }
+    
+    // Update the grid panel
+    m_gridPanel->SetItemId(selectedPos, itemId);
+    
+    // Update the preview
+    UpdatePreview();
+    
+    // Log the addition for debugging
+    wxLogDebug("Added item ID %d at position %s via Add button", 
+               itemId, wxstr(edgePositionToString(selectedPos)).c_str());
+    */
+}
+
+void BorderEditorPanel::OnClear(wxCommandEvent& event) {
+    if (m_activeTab == 0) {
+        // Border tab
+    ClearItems();
+    } else {
+        // Ground tab
+        ClearGroundItems();
+    }
+}
+
+void BorderEditorPanel::ClearItems(bool clearBrowser) {
+    m_borderItems.clear();
+    m_gridPanel->Clear();
+    m_previewPanel->Clear();
+    
+    // Reset controls to defaults
+    m_currentBorderId = m_nextBorderId; // Use m_currentBorderId instead of m_idCtrl
+    if (m_nameCtrl) m_nameCtrl->SetValue("");
+    if (m_isOptionalCheck) m_isOptionalCheck->SetValue(false);
+    if (m_isGroundCheck) m_isGroundCheck->SetValue(false);
+    if (m_groupCheck) m_groupCheck->SetValue(false);
+    
+    // Deselect browser list
+    if (clearBrowser && m_borderBrowserList) {
+        m_borderBrowserList->SetSelection(wxNOT_FOUND);
+    }
+}
+
+void BorderEditorPanel::UpdatePreview() {
+    m_previewPanel->SetBorderItems(m_borderItems);
+    m_previewPanel->Refresh();
+}
+
+bool BorderEditorPanel::ValidateBorder() {
+    // Check for empty name
+    if (m_nameCtrl->GetValue().IsEmpty()) {
+        wxMessageBox("Please enter a name for the border.", "Validation Error", wxICON_ERROR);
+        return false;
+    }
+    
+    if (m_borderItems.empty()) {
+        wxMessageBox("The border must have at least one item.", "Validation Error", wxICON_ERROR);
+        return false;
+    }
+    
+    // Check that there are no duplicate positions
+    std::set<BorderEdgePosition> positions;
+    for (const BorderItem& item : m_borderItems) {
+        if (positions.find(item.position) != positions.end()) {
+            wxMessageBox("The border contains duplicate positions.", "Validation Error", wxICON_ERROR);
+            return false;
+        }
+        positions.insert(item.position);
+    }
+    
+    // Check for ID validity (using m_currentBorderId)
+    int id = m_currentBorderId; // Use m_currentBorderId
+    if (id <= 0) {
+        wxMessageBox("Border ID must be greater than 0.", "Validation Error", wxICON_ERROR);
+        return false;
+    }
+    
+    return true;
+}
+
+void BorderEditorPanel::SaveBorder() {
+    if (!ValidateBorder()) {
+        return;
+    }
+
+    int preSave = wxMessageBox(
+        "This action will save the border and reload data files (F5). Continue?",
+        "Confirm Save",
+        wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
+        this
+    );
+    if (preSave != wxYES) {
+        return;
+    }
+    
+    // Get the border properties
+    int id = m_currentBorderId; // Use m_currentBorderId
+    wxString name = m_nameCtrl->GetValue();
+    
+    // Double check that we have a name (it's also checked in ValidateBorder)
+    if (name.IsEmpty()) {
+        wxMessageBox("You must provide a name for the border.", "Error", wxICON_ERROR);
+        return;
+    }
+    bool isOptional = m_isOptionalCheck->GetValue();
+    bool isGround = m_isGroundCheck->GetValue();
+    int group = m_groupCheck->GetValue() ? 1 : 0; // Read m_groupCheck as checkbox
+    
+    // Find the borders.xml file using the same version path conversion
+    wxString dataDir = g_gui.GetDataDirectory();
+    
+    // actual borders are in the borders/ subfolder
+    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() + 
+                          "materials" + wxFileName::GetPathSeparator() + 
+                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+    
+    if (!wxFileExists(bordersFile)) {
+        wxMessageBox("Cannot find borders.xml file in the data directory.", "Error", wxICON_ERROR);
+        return;
+    }
+    
+    // Load the XML file
+    pugi::xml_document doc;
+    pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
+    
+    if (!result) {
+        wxMessageBox("Failed to load borders.xml: " + wxString(result.description()), "Error", wxICON_ERROR);
+        return;
+    }
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) {
+        wxMessageBox("Invalid borders.xml file: missing 'materials' node", "Error", wxICON_ERROR);
+        return;
+    }
+    
+    // Check if a border with this ID already exists
+    bool borderExists = false;
+    pugi::xml_node existingBorder;
+    
+    for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+        pugi::xml_attribute idAttr = borderNode.attribute("id");
+        if (idAttr && idAttr.as_int() == id) {
+            borderExists = true;
+            existingBorder = borderNode;
+            break;
+        }
+    }
+    
+    if (borderExists) {
+        // Check if there's a comment node before the existing border - we want to remove legacy comments too
+        pugi::xml_node commentNode = existingBorder.previous_sibling();
+        bool hadComment = (commentNode && commentNode.type() == pugi::node_comment);
+        
+        // Ask for confirmation to overwrite
+        if (wxMessageBox("A border with ID " + wxString::Format("%d", id) + " already exists. Do you want to overwrite it?", 
+                        "Confirm Overwrite", wxYES_NO | wxICON_QUESTION) != wxYES) {
+            return;
+        }
+        
+        // Remove precedent comment if it exists (legacy cleanup)
+        if (hadComment) {
+            materials.remove_child(commentNode);
+        }
+        
+        // Remove the existing border - this ensures all old PCDATA/children are gone
+        materials.remove_child(existingBorder);
+    }
+    
+    // Format the name - ensure we have a fallback
+    if (name.IsEmpty()) {
+        name = wxString::Format("Border %d", id);
+    }
+    
+    // Create the new border node
+    pugi::xml_node borderNode = materials.append_child("border");
+    borderNode.append_attribute("id").set_value(id);
+    
+    // RULE: Always save name as attribute, NOT as PCDATA/Comment
+    borderNode.append_attribute("name").set_value(nstr(name).c_str());
+    
+    if (isOptional) {
+        borderNode.append_attribute("type").set_value("optional");
+    }
+    
+    if (isGround) {
+        borderNode.append_attribute("ground").set_value("true");
+    }
+    
+    if (group > 0) {
+        borderNode.append_attribute("group").set_value(group);
+    }
+    
+    // Add all border items
+    for (const BorderItem& item : m_borderItems) {
+        pugi::xml_node itemNode = borderNode.append_child("borderitem");
+        itemNode.append_attribute("edge").set_value(edgePositionToString(item.position).c_str());
+        itemNode.append_attribute("item").set_value(item.itemId);
+    }
+    
+    // Save the file
+    if (!doc.save_file(nstr(bordersFile).c_str())) {
+        wxMessageBox("Failed to save changes to borders.xml", "Error", wxICON_ERROR);
+        return;
+    }
+
+    TriggerReloadDataFiles();
+    ReloadCurrentBrushEditorXml(wxString::Format("%d", id));
+
+    wxMessageBox("Border saved successfully.", "Success", wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP, this);
+}
+
+void BorderEditorPanel::OnSave(wxCommandEvent& event) {
+    if (m_activeTab == 0) {
+        // Border tab
+        SaveBorder();
+    } else if (m_activeTab == 1) {
+        // Ground tab
+        SaveGroundBrush();
+    }
+}
+
+void BorderEditorPanel::OnClose(wxCommandEvent& event) {
+    if (g_gui.aui_manager) {
+        wxAuiPaneInfo& pane = g_gui.aui_manager->GetPane(this);
+        if (pane.IsOk()) {
+            pane.Hide();
+            g_gui.aui_manager->Update();
+            return;
+        }
+    }
+
+    wxWindow* parent = GetParent();
+    while (parent && !parent->IsTopLevel()) {
+        parent = parent->GetParent();
+    }
+
+    if (parent) {
+        parent->Close();
+    } else {
+        Destroy();
+    }
+}
+
+void BorderEditorPanel::OnGridCellClicked(wxMouseEvent& event) {
+    // This event is handled by the BorderGridPanel directly
+    event.Skip();
+}
+
+// ============================================================================
+// BorderItemButton
+
+BorderItemButton::BorderItemButton(wxWindow* parent, BorderEdgePosition position, wxWindowID id) :
+    wxButton(parent, id, "", wxDefaultPosition, wxSize(32, 32)),
+    m_itemId(0),
+    m_position(position) {
+    // Set up the button to show sprite graphics
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+}
+
+BorderItemButton::~BorderItemButton() {
+    // No need to destroy anything manually
+}
+
+void BorderItemButton::SetItemId(uint16_t id) {
+    m_itemId = id;
+    Refresh();
+}
+
+void BorderItemButton::OnPaint(wxPaintEvent& event) {
+    wxPaintDC dc(this);
+    
+    // Draw the button background
+    wxRect rect = GetClientRect();
+    dc.SetBrush(wxBrush(GetBackgroundColour()));
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.DrawRectangle(rect);
+    
+    // Draw the item sprite if available
+    if (m_itemId > 0) {
+        const ItemType& type = g_items.getItemType(m_itemId);
+        if (type.id != 0) {
+            Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+            if (sprite) {
+                sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, 0, 0, rect.GetWidth(), rect.GetHeight());
+            }
+        }
+    }
+    
+    // Draw a border around the button if it's focused
+    if (HasFocus()) {
+        dc.SetPen(*wxBLACK_PEN);
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawRectangle(rect);
+    }
+}
+
+// ============================================================================
+// SimpleRawPalettePanel
+
+BEGIN_EVENT_TABLE(SimpleRawPalettePanel, wxScrolledWindow)
+    EVT_PAINT(SimpleRawPalettePanel::OnPaint)
+    EVT_LEFT_UP(SimpleRawPalettePanel::OnLeftUp)
+    EVT_MOTION(SimpleRawPalettePanel::OnMotion)
+    EVT_LEAVE_WINDOW(SimpleRawPalettePanel::OnLeave)
+    EVT_SIZE(SimpleRawPalettePanel::OnSize)
+END_EVENT_TABLE()
+
+SimpleRawPalettePanel::SimpleRawPalettePanel(wxWindow* parent, wxWindowID id) :
+    wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxVSCROLL | wxBORDER_SUNKEN)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    
+    // Start empty, let the parent controller load the default tileset
+    // by calling LoadTileset("Borders")
+    
+    RecalculateLayout();
+}
+
+void SimpleRawPalettePanel::SetItemIds(const std::vector<uint16_t>& ids) {
+    m_itemIds = ids;
+    RecalculateLayout();
+    Refresh();
+}
+
+void SimpleRawPalettePanel::LoadTileset(const wxString& categoryName, PaletteFilterMode filterMode) {
+    m_itemIds.clear();
+    
+    // Find the specific tileset by name
+    auto it = g_materials.tilesets.find(nstr(categoryName).c_str());
+    if (it != g_materials.tilesets.end()) {
+        Tileset* tileset = it->second;
+        if (tileset) {
+            // Load ONLY from RAW category
+            const TilesetCategory* rawCat = tileset->getCategory(TILESET_RAW);
+            if (rawCat) {
+                for (Brush* brush : rawCat->brushlist) {
+                    if (RAWBrush* rb = dynamic_cast<RAWBrush*>(brush)) {
+                        uint16_t id = rb->getItemID();
+                        
+                        // Apply filter
+                        bool include = true;
+                        if (filterMode == FILTER_GROUND) {
+                            include = g_items[id].isGroundTile();
+                        } else if (filterMode == FILTER_WALL) {
+                            include = g_items[id].isWall;
+                        }
+                        
+                        if (include) {
+                            m_itemIds.push_back(id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    // Remove duplicates and sort
+    std::sort(m_itemIds.begin(), m_itemIds.end());
+    m_itemIds.erase(std::unique(m_itemIds.begin(), m_itemIds.end()), m_itemIds.end());
+    
+    // Reset hover to avoid stuck highlighting
+    m_hoverIndex = -1;
+
+    RecalculateLayout();
+    Refresh();
+}
+
+SimpleRawPalettePanel::~SimpleRawPalettePanel() {}
+
+void SimpleRawPalettePanel::RecalculateLayout() {
+    int w, h;
+    GetClientSize(&w, &h);
+    if (w < m_itemSize) w = m_itemSize;
+    
+    m_cols = (w - m_padding) / (m_itemSize + m_padding);
+    if (m_cols < 1) m_cols = 1;
+    
+    // Ensure m_cols is at least 1 to avoid division by zero
+    if (m_cols < 1) m_cols = 1;
+
+    m_rows = (m_itemIds.size() + m_cols - 1) / m_cols;
+    
+    int unitY = m_itemSize + m_padding;
+    SetVirtualSize(m_cols * (m_itemSize + m_padding) + m_padding, 
+                   m_rows * unitY + m_padding);
+    SetScrollRate(0, unitY); // Row-level scrolling for speed
+    Refresh();
+}
+
+void SimpleRawPalettePanel::OnSize(wxSizeEvent& event) {
+    RecalculateLayout();
+    event.Skip();
+}
+
+void SimpleRawPalettePanel::OnPaint(wxPaintEvent& event) {
+    wxAutoBufferedPaintDC dc(this);
+    DoPrepareDC(dc);
+    dc.SetBackground(wxBrush(wxColour(0, 0, 0)));
+    dc.SetTextForeground(wxColour(255, 255, 255)); // Ensure text is visible on black (if any)
+    dc.Clear();
+    
+    int startUnitX, startUnitY;
+    GetViewStart(&startUnitX, &startUnitY);
+    
+    int clientW, clientH;
+    GetClientSize(&clientW, &clientH);
+    
+    // Scroll unit is 1 row (itemSize + padding)
+    int startRow = startUnitY;
+    // Add extra buffer rows to be safe
+    int endRow = startRow + (clientH / (m_itemSize + m_padding)) + 2;
+    
+    if (startRow < 0) startRow = 0;
+    
+    int startIndex = startRow * m_cols;
+    int endIndex = endRow * m_cols;
+    if (endIndex > (int)m_itemIds.size()) endIndex = m_itemIds.size();
+    
+    for (int i = startIndex; i < endIndex; ++i) {
+        int col = i % m_cols;
+        int row = i / m_cols;
+        int x = m_padding + col * (m_itemSize + m_padding);
+        int y = m_padding + row * (m_itemSize + m_padding);
+        
+        wxRect rect(x, y, m_itemSize, m_itemSize);
+        
+        if (i == m_hoverIndex) {
+            dc.SetPen(wxPen(wxColour(180, 200, 255)));
+            dc.SetBrush(wxBrush(wxColour(220, 240, 255)));
+            dc.DrawRectangle(rect.Inflate(1));
+        }
+
+        uint16_t id = m_itemIds[i];
+        if (id != 0) {
+             const ItemType& type = g_items.getItemType(id);
+             Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+             if (sprite) {
+                 // Draw directly to the DC to preserve transparency
+                 sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, x, y, m_itemSize, m_itemSize);
+             }
+        }
+    }
+}
+
+void SimpleRawPalettePanel::OnMotion(wxMouseEvent& event) {
+    wxPoint pos = event.GetPosition();
+    CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
+    int index = HitTest(pos);
+    if (index != m_hoverIndex) {
+        m_hoverIndex = index;
+        Refresh();
+        
+        if (index >= 0) {
+            // Tooltip
+             if (index < (int)m_itemIds.size()) {
+                 const ItemType& type = g_items.getItemType(m_itemIds[index]);
+                 SetToolTip(wxString::Format("%s (%d)", type.name, m_itemIds[index]));
+             }
+        } else {
+            UnsetToolTip();
+        }
+    }
+}
+
+void SimpleRawPalettePanel::OnLeave(wxMouseEvent& event) {
+    if (m_hoverIndex != -1) {
+        m_hoverIndex = -1;
+        Refresh();
+    }
+}
+
+int SimpleRawPalettePanel::HitTest(const wxPoint& pt) const {
+    int col = (pt.x - m_padding) / (m_itemSize + m_padding);
+    int row = (pt.y - m_padding) / (m_itemSize + m_padding);
+    
+    if (col >= 0 && col < m_cols && row >= 0) {
+        int index = row * m_cols + col;
+        if (index < (int)m_itemIds.size()) return index;
+    }
+    return -1;
+}
+
+void SimpleRawPalettePanel::OnLeftUp(wxMouseEvent& event) {
+    wxPoint pos = event.GetPosition();
+    CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
+    int index = HitTest(pos);
+    if (index >= 0 && index < (int)m_itemIds.size()) {
+         uint16_t id = m_itemIds[index];
+         // Force selection of the brush internally, bypassing the main palette's checks
+         // which might fail if the item isn't in the main palette's current view.
+         g_gui.SelectBrushInternal(newd RAWBrush(id));
+         
+         // Fire event so the dialog can handle it (e.g. for Ground tab)
+         wxCommandEvent evt(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
+         evt.SetEventObject(this);
+         evt.SetInt(id);
+         ProcessWindowEvent(evt);
+         
+         Refresh();
+    }
+}
+
+#if 0
+class BrushBrowserGridPanel : public wxScrolledWindow {
+public:
+    struct Entry {
+        wxString label;
+        wxString key;
+        uint16_t previewItemId;
+    };
+
+    BrushBrowserGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY) :
+        wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxVSCROLL | wxBORDER_NONE),
+        m_cellSize(48),
+        m_padding(6),
+        m_cols(1),
+        m_rows(0),
+        m_selected(-1)
+    {
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetScrollRate(0, m_cellSize + m_padding);
+    }
+
+    void SetEntries(std::vector<Entry> entries) {
+        m_entries = std::move(entries);
+        if (m_selected >= (int)m_entries.size()) {
+            m_selected = -1;
+        }
+        RecalculateLayout();
+        Refresh();
+    }
+
+    void SetSelectionByKey(const wxString& key) {
+        m_selected = -1;
+        for (size_t i = 0; i < m_entries.size(); ++i) {
+            if (m_entries[i].key == key) {
+                m_selected = (int)i;
+                break;
+            }
+        }
+        Refresh();
+    }
+
+private:
+    std::vector<Entry> m_entries;
+    int m_cellSize;
+    int m_padding;
+    int m_cols;
+    int m_rows;
+    int m_selected;
+
+    void RecalculateLayout() {
+        int w, h;
+        GetClientSize(&w, &h);
+        if (w < m_cellSize) w = m_cellSize;
+
+        m_cols = (w - m_padding) / (m_cellSize + m_padding);
+        if (m_cols < 1) m_cols = 1;
+        m_rows = (m_entries.size() + m_cols - 1) / m_cols;
+
+        int unitY = m_cellSize + m_padding;
+        SetVirtualSize(m_cols * (m_cellSize + m_padding) + m_padding, m_rows * unitY + m_padding);
+        SetScrollRate(0, unitY);
+    }
+
+    int HitTest(const wxPoint& pt) const {
+        int col = (pt.x - m_padding) / (m_cellSize + m_padding);
+        int row = (pt.y - m_padding) / (m_cellSize + m_padding);
+
+        if (col >= 0 && col < m_cols && row >= 0) {
+            int index = row * m_cols + col;
+            if (index >= 0 && index < (int)m_entries.size()) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    void OnSize(wxSizeEvent& event) {
+        RecalculateLayout();
+        event.Skip();
+    }
+
+    void OnPaint(wxPaintEvent& event) {
+        wxAutoBufferedPaintDC dc(this);
+        DoPrepareDC(dc);
+        dc.SetBackground(wxBrush(wxColour(0, 0, 0)));
+        dc.Clear();
+
+        int startUnitX, startUnitY;
+        GetViewStart(&startUnitX, &startUnitY);
+
+        int clientW, clientH;
+        GetClientSize(&clientW, &clientH);
+
+        int unitY = m_cellSize + m_padding;
+        int startRow = startUnitY;
+        int endRow = startRow + (clientH / unitY) + 2;
+        if (startRow < 0) startRow = 0;
+
+        int startIndex = startRow * m_cols;
+        int endIndex = endRow * m_cols;
+        if (endIndex > (int)m_entries.size()) endIndex = (int)m_entries.size();
+
+        for (int i = startIndex; i < endIndex; ++i) {
+            int col = i % m_cols;
+            int row = i / m_cols;
+            int x = m_padding + col * (m_cellSize + m_padding);
+            int y = m_padding + row * (m_cellSize + m_padding);
+
+            wxRect rect(x, y, m_cellSize, m_cellSize);
+
+            if (i == m_selected) {
+                dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
+                dc.SetBrush(*wxTRANSPARENT_BRUSH);
+                dc.DrawRectangle(rect);
+            }
+
+            uint16_t itemId = m_entries[i].previewItemId;
+            if (itemId > 0) {
+                const ItemType& type = g_items.getItemType(itemId);
+                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+                if (sprite) {
+                    sprite->DrawTo(&dc, SPRITE_SIZE_32x32_SCALED, x, y, m_cellSize, m_cellSize);
+                }
+            }
+        }
+    }
+
+    void OnLeftUp(wxMouseEvent& event) {
+        wxPoint pos = event.GetPosition();
+        CalcUnscrolledPosition(pos.x, pos.y, &pos.x, &pos.y);
+        int index = HitTest(pos);
+        if (index >= 0 && index < (int)m_entries.size()) {
+            m_selected = index;
+            Refresh();
+
+            wxCommandEvent evt(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
+            evt.SetEventObject(this);
+            evt.SetString(m_entries[index].key);
+            wxPostEvent(GetParent(), evt);
+        }
+    }
+
+    DECLARE_EVENT_TABLE()
+};
+
+BEGIN_EVENT_TABLE(BrushBrowserGridPanel, wxScrolledWindow)
+    EVT_PAINT(BrushBrowserGridPanel::OnPaint)
+    EVT_LEFT_UP(BrushBrowserGridPanel::OnLeftUp)
+    EVT_SIZE(BrushBrowserGridPanel::OnSize)
+END_EVENT_TABLE()
+#endif
+
+// ============================================================================
+// BorderGridPanel
+
+BorderGridPanel::BorderGridPanel(wxWindow* parent, wxWindowID id) :
+    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_SUNKEN)
+{
+    m_items.clear();
+    m_selectedPosition = EDGE_NONE;
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    
+    // Enable Full Repaint on Resize for responsive drawing
+    SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
+}
+
+BorderGridPanel::~BorderGridPanel() {
+    // Nothing to destroy manually
+}
+
+void BorderGridPanel::SetItemId(BorderEdgePosition pos, uint16_t itemId) {
+    if (pos >= 0 && pos < EDGE_COUNT) {
+        m_items[pos] = itemId;
+        Refresh();
+    }
+}
+
+uint16_t BorderGridPanel::GetItemId(BorderEdgePosition pos) const {
+    auto it = m_items.find(pos);
+    if (it != m_items.end()) {
+        return it->second;
+    }
+    return 0;
+}
+
+void BorderGridPanel::Clear() {
+    for (auto& item : m_items) {
+        item.second = 0;
+    }
+    Refresh();
+}
+
+void BorderGridPanel::SetSelectedPosition(BorderEdgePosition pos) {
+    m_selectedPosition = pos;
+    Refresh();
+}
+
+// Helper to calculate grid metrics
+// struct GridMetrics { ... } // MOVED TO TOP OF FILE
+
+void BorderGridPanel::OnPaint(wxPaintEvent& event) {
+    wxAutoBufferedPaintDC dc(this);
+    
+    // Draw the panel background using system colors
+    wxRect rect = GetClientRect();
+    dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+    dc.Clear();
+    
+    GridMetrics m(rect.GetSize());
+    
+    // Draw the grid layout
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    
+    // Helper function to draw a grid
+    auto drawGrid = [&](int offsetX, int offsetY, int gridSize, int cellSize) {
+        for (int i = 0; i <= gridSize; i++) {
+            dc.DrawLine(
+                offsetX + i * cellSize, 
+                offsetY, 
+                offsetX + i * cellSize, 
+                offsetY + gridSize * cellSize
+            );
+            
+            // Horizontal lines
+            dc.DrawLine(
+                offsetX, 
+                offsetY + i * cellSize, 
+                offsetX + gridSize * cellSize, 
+                offsetY + i * cellSize
+            );
+        }
+    };
+    
+    // Draw the three grid sections
+    drawGrid(m.normalX, m.normalY, 2, m.cellSize);
+    drawGrid(m.cornerX, m.cornerY, 2, m.cellSize);
+    drawGrid(m.diagX, m.diagY, 2, m.cellSize);
+    
+    // Set font for position labels
+    dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+    // Scale font size roughly
+    font.SetPixelSize(wxSize(0, std::max(10, m.cellSize / 4)));
+    dc.SetFont(font);
+    
+    int padding = 2; // Fixed small padding to maximize sprite size
+    
+    // Function to draw an item at a position
+    auto drawItemAtPos = [&](BorderEdgePosition pos, int gridX, int gridY, int offsetX, int offsetY) {
+        int x = offsetX + gridX * m.cellSize + padding;
+        int y = offsetY + gridY * m.cellSize + padding;
+        int size = m.cellSize - 2 * padding;
+        
+        // Highlight selected position
+        if (pos == m_selectedPosition) {
+            // "Selection Blue" border, transparent fill to keep sprite visible
+            dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
+            dc.SetBrush(*wxTRANSPARENT_BRUSH);
+            dc.DrawRectangle(x - padding, y - padding, m.cellSize, m.cellSize);
+        }
+        
+        // Draw sprite if available
+        uint16_t itemId = GetItemId(pos);
+        if (itemId > 0) {
+            const ItemType& type = g_items.getItemType(itemId);
+            if (type.id != 0) {
+                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+                if (sprite) {
+                    // Local scaling: Draw to temp DC, extract bitmap, scale, then draw
+                    wxMemoryDC tempDC;
+                    wxBitmap tempBitmap(32, 32);
+                    tempDC.SelectObject(tempBitmap);
+                    tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+                    tempDC.Clear();
+                    
+                    // Draw sprite at native size to temp DC
+                    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
+                    
+                    tempDC.SelectObject(wxNullBitmap);
+                    
+                    // Convert to image, scale, and draw
+                    wxImage img = tempBitmap.ConvertToImage();
+                    if (img.IsOk()) {
+                        img.Rescale(size, size, wxIMAGE_QUALITY_NEAREST);
+                        wxBitmap scaledBmp(img);
+                        dc.DrawBitmap(scaledBmp, x, y, true);
+                    }
+                }
+            }
+        } else {
+            // Only draw text label if NO item is present to prevent overlap
+            wxString label = wxstr(edgePositionToString(pos));
+            wxSize textSize = dc.GetTextExtent(label);
+            
+            // Center text
+            dc.DrawText(label, x + (size - textSize.GetWidth()) / 2, 
+                      y + size - textSize.GetHeight());
+        }
+    };
+    
+    // Draw normal direction items
+    drawItemAtPos(EDGE_N, 0, 0, m.normalX, m.normalY);
+    drawItemAtPos(EDGE_E, 1, 0, m.normalX, m.normalY);
+    drawItemAtPos(EDGE_S, 0, 1, m.normalX, m.normalY);
+    drawItemAtPos(EDGE_W, 1, 1, m.normalX, m.normalY);
+    
+    // Draw corner items
+    drawItemAtPos(EDGE_CNW, 0, 0, m.cornerX, m.cornerY);
+    drawItemAtPos(EDGE_CNE, 1, 0, m.cornerX, m.cornerY);
+    drawItemAtPos(EDGE_CSW, 0, 1, m.cornerX, m.cornerY);
+    drawItemAtPos(EDGE_CSE, 1, 1, m.cornerX, m.cornerY);
+    
+    // Draw diagonal items
+    drawItemAtPos(EDGE_DNW, 0, 0, m.diagX, m.diagY);
+    drawItemAtPos(EDGE_DNE, 1, 0, m.diagX, m.diagY);
+    drawItemAtPos(EDGE_DSW, 0, 1, m.diagX, m.diagY);
+    drawItemAtPos(EDGE_DSE, 1, 1, m.diagX, m.diagY);
+}
+
+wxPoint BorderGridPanel::GetPositionCoordinates(BorderEdgePosition pos) const {
+    switch (pos) {
+        case EDGE_N:   return wxPoint(1, 0);
+        case EDGE_E:   return wxPoint(2, 1);
+        case EDGE_S:   return wxPoint(1, 2);
+        case EDGE_W:   return wxPoint(0, 1);
+        case EDGE_CNW: return wxPoint(0, 0);
+        case EDGE_CNE: return wxPoint(2, 0);
+        case EDGE_CSE: return wxPoint(2, 2);
+        case EDGE_CSW: return wxPoint(0, 2);
+        case EDGE_DNW: return wxPoint(0.5, 0.5);
+        case EDGE_DNE: return wxPoint(1.5, 0.5);
+        case EDGE_DSE: return wxPoint(1.5, 1.5);
+        case EDGE_DSW: return wxPoint(0.5, 1.5);
+        default:       return wxPoint(-1, -1);
+    }
+}
+
+BorderEdgePosition BorderGridPanel::GetPositionFromCoordinates(int x, int y) const
+{
+    GridMetrics m(GetClientSize());
+    
+    const int block_width = 2 * m.cellSize;
+    const int block_height = 2 * m.cellSize;
+    
+    // Check which grid section the click is in and calculate the grid cell
+    
+    // Normal grid
+    if (x >= m.normalX && x < m.normalX + block_width &&
+        y >= m.normalY && y < m.normalY + block_height) {
+        
+        int gridX = (x - m.normalX) / m.cellSize;
+        int gridY = (y - m.normalY) / m.cellSize;
+        
+        if (gridX == 0 && gridY == 0) return EDGE_N;
+        if (gridX == 1 && gridY == 0) return EDGE_E;
+        if (gridX == 0 && gridY == 1) return EDGE_S;
+        if (gridX == 1 && gridY == 1) return EDGE_W;
+    }
+    
+    // Corner grid
+    if (x >= m.cornerX && x < m.cornerX + block_width &&
+        y >= m.cornerY && y < m.cornerY + block_height) {
+        
+        int gridX = (x - m.cornerX) / m.cellSize;
+        int gridY = (y - m.cornerY) / m.cellSize;
+        
+        if (gridX == 0 && gridY == 0) return EDGE_CNW;
+        if (gridX == 1 && gridY == 0) return EDGE_CNE;
+        if (gridX == 0 && gridY == 1) return EDGE_CSW;
+        if (gridX == 1 && gridY == 1) return EDGE_CSE;
+    }
+    
+    // Diagonal grid
+    if (x >= m.diagX && x < m.diagX + block_width &&
+        y >= m.diagY && y < m.diagY + block_height) {
+        
+        int gridX = (x - m.diagX) / m.cellSize;
+        int gridY = (y - m.diagY) / m.cellSize;
+        
+        if (gridX == 0 && gridY == 0) return EDGE_DNW;
+        if (gridX == 1 && gridY == 0) return EDGE_DNE;
+        if (gridX == 0 && gridY == 1) return EDGE_DSW;
+        if (gridX == 1 && gridY == 1) return EDGE_DSE;
+    }
+    
+    return EDGE_NONE;
+}
+
+wxSize BorderGridPanel::DoGetBestSize() const {
+    const int grid_cell_size = 64;
+    const int SECTION_SPACING = 20;
+    const int MARGIN = 10;
+    
+    // 3 blocks of 2 cells each, plus 2 spacings, plus side margins
+    int width = MARGIN + (2 * grid_cell_size) + SECTION_SPACING + 
+                (2 * grid_cell_size) + SECTION_SPACING + 
+                (2 * grid_cell_size) + MARGIN;
+                
+    // 1 block height plus margins
+    int height = MARGIN + (2 * grid_cell_size) + MARGIN;
+    
+    return wxSize(width, height);
+}
+
+void BorderGridPanel::OnMouseClick(wxMouseEvent& event) {
+    int x = event.GetX();
+    int y = event.GetY();
+    
+    BorderEdgePosition pos = GetPositionFromCoordinates(x, y);
+    if (pos != EDGE_NONE) {
+        // Set the position as selected in the grid
+        SetSelectedPosition(pos);
+        
+        // Notify the parent dialog that a position was selected
+        wxCommandEvent selEvent(wxEVT_COMMAND_BUTTON_CLICKED, ID_BORDER_GRID_SELECT);
+        selEvent.SetInt(static_cast<int>(pos));
+        
+        // Find the parent BorderEditorPanel
+        wxWindow* parent = GetParent();
+        while (parent && !dynamic_cast<BorderEditorPanel*>(parent)) {
+            parent = parent->GetParent();
+        }
+        
+        // Send the event to the parent dialog
+        BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(parent);
+        if (dialog) {
+            // Call the event handler directly
+            wxLogDebug("BorderGridPanel::OnMouseClick: Calling OnPositionSelected directly for position %s", wxstr(edgePositionToString(pos)));
+            dialog->OnPositionSelected(selEvent);
+        } else {
+            // If we couldn't find the parent dialog, post the event to the parent
+            wxLogDebug("BorderGridPanel::OnMouseClick: Could not find BorderEditorPanel parent, posting event");
+            wxPostEvent(GetParent(), selEvent);
+        }
+    }
+}
+
+void BorderGridPanel::OnMouseDown(wxMouseEvent& event) {
+    // Get the position from the coordinates
+    BorderEdgePosition pos = GetPositionFromCoordinates(event.GetX(), event.GetY());
+    
+    // Set the selected position
+    SetSelectedPosition(pos);
+    
+    event.Skip();
+}
+
+// ============================================================================
+// BorderPreviewPanel
+
+BorderPreviewPanel::BorderPreviewPanel(wxWindow* parent, wxWindowID id) :
+    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize) { // Use default size, let sizer expand
+    // Set up the panel to handle painting
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    
+    // Enable Full Repaint on Resize
+    SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
+}
+
+BorderPreviewPanel::~BorderPreviewPanel() {
+    // Nothing to destroy manually
+}
+
+void BorderPreviewPanel::SetBorderItems(const std::vector<BorderItem>& items) {
+    m_borderItems = items;
+    Refresh();
+}
+
+void BorderPreviewPanel::Clear() {
+    m_borderItems.clear();
+    Refresh();
+}
+
+void BorderPreviewPanel::OnPaint(wxPaintEvent& event) {
+    wxAutoBufferedPaintDC dc(this);
+    
+    // Get panel dimensions
+    wxRect rect = GetClientRect();
+    int panelWidth = rect.GetWidth();
+    int panelHeight = rect.GetHeight();
+    
+    // Use parent's background instead of filling entire panel with grey
+    dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
+    dc.Clear();
+    
+    // 5x5 Cross Test Pattern for comprehensive border verification
+    const int GRID_SIZE = 5;
+    const int TITLE_HEIGHT = 25;  // Space for the title label
+    const int MARGIN = 5;         // Small margin around the grid
+    
+    // *** DYNAMIC CELL SIZE: Calculate based on available space (like BorderGridPanel) ***
+    int availableWidth = panelWidth - 2 * MARGIN;
+    int availableHeight = panelHeight - TITLE_HEIGHT - 2 * MARGIN;
+    
+    // Calculate cell size to fit the 5x5 grid in available space
+    int cellSize = std::min(availableWidth / GRID_SIZE, availableHeight / GRID_SIZE);
+    
+    // Enforce minimum and maximum cell size for visual consistency
+    if (cellSize < 32) cellSize = 32;   // Minimum: match native sprite size
+    if (cellSize > 64) cellSize = 64;   // Maximum: don't go too large
+    
+    int totalGridSize = GRID_SIZE * cellSize;
+    
+    // Center grid in the panel
+    int startX = (panelWidth - totalGridSize) / 2;
+    int startY = TITLE_HEIGHT + (availableHeight - totalGridSize) / 2;
+    
+    // Ensure grid doesn't go above the title
+    if (startY < TITLE_HEIGHT) {
+        startY = TITLE_HEIGHT;
+    }
+    
+    // Visual Polish: Add "Preview" label at the top
+    dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+    font.MakeBold();
+    dc.SetFont(font);
+    
+    wxString label = "Preview (5x5 Test Pattern)";
+    wxSize textSize = dc.GetTextExtent(label);
+    dc.DrawText(label, (panelWidth - textSize.GetWidth()) / 2, 5);
+    
+    // *** TIGHT BACKGROUND: Draw grey background exactly around the grid (1px border) ***
+    const int BORDER_WIDTH = 1;
+    wxRect gridBgRect(
+        startX - BORDER_WIDTH,
+        startY - BORDER_WIDTH,
+        totalGridSize + 2 * BORDER_WIDTH,
+        totalGridSize + 2 * BORDER_WIDTH
+    );
+    dc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+    dc.DrawRectangle(gridBgRect);
+    
+    // Draw grid lines for the 5x5 area
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+    
+    // Vertical lines
+    for (int i = 0; i <= GRID_SIZE; i++) {
+        dc.DrawLine(startX + i * cellSize, startY, 
+                    startX + i * cellSize, startY + totalGridSize);
+    }
+    
+    // Horizontal lines
+    for (int i = 0; i <= GRID_SIZE; i++) {
+        dc.DrawLine(startX, startY + i * cellSize, 
+                    startX + totalGridSize, startY + i * cellSize);
+    }
+    
+    // Helper lambda: Get the target edge for a grid position (x, y)
+    auto getEdgeAtPosition = [](int x, int y) -> BorderEdgePosition {
+        // Row 0
+        if (y == 0) {
+            if (x == 1) return EDGE_CSE;
+            if (x == 2) return EDGE_S;
+            if (x == 3) return EDGE_CSW;
+        }
+        // Row 1
+        else if (y == 1) {
+            if (x == 0) return EDGE_CSE;
+            if (x == 1) return EDGE_DSE;
+            if (x == 3) return EDGE_DSW;
+            if (x == 4) return EDGE_CSW;
+        }
+        // Row 2 (Center row)
+        else if (y == 2) {
+            if (x == 0) return EDGE_E;
+            if (x == 4) return EDGE_W;
+            // x=2 is center ground (empty)
+        }
+        // Row 3
+        else if (y == 3) {
+            if (x == 0) return EDGE_CNE;
+            if (x == 1) return EDGE_DNE;
+            if (x == 3) return EDGE_DNW;
+            if (x == 4) return EDGE_CNW;
+        }
+        // Row 4
+        else if (y == 4) {
+            if (x == 1) return EDGE_CNE;
+            if (x == 2) return EDGE_N;
+            if (x == 3) return EDGE_CNW;
+        }
+        
+        return static_cast<BorderEdgePosition>(-1); // No edge for this cell
+    };
+    
+    // *** SPRITE SCALING: Use same technique as BorderGridPanel for consistency ***
+    const int spritePadding = 2;  // Small padding within each cell
+    const int spriteSize = cellSize - 2 * spritePadding;
+    
+    // Draw border items based on the cross pattern
+    for (int y = 0; y < GRID_SIZE; y++) {
+        for (int x = 0; x < GRID_SIZE; x++) {
+            BorderEdgePosition targetEdge = getEdgeAtPosition(x, y);
+            
+            if (targetEdge == static_cast<BorderEdgePosition>(-1)) {
+                continue; // Empty cell
+            }
+            
+            // Search for an item with this edge position
+            for (const BorderItem& item : m_borderItems) {
+                if (item.position == targetEdge) {
+                    int cellX = startX + x * cellSize + spritePadding;
+                    int cellY = startY + y * cellSize + spritePadding;
+                    
+                    // Draw the item sprite using same scaling as BorderGridPanel
+                    const ItemType& type = g_items.getItemType(item.itemId);
+                    if (type.id != 0) {
+                        Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+                        if (sprite) {
+                            // Create temp bitmap, draw sprite at native size, then scale
+                            wxMemoryDC tempDC;
+                            wxBitmap tempBitmap(32, 32);
+                            tempDC.SelectObject(tempBitmap);
+                            tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+                            tempDC.Clear();
+                            
+                            // Draw sprite at native 32x32 size to temp DC
+                            sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
+                            
+                            tempDC.SelectObject(wxNullBitmap);
+                            
+                            // Convert to image, scale to fill cell, and draw
+                            wxImage img = tempBitmap.ConvertToImage();
+                            if (img.IsOk()) {
+                                // Scale to fit the cell (dynamic size)
+                                img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
+                                wxBitmap scaledBmp(img);
+                                dc.DrawBitmap(scaledBmp, cellX, cellY, true);
+                            }
+                        }
+                    }
+                    break; // Found and drawn, move to next grid cell
+                }
+            }
+        }
+    }
+}
+
+void BorderEditorPanel::LoadExistingGroundBrushes() {
+    // Legacy method - ground brushes are now populated via PopulateGroundList()
+    // Called from constructor for compatibility, actual population happens on tab change
+}
+void BorderEditorPanel::ClearGroundItems(bool clearBrowser) {
+    if (m_groundGridContainer) m_groundGridContainer->Clear();
+    if (m_groundNameCtrl) m_groundNameCtrl->SetValue("");
+    if (m_serverLookIdCtrl) m_serverLookIdCtrl->SetValue(0);
+    if (m_zOrderCtrl) m_zOrderCtrl->SetValue(0);
+    
+    // Reset border alignment options
+    if (m_includeToNoneCheck) m_includeToNoneCheck->SetValue(true);
+    if (m_includeInnerCheck) m_includeInnerCheck->SetValue(false);
+    if (m_borderAlignmentButton) {
+        m_borderAlignmentSelection = 0;
+        m_borderAlignmentButton->SetLabel("Outer \u25BC");
+    }
+    if (m_groundPreviewPanel) m_groundPreviewPanel->SetWeightedItems({}); // Clear preview
+
+    // Deselect browser list
+    if (clearBrowser && m_borderBrowserList) {
+        m_borderBrowserList->SetSelection(wxNOT_FOUND);
+    }
+}
+
+void BorderEditorPanel::OnPageChanged(wxBookCtrlEvent& event) {
+    m_activeTab = event.GetSelection();
+
+    LoadTilesets();
+
+    if (m_browserSearchCtrl) {
+        m_browserSearchCtrl->Clear();
+    }
+
+    UpdateBrowserLabel();
+
+    if (m_newButton) {
+        switch (m_activeTab) {
+            case 0: m_newButton->SetLabel("New Border"); break;
+            case 1: m_newButton->SetLabel("New Ground"); break;
+            case 2: m_newButton->SetLabel("New Wall"); break;
+        }
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+
+    if (m_selectedBrowserTileId != 0) {
+        RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
+        switch (m_activeTab) {
+            case 0: LoadBorderByMainTileId(m_selectedBrowserTileId); break;
+            case 1: LoadGroundBrushByMainTileId(m_selectedBrowserTileId); break;
+            case 2: LoadWallBrushByMainTileId(m_selectedBrowserTileId); break;
+        }
+    }
+
+    event.Skip();
+}
+
+void BorderEditorPanel::UpdateBrowserLabel() {
+    // No longer needed - mode is indicated by toggle buttons
+}
+
+void BorderEditorPanel::OnModeSwitch(wxCommandEvent& event) {
+    wxToggleButton* clickedBtn = dynamic_cast<wxToggleButton*>(event.GetEventObject());
+    if (!clickedBtn) return;
+    
+    // Determine which mode was selected
+    int newTab = 0;
+    if (clickedBtn == m_borderModeBtn) {
+        newTab = 0;
+    } else if (clickedBtn == m_groundModeBtn) {
+        newTab = 1;
+    } else if (clickedBtn == m_wallModeBtn) {
+        newTab = 2;
+    }
+    
+    // Update toggle button states (only clicked one should be depressed)
+    m_borderModeBtn->SetValue(newTab == 0);
+    m_groundModeBtn->SetValue(newTab == 1);
+    m_wallModeBtn->SetValue(newTab == 2);
+    
+    // Switch the notebook page to show the correct editor panel for this mode
+    if (m_notebook) {
+        m_notebook->ChangeSelection(newTab);
+    }
+    m_activeTab = newTab;
+    
+    // Refresh tileset list (and apply filters) for the new mode
+    LoadTilesets();
+
+    {
+        const auto options = GetBrowserTilesetOptions();
+        if (!options.empty()) {
+            bool filterExists = false;
+            for (const auto& opt : options) {
+                if (opt.second == m_browserTilesetFilter) {
+                    filterExists = true;
+                    break;
+                }
+            }
+
+            if (m_browserTilesetFilter.IsEmpty() || !filterExists) {
+                m_browserTilesetFilter = options.front().second;
+            }
+
+            wxString shown = options.front().first;
+            for (const auto& opt : options) {
+                if (opt.second == m_browserTilesetFilter) {
+                    shown = opt.first;
+                    break;
+                }
+            }
+
+            if (m_browserTilesetFilterButton) {
+                m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
+            }
+        } else {
+            m_browserTilesetFilter.clear();
+            if (m_browserTilesetFilterButton) {
+                m_browserTilesetFilterButton->SetLabel("Tileset: Select ▼");
+            }
+        }
+    }
+    
+    // Clear search and repopulate sidebar
+    if (m_browserSearchCtrl) {
+        m_browserSearchCtrl->Clear();
+    }
+    
+    // Keep browser list unified; just re-apply search/filter
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+
+    bool restored = false;
+    if (m_selectedBrowserTileId != 0) {
+        restored = RestoreBrowserSelection(wxString::Format("%u", (unsigned)m_selectedBrowserTileId));
+    }
+
+    if (!restored) {
+        switch (m_activeTab) {
+            case 0: ClearItems(false); break;
+            case 1: ClearGroundItems(false); break;
+            case 2: ClearWallItems(false); break;
+        }
+        return;
+    }
+
+    switch (m_activeTab) {
+        case 0: LoadBorderByMainTileId(m_selectedBrowserTileId); break;
+        case 1: LoadGroundBrushByMainTileId(m_selectedBrowserTileId); break;
+        case 2: LoadWallBrushByMainTileId(m_selectedBrowserTileId); break;
+    }
+}
+
+void BorderEditorPanel::PopulateBorderList() {
+    m_fullBrowserList.Clear();
+    m_fullBrowserIds.Clear();
+    m_fullBrowserPreviewIds.clear();
+    m_borderBrowserList->Clear();
+
+    wxString dataDir = g_gui.GetDataDirectory();
+
+    wxString bordersFile = dataDir + wxFileName::GetPathSeparator() +
+                          "materials" + wxFileName::GetPathSeparator() +
+                          "borders" + wxFileName::GetPathSeparator() + "borders.xml";
+
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
+                          "materials" + wxFileName::GetPathSeparator() +
+                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+
+    if (!wxFileExists(bordersFile) || !wxFileExists(groundsFile)) {
+        return;
+    }
+
+    std::map<int, wxString> borderNames;
+    int maxId = 0;
+
+    {
+        pugi::xml_document doc;
+        pugi::xml_parse_result result = doc.load_file(nstr(bordersFile).c_str());
+        if (!result) {
+            return;
+        }
+
+        pugi::xml_node materials = doc.child("materials");
+        if (!materials) {
+            return;
+        }
+
+        for (pugi::xml_node borderNode = materials.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+            pugi::xml_attribute idAttr = borderNode.attribute("id");
+            if (!idAttr) {
+                continue;
+            }
+
+            const int id = idAttr.as_int();
+            if (id > maxId) {
+                maxId = id;
+            }
+
+            wxString name;
+            pugi::xml_attribute nameAttr = borderNode.attribute("name");
+            if (nameAttr && wxString(nameAttr.as_string()).Trim().Length() > 0) {
+                name = wxString(nameAttr.as_string());
+            } else {
+                const char* nodeText = borderNode.child_value();
+                if (nodeText && strlen(nodeText) > 0) {
+                    wxString textContent = wxString(nodeText).Trim(true).Trim(false);
+                    while (textContent.StartsWith("-") || textContent.StartsWith(" ")) {
+                        textContent = textContent.Mid(1);
+                    }
+                    while (textContent.EndsWith("-") || textContent.EndsWith(" ")) {
+                        textContent = textContent.RemoveLast();
+                    }
+                    textContent = textContent.Trim(true).Trim(false);
+                    if (!textContent.IsEmpty()) {
+                        name = textContent;
+                    }
+                }
+
+                if (name.IsEmpty()) {
+                    name = "(no name)";
+                }
+            }
+
+            borderNames[id] = name;
+        }
+    }
+
+    std::map<int, std::pair<uint16_t, wxString>> borderToMainTile;
+
+    {
+        pugi::xml_document doc;
+        if (!doc.load_file(nstr(groundsFile).c_str())) {
+            return;
+        }
+
+        pugi::xml_node materials = doc.child("materials");
+        if (!materials) {
+            return;
+        }
+
+        for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+            pugi::xml_attribute typeAttr = brushNode.attribute("type");
+            if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+                continue;
+            }
+
+            pugi::xml_attribute nameAttr = brushNode.attribute("name");
+            if (!nameAttr) {
+                continue;
+            }
+
+            uint16_t mainTileId = 0;
+            if (pugi::xml_attribute serverLookIdAttr = brushNode.attribute("server_lookid")) {
+                mainTileId = serverLookIdAttr.as_uint();
+            } else if (pugi::xml_attribute lookIdAttr = brushNode.attribute("lookid")) {
+                mainTileId = lookIdAttr.as_uint();
+            }
+
+            if (mainTileId == 0) {
+                continue;
+            }
+
+            int outerBorderId = 0;
+            for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+                pugi::xml_attribute idAttr = borderNode.attribute("id");
+                if (!idAttr) {
+                    continue;
+                }
+
+                wxString align = wxString(borderNode.attribute("align").as_string());
+                if (align.IsEmpty() || align == "outer") {
+                    outerBorderId = idAttr.as_int();
+                    break;
+                }
+            }
+
+            if (outerBorderId <= 0) {
+                continue;
+            }
+
+            if (borderToMainTile.find(outerBorderId) == borderToMainTile.end()) {
+                borderToMainTile[outerBorderId] = { mainTileId, wxString(nameAttr.as_string()) };
+            }
+        }
+    }
+
+    for (const auto& pair : borderToMainTile) {
+        const int borderId = pair.first;
+        const uint16_t tileId = pair.second.first;
+        const wxString brushName = pair.second.second;
+
+        wxString borderName;
+        auto itName = borderNames.find(borderId);
+        if (itName != borderNames.end()) {
+            borderName = itName->second;
+        } else {
+            borderName = wxString::Format("border %d", borderId);
+        }
+
+        wxString label = wxString::Format("%d - %s [%s]", (int)tileId, brushName, borderName);
+
+        m_fullBrowserList.Add(label);
+        m_fullBrowserIds.Add(wxString::Format("%d", borderId));
+        m_fullBrowserPreviewIds.push_back(tileId);
+
+        m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", borderId)));
+    }
+
+    m_nextBorderId = maxId + 1;
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::PopulateGroundList() {
+    m_fullBrowserList.Clear();
+    m_fullBrowserIds.Clear();
+    m_fullBrowserPreviewIds.clear();
+    m_borderBrowserList->Clear();
+    
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + 
+                          "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+    
+    if (!wxFileExists(groundsFile)) return;
+    
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(groundsFile).c_str())) return;
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) return;
+    
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute typeAttr = brushNode.attribute("type");
+        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") continue;
+        
+        pugi::xml_attribute nameAttr = brushNode.attribute("name");
+        if (!nameAttr) continue;
+        
+        wxString brushName = wxString(nameAttr.as_string());
+        m_fullBrowserList.Add(brushName);
+        m_fullBrowserIds.Add(brushName);
+
+        uint16_t previewId = 0;
+        pugi::xml_node itemNode = brushNode.child("item");
+        if (itemNode) {
+            previewId = itemNode.attribute("id").as_uint();
+        }
+        m_fullBrowserPreviewIds.push_back(previewId);
+
+        m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::PopulateWallList() {
+    m_fullBrowserList.Clear();
+    m_fullBrowserIds.Clear();
+    m_fullBrowserPreviewIds.clear();
+    m_borderBrowserList->Clear();
+    
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() + 
+                        "materials" + wxFileName::GetPathSeparator() + "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+    
+    if (!wxFileExists(wallsFile)) return;
+    
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(wallsFile).c_str())) return;
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) return;
+    
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute nameAttr = brushNode.attribute("name");
+        if (!nameAttr) continue;
+        
+        wxString brushName = wxString(nameAttr.as_string());
+        m_fullBrowserList.Add(brushName);
+        m_fullBrowserIds.Add(brushName);
+
+        uint16_t previewId = 0;
+        pugi::xml_node wallNode = brushNode.child("wall");
+        if (wallNode) {
+            pugi::xml_node itemNode = wallNode.child("item");
+            if (itemNode) {
+                previewId = itemNode.attribute("id").as_uint();
+            }
+        }
+        m_fullBrowserPreviewIds.push_back(previewId);
+
+        m_borderBrowserList->Append(brushName, new wxStringClientData(brushName));
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::PopulateUnifiedList() {
+    m_fullBrowserList.Clear();
+    m_fullBrowserIds.Clear();
+    m_fullBrowserPreviewIds.clear();
+    m_borderBrowserList->Clear();
+
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
+                          "materials" + wxFileName::GetPathSeparator() +
+                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+
+    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() +
+                        "materials" + wxFileName::GetPathSeparator() +
+                        "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+
+    std::set<uint16_t> seen;
+
+    if (wxFileExists(groundsFile)) {
+        pugi::xml_document doc;
+        if (doc.load_file(nstr(groundsFile).c_str())) {
+            pugi::xml_node materials = doc.child("materials");
+            for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+                pugi::xml_attribute typeAttr = brushNode.attribute("type");
+                if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+                    continue;
+                }
+
+                pugi::xml_attribute nameAttr = brushNode.attribute("name");
+                if (!nameAttr) {
+                    continue;
+                }
+
+                uint16_t tileId = 0;
+                if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+                    tileId = a.as_uint();
+                } else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+                    tileId = a.as_uint();
+                } else if (pugi::xml_node itemNode = brushNode.child("item")) {
+                    tileId = itemNode.attribute("id").as_uint();
+                }
+
+                if (tileId == 0) {
+                    continue;
+                }
+
+                if (seen.find(tileId) != seen.end()) {
+                    continue;
+                }
+                seen.insert(tileId);
+
+                wxString brushName = wxString(nameAttr.as_string());
+                wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
+
+                m_fullBrowserList.Add(label);
+                m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
+                m_fullBrowserPreviewIds.push_back(tileId);
+
+                m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
+            }
+        }
+    }
+
+    if (wxFileExists(wallsFile)) {
+        pugi::xml_document doc;
+        if (doc.load_file(nstr(wallsFile).c_str())) {
+            pugi::xml_node materials = doc.child("materials");
+            for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+                pugi::xml_attribute nameAttr = brushNode.attribute("name");
+                if (!nameAttr) {
+                    continue;
+                }
+
+                uint16_t tileId = 0;
+                if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+                    tileId = a.as_uint();
+                }
+
+                if (tileId == 0) {
+                    continue;
+                }
+
+                if (seen.find(tileId) != seen.end()) {
+                    continue;
+                }
+                seen.insert(tileId);
+
+                wxString brushName = wxString(nameAttr.as_string());
+                wxString label = wxString::Format("%d - %s", (int)tileId, brushName);
+
+                m_fullBrowserList.Add(label);
+                m_fullBrowserIds.Add(wxString::Format("%d", (int)tileId));
+                m_fullBrowserPreviewIds.push_back(tileId);
+
+                m_borderBrowserList->Append(label, new wxStringClientData(wxString::Format("%d", (int)tileId)));
+            }
+        }
+    }
+
+    FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+}
+
+void BorderEditorPanel::OnBrowserSearch(wxCommandEvent& event) {
+    FilterBrowserList(m_browserSearchCtrl->GetValue());
+}
+
+static wxString FindTilesetByPreferredOrContains(const wxString& preferred, const std::vector<wxString>& needlesLower) {
+    if (!preferred.IsEmpty() && g_materials.tilesets.find(nstr(preferred).c_str()) != g_materials.tilesets.end()) {
+        return preferred;
+    }
+
+    for (const auto& pair : g_materials.tilesets) {
+        wxString ts = wxString(pair.first);
+        wxString lower = ts.Lower();
+        for (const wxString& needle : needlesLower) {
+            if (!needle.IsEmpty() && lower.Contains(needle)) {
+                return ts;
+            }
+        }
+    }
+
+    return wxString();
+}
+
+static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions() {
+    std::vector<std::pair<wxString, wxString>> options;
+
+    wxString mountains = FindTilesetByPreferredOrContains("Grounds - Mountains", { "mountain", "montain" });
+    if (!mountains.IsEmpty()) {
+        options.push_back({ "Mountains", mountains });
+    }
+
+    wxString nature = FindTilesetByPreferredOrContains("Grounds - Nature", { "nature" });
+    if (!nature.IsEmpty()) {
+        options.push_back({ "Nature", nature });
+    }
+
+    wxString ornamented = FindTilesetByPreferredOrContains("Grounds - Ornamented", { "ornament" });
+    if (!ornamented.IsEmpty()) {
+        options.push_back({ "Ornamented", ornamented });
+    }
+
+    wxString wall = FindTilesetByPreferredOrContains("Walls", { "wall" });
+    if (!wall.IsEmpty()) {
+        options.push_back({ "Wall", wall });
+    }
+
+    return options;
+}
+
+void BorderEditorPanel::OnBrowserTilesetFilterButtonClick(wxCommandEvent& event) {
+    wxMenu menu;
+
+    const auto options = GetBrowserTilesetOptions();
+    if (options.empty()) {
+        return;
+    }
+
+    auto addRadio = [&](const wxString& shown, const wxString& value) {
+        wxMenuItem* item = menu.AppendRadioItem(wxID_ANY, shown);
+        if (value == m_browserTilesetFilter) {
+            item->Check(true);
+        }
+        menu.Bind(wxEVT_MENU, [this, shown, value](wxCommandEvent&) {
+            const uint16_t keepTileId = m_selectedBrowserTileId;
+
+            m_browserTilesetFilter = value;
+            if (m_browserTilesetFilterButton) {
+                m_browserTilesetFilterButton->SetLabel("Tileset: " + shown + " ▼");
+            }
+
+            FilterBrowserList(m_browserSearchCtrl ? m_browserSearchCtrl->GetValue() : wxString());
+
+            bool restored = false;
+            if (keepTileId != 0) {
+                restored = RestoreBrowserSelection(wxString::Format("%u", (unsigned)keepTileId));
+            }
+
+            if (restored) {
+                switch (m_activeTab) {
+                    case 0: LoadBorderByMainTileId(keepTileId); break;
+                    case 1: LoadGroundBrushByMainTileId(keepTileId); break;
+                    case 2: LoadWallBrushByMainTileId(keepTileId); break;
+                }
+            } else {
+                switch (m_activeTab) {
+                    case 0: ClearItems(false); break;
+                    case 1: ClearGroundItems(false); break;
+                    case 2: ClearWallItems(false); break;
+                }
+            }
+        }, item->GetId());
+    };
+
+    for (const auto& opt : options) {
+        addRadio(opt.first, opt.second);
+    }
+
+    PopupMenu(&menu);
+}
+
+void BorderEditorPanel::FilterBrowserList(const wxString& query) {
+    m_borderBrowserList->Clear();
+    wxString lowerQuery = query.Lower();
+
+    const auto filterOptions = GetBrowserTilesetOptions();
+
+    const bool useTilesetFilter = !m_browserTilesetFilter.IsEmpty();
+    const std::string tilesetName = useTilesetFilter ? nstr(m_browserTilesetFilter) : std::string();
+
+    std::vector<BrushBrowserGridPanel::Entry> entries;
+    entries.reserve(m_fullBrowserList.GetCount());
+
+    for (size_t i = 0; i < m_fullBrowserList.GetCount(); i++) {
+        if (!query.IsEmpty() && !m_fullBrowserList[i].Lower().Contains(lowerQuery)) {
+            continue;
+        }
+
+        uint16_t previewId = 0;
+        if (i < m_fullBrowserPreviewIds.size()) {
+            previewId = m_fullBrowserPreviewIds[i];
+        }
+
+        if (useTilesetFilter) {
+            if (previewId == 0) {
+                continue;
+            }
+
+            const ItemType& type = g_items.getItemType(previewId);
+            if (type.id == 0) {
+                continue;
+            }
+
+            auto inTilesetFor = [&](const wxString& tilesetWx) -> bool {
+                const std::string ts = nstr(tilesetWx);
+                return
+                    g_materials.isInTileset(type.brush, ts) ||
+                    g_materials.isInTileset(type.doodad_brush, ts) ||
+                    g_materials.isInTileset(type.raw_brush, ts);
+            };
+
+            if (!inTilesetFor(m_browserTilesetFilter)) {
+                continue;
+            }
+
+            if (filterOptions.size() > 1) {
+                size_t selectedIndex = filterOptions.size();
+                for (size_t idx = 0; idx < filterOptions.size(); ++idx) {
+                    if (filterOptions[idx].second == m_browserTilesetFilter) {
+                        selectedIndex = idx;
+                        break;
+                    }
+                }
+
+                if (selectedIndex != filterOptions.size()) {
+                    bool belongsToHigher = false;
+                    for (size_t idx = 0; idx < selectedIndex; ++idx) {
+                        const wxString& higherTs = filterOptions[idx].second;
+                        if (higherTs.IsEmpty()) {
+                            continue;
+                        }
+                        if (inTilesetFor(higherTs)) {
+                            belongsToHigher = true;
+                            break;
+                        }
+                    }
+                    if (belongsToHigher) {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        wxString displayLabel = m_fullBrowserList[i];
+        if (previewId != 0 && !filterOptions.empty()) {
+            if (useTilesetFilter) {
+                wxString selectedShown;
+                for (const auto& opt : filterOptions) {
+                    if (opt.second == m_browserTilesetFilter) {
+                        selectedShown = opt.first;
+                        break;
+                    }
+                }
+
+                if (!selectedShown.IsEmpty()) {
+                    displayLabel += " [" + selectedShown + "]";
+                }
+            } else {
+                const ItemType& type = g_items.getItemType(previewId);
+                if (type.id != 0) {
+                    wxString tagList;
+                    bool first = true;
+
+                    for (const auto& opt : filterOptions) {
+                        const wxString& shown = opt.first;
+                        const wxString& tsNameWx = opt.second;
+                        if (tsNameWx.IsEmpty()) {
+                            continue;
+                        }
+
+                        const std::string tsName = nstr(tsNameWx);
+                        const bool inTileset =
+                            g_materials.isInTileset(type.brush, tsName) ||
+                            g_materials.isInTileset(type.doodad_brush, tsName) ||
+                            g_materials.isInTileset(type.raw_brush, tsName);
+
+                        if (inTileset) {
+                            if (!first) {
+                                tagList += ", ";
+                            }
+                            tagList += shown;
+                            first = false;
+                        }
+                    }
+
+                    if (!tagList.IsEmpty()) {
+                        displayLabel += " [" + tagList + "]";
+                    }
+                }
+            }
+        }
+
+        m_borderBrowserList->Append(displayLabel, new wxStringClientData(m_fullBrowserIds[i]));
+
+        BrushBrowserGridPanel::Entry e;
+        e.label = displayLabel;
+        e.key = m_fullBrowserIds[i];
+        e.previewItemId = previewId;
+        entries.push_back(std::move(e));
+    }
+
+    if (m_browserGrid) {
+        m_browserGrid->SetEntries(std::move(entries));
+    }
+}
+
+void BorderEditorPanel::OnGroundGridSelect(wxCommandEvent& event) {
+    // Selection logic logic is handled by container/cell highlighting
+    // No UI updates needed here anymore as editing is via double-click modal
+}
+
+void BorderEditorPanel::LoadTilesets() {
+    // Clear the choice control
+    m_tilesetListData.Clear();
+    m_tilesets.clear();
+    
+    // Get the appropriate whitelist for the current mode
+    const std::set<wxString>& whitelist = 
+        (m_activeTab == 0) ? m_borderEnabledTilesets :
+        (m_activeTab == 1) ? m_groundEnabledTilesets :
+                             m_wallEnabledTilesets;
+    
+    // Use the already-loaded tilesets from g_materials
+    // (g_materials.tilesets is populated by the Materials loader at startup)
+    wxArrayString tilesetNames;
+    for (const auto& pair : g_materials.tilesets) {
+        if (pair.second) {
+            wxString tilesetName = wxString(pair.first);
+            const bool allowed = whitelist.empty() || whitelist.find(tilesetName) != whitelist.end();
+            if (allowed) {
+                tilesetNames.Add(tilesetName);
+                m_tilesets[tilesetName] = tilesetName;
+            }
+        }
+    }
+    
+    // Sort tileset names alphabetically
+    tilesetNames.Sort();
+    
+    // Add sorted names to the tileset list
+    m_tilesetListData = tilesetNames;
+    
+    // Update the appropriate ComboBox based on active tab
+    // Update the appropriate Control based on active tab
+    if (m_activeTab == 0 && m_rawCategoryButton) {
+        // Border tab
+        m_rawCategoryNames = m_tilesetListData;
+        
+        if (!m_tilesetListData.IsEmpty()) {
+            m_rawCategorySelection = 0;
+            m_rawCategoryButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+            
+            if(m_itemPalettePanel) m_itemPalettePanel->LoadTileset(m_tilesetListData[0]);
+        } else {
+             m_rawCategoryButton->SetLabel("Select \u25BC");
+             if(m_itemPalettePanel) m_itemPalettePanel->LoadTileset("");
+        }
+    } else if (m_activeTab == 1 && m_groundTilesetButton) {
+        // Ground tab
+        if (!m_tilesetListData.IsEmpty()) {
+            m_groundTilesetSelection = 0;
+            m_groundTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+            
+            if(m_groundPalette) m_groundPalette->LoadTileset(m_tilesetListData[0], FILTER_GROUND);
+        } else {
+            m_groundTilesetButton->SetLabel("Select \u25BC");
+        }
+    } else if (m_activeTab == 2 && m_wallTilesetButton) {
+        // Wall tab
+         if (!m_tilesetListData.IsEmpty()) {
+            m_wallTilesetSelection = 0;
+            m_wallTilesetButton->SetLabel(m_tilesetListData[0] + " \u25BC");
+            
+            if(m_wallPalette) m_wallPalette->LoadTileset(m_tilesetListData[0], FILTER_WALL);
+         } else {
+             m_wallTilesetButton->SetLabel("Select \u25BC");
+         }
+    }
+
+} 
+
+// ============================================================================
+// Filter Config Persistence
+
+void BorderEditorPanel::SaveFilterConfig() {
+    // Save filter configuration to JSON file
+    wxString configDir = wxFileName::GetHomeDir() + wxFileName::GetPathSeparator() + ".rme";
+    if (!wxDirExists(configDir)) {
+        if (!wxMkdir(configDir)) {
+            // Failed to create directory
+            return;
+        }
+    }
+    
+    wxString configFile = configDir + wxFileName::GetPathSeparator() + "border_editor_filters_v2.json";
+    
+    // Build JSON manually (simple format)
+    wxString json = "{\n";
+    
+    // Border enabled tilesets
+    json += "  \"border_enabled\": [";
+    bool first = true;
+    for (const wxString& ts : m_borderEnabledTilesets) {
+        if (!first) json += ", ";
+        json += "\"" + ts + "\"";
+        first = false;
+    }
+    json += "],\n";
+    
+    // Ground enabled tilesets
+    json += "  \"ground_enabled\": [";
+    first = true;
+    for (const wxString& ts : m_groundEnabledTilesets) {
+        if (!first) json += ", ";
+        json += "\"" + ts + "\"";
+        first = false;
+    }
+    json += "],\n";
+    
+    // Wall enabled tilesets
+    json += "  \"wall_enabled\": [";
+    first = true;
+    for (const wxString& ts : m_wallEnabledTilesets) {
+        if (!first) json += ", ";
+        json += "\"" + ts + "\"";
+        first = false;
+    }
+    json += "]\n";
+    
+    json += "}\n";
+    
+    wxFile file;
+    if (file.Create(configFile, true)) { // true = overwrite
+        file.Write(json);
+        file.Close();
+    }
+}
+
+void BorderEditorPanel::LoadFilterConfig() {
+    // Ensure clean state
+    m_borderEnabledTilesets.clear();
+    m_groundEnabledTilesets.clear();
+    m_wallEnabledTilesets.clear();
+
+    wxString configDir = wxFileName::GetHomeDir() + wxFileName::GetPathSeparator() + ".rme";
+    wxString configFile = configDir + wxFileName::GetPathSeparator() + "border_editor_filters_v2.json";
+    
+    if (!wxFileExists(configFile)) {
+        // No config file - whitelists stay empty (default: no filter applied / clean state)
+        // This ensures "Addon and Quest Items" is NOT selected by default
+        return;
+    }
+    
+    wxFile file(configFile, wxFile::read);
+    if (!file.IsOpened()) return;
+    
+    wxString content;
+    file.ReadAll(&content);
+    file.Close();
+    
+    // Simple JSON parsing for our specific format
+    auto parseArray = [&content](const wxString& key) -> std::set<wxString> {
+        std::set<wxString> result;
+        int startPos = content.Find("\"" + key + "\": [");
+        if (startPos == wxNOT_FOUND) return result;
+        
+        int arrayStart = content.find('[', startPos);
+        int arrayEnd = content.find(']', arrayStart);
+        if (arrayStart == wxNOT_FOUND || arrayEnd == wxNOT_FOUND) return result;
+        
+        wxString arrayContent = content.Mid(arrayStart + 1, arrayEnd - arrayStart - 1);
+        
+        // Parse quoted strings
+        int pos = 0;
+        while ((pos = arrayContent.find('"', pos)) != wxNOT_FOUND) {
+            int endQuote = arrayContent.find('"', pos + 1);
+            if (endQuote == wxNOT_FOUND) break;
+            result.insert(arrayContent.Mid(pos + 1, endQuote - pos - 1));
+            pos = endQuote + 1;
+        }
+        return result;
+    };
+    
+    m_borderEnabledTilesets = parseArray("border_enabled");
+    m_groundEnabledTilesets = parseArray("ground_enabled");
+    m_wallEnabledTilesets = parseArray("wall_enabled");
+}
+
+// ============================================================================
+// WallGridPanel - Visual Selector for Wall Types
+// ============================================================================
+
+BEGIN_EVENT_TABLE(WallGridPanel, wxPanel)
+    EVT_PAINT(WallGridPanel::OnPaint)
+    EVT_LEFT_DOWN(WallGridPanel::OnMouseClick)
+END_EVENT_TABLE()
+
+WallGridPanel::WallGridPanel(wxWindow* parent, wxWindowID id) :
+    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+}
+
+WallGridPanel::~WallGridPanel() {
+}
+
+void WallGridPanel::SetWallTypes(const std::map<std::string, WallTypeData>& types) {
+    m_types = types;
+    Refresh();
+}
+
+void WallGridPanel::SetSelectedType(const std::string& type) {
+    m_selectedType = type;
+    Refresh();
+}
+
+void WallGridPanel::OnPaint(wxPaintEvent& event) {
+    wxAutoBufferedPaintDC dc(this);
+    
+    // Background
+    dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+    dc.Clear();
+    
+    wxRect rect = GetClientRect();
+    int w = rect.GetWidth();
+    int h = rect.GetHeight();
+    
+    // Calculate 3x3 grid metrics centered
+    int padding = 2;
+    int cellSize = std::min((w - 2 * 5) / 3, (h - 2 * 5) / 3);
+    if (cellSize < 32) cellSize = 32;
+    
+    int startX = (w - (cellSize * 3)) / 2;
+    int startY = (h - (cellSize * 3)) / 2;
+    
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    
+    // Draw Grid (3x3)
+    for (int i = 0; i <= 3; i++) {
+        dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + 3 * cellSize);
+        dc.DrawLine(startX, startY + i * cellSize, startX + 3 * cellSize, startY + i * cellSize);
+    }
+    
+    auto drawTypeAt = [&](const std::string& type, int gridX, int gridY) {
+        int x = startX + gridX * cellSize + padding;
+        int y = startY + gridY * cellSize + padding;
+        int size = cellSize - 2 * padding;
+        
+        bool isSelected = (m_selectedType == type);
+        
+        if (isSelected) {
+            dc.SetPen(wxPen(wxColour(0, 120, 215), 2));
+            dc.DrawRectangle(x - padding, y - padding, cellSize, cellSize);
+        }
+        
+        if (m_types.find(type) != m_types.end() && !m_types[type].items.empty()) {
+            uint16_t itemId = m_types[type].items[0].itemId;
+            if (itemId > 0) {
+                const ItemType& it = g_items.getItemType(itemId);
+                if (it.id != 0) {
+                    Sprite* s = g_gui.gfx.getSprite(it.clientID);
+                    if (s) {
+                        wxMemoryDC tempDC;
+                        wxBitmap tempBitmap(32, 32);
+                        tempDC.SelectObject(tempBitmap);
+                        tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+                        tempDC.Clear();
+                        s->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
+                        tempDC.SelectObject(wxNullBitmap);
+                        
+                        wxImage img = tempBitmap.ConvertToImage();
+                        if (img.IsOk()) {
+                            img.Rescale(size, size, wxIMAGE_QUALITY_NEAREST);
+                            dc.DrawBitmap(wxBitmap(img), x, y, true);
+                        }
+                    }
+                }
+            }
+        }
+    };
+    
+    // 3x3 Mapping (User configured)
+    // Row 0: Pole, horizontal, horizontal (Swapped Corner/Pole)
+    drawTypeAt("pole", 0, 0); 
+    drawTypeAt("horizontal", 1, 0);
+    drawTypeAt("horizontal", 2, 0);
+    
+    // Row 1: vertical, (empty), vertical
+    drawTypeAt("vertical", 0, 1);
+    // (1,1) is empty/vazio
+    drawTypeAt("vertical", 2, 1);
+    
+    // Row 2: vertical, horizontal, Corner (Swapped Corner/Pole)
+    drawTypeAt("vertical", 0, 2);
+    drawTypeAt("horizontal", 1, 2);
+    drawTypeAt("corner", 2, 2);
+}
+
+void WallGridPanel::OnMouseClick(wxMouseEvent& event) {
+    wxRect rect = GetClientRect();
+    int w = rect.GetWidth();
+    int h = rect.GetHeight();
+    
+    int cellSize = std::min((w - 2 * 5) / 3, (h - 2 * 5) / 3);
+    if (cellSize < 32) cellSize = 32;
+    
+    int startX = (w - (cellSize * 3)) / 2;
+    int startY = (h - (cellSize * 3)) / 2;
+    
+    int mouseX = event.GetX();
+    int mouseY = event.GetY();
+    
+    if (mouseX >= startX && mouseX < startX + 3 * cellSize &&
+        mouseY >= startY && mouseY < startY + 3 * cellSize) {
+        
+        int gridX = (mouseX - startX) / cellSize;
+        int gridY = (mouseY - startY) / cellSize;
+        
+        std::string clickedType = "";
+        
+        // Row 0
+        if (gridX == 0 && gridY == 0) clickedType = "pole"; // Swapped
+        else if (gridX == 1 && gridY == 0) clickedType = "horizontal";
+        else if (gridX == 2 && gridY == 0) clickedType = "horizontal";
+        
+        // Row 1
+        else if (gridX == 0 && gridY == 1) clickedType = "vertical";
+        // (1,1) is empty
+        else if (gridX == 2 && gridY == 1) clickedType = "vertical";
+        
+        // Row 2
+        else if (gridX == 0 && gridY == 2) clickedType = "vertical";
+        else if (gridX == 1 && gridY == 2) clickedType = "horizontal";
+        else if (gridX == 2 && gridY == 2) clickedType = "corner"; // Swapped
+        
+        if (!clickedType.empty()) {
+            m_selectedType = clickedType;
+            Refresh();
+            
+            wxCommandEvent evt(wxEVT_COMMAND_BUTTON_CLICKED, GetId());
+            evt.SetString(clickedType);
+            evt.SetEventObject(this);
+            
+            // Find parent dialog and call callback directly
+            wxWindow* parent = GetParent();
+            while (parent && !dynamic_cast<BorderEditorPanel*>(parent)) {
+                parent = parent->GetParent();
+            }
+            
+            if (BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(parent)) {
+                dialog->OnWallGridSelect(evt);
+            }
+        }
+    }
+}
+
+// ============================================================================
+// WallVisualPanel
+
+BEGIN_EVENT_TABLE(WallVisualPanel, wxPanel)
+    EVT_PAINT(WallVisualPanel::OnPaint)
+END_EVENT_TABLE()
+
+WallVisualPanel::WallVisualPanel(wxWindow* parent, wxWindowID id) :
+    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+    SetWindowStyle(GetWindowStyle() | wxFULL_REPAINT_ON_RESIZE);
+}
+
+WallVisualPanel::~WallVisualPanel() {
+}
+
+void WallVisualPanel::SetWallItems(const std::map<std::string, WallTypeData>& items) {
+    m_items = items;
+    Refresh();
+}
+
+void WallVisualPanel::Clear() {
+    m_items.clear();
+    Refresh();
+}
+
+void WallVisualPanel::OnPaint(wxPaintEvent& event) {
+    wxAutoBufferedPaintDC dc(this);
+    
+    // Get panel dimensions
+    wxRect rect = GetClientRect();
+    int panelWidth = rect.GetWidth();
+    int panelHeight = rect.GetHeight();
+    
+    // Use parent's background
+    if (GetParent()) {
+        dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
+    } else {
+        dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+    }
+    dc.Clear();
+    
+    // 5x5 Test Pattern
+    const int GRID_SIZE = 5;
+    const int TITLE_HEIGHT = 20;
+    const int MARGIN = 5;
+    
+    int availableWidth = panelWidth - 2 * MARGIN;
+    int availableHeight = panelHeight - TITLE_HEIGHT - 2 * MARGIN;
+    
+    if (availableWidth <= 0 || availableHeight <= 0) return;
+    
+    // Calculate cell size
+    int cellSize = std::min(availableWidth, availableHeight) / GRID_SIZE;
+    if (cellSize < 16) cellSize = 16;
+    
+    // Limits
+    if (cellSize > 64) cellSize = 64; 
+    
+    int totalGridSize = GRID_SIZE * cellSize;
+    
+    // Center grid
+    int startX = (panelWidth - totalGridSize) / 2;
+    int startY = TITLE_HEIGHT + (availableHeight - totalGridSize) / 2;
+    if (startY < TITLE_HEIGHT) startY = TITLE_HEIGHT;
+    
+    // Draw "Preview" label
+    dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    wxFont font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+    font.MakeBold();
+    dc.SetFont(font);
+    
+    wxString label = "Preview";
+    wxSize textSize = dc.GetTextExtent(label);
+    dc.DrawText(label, (panelWidth - textSize.GetWidth()) / 2, 2);
+    
+    // Background border
+    const int BORDER_WIDTH = 1;
+    wxRect gridBgRect(startX - BORDER_WIDTH, startY - BORDER_WIDTH, totalGridSize + 2 * BORDER_WIDTH, totalGridSize + 2 * BORDER_WIDTH);
+    dc.SetBrush(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+    dc.DrawRectangle(gridBgRect);
+    
+    // Draw 5x5 grid lines
+    dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+    for (int i = 0; i <= GRID_SIZE; i++) {
+        dc.DrawLine(startX + i * cellSize, startY, startX + i * cellSize, startY + totalGridSize);
+        dc.DrawLine(startX, startY + i * cellSize, startX + totalGridSize, startY + i * cellSize);
+    }
+    
+    // Mapping Logic: Grid Position -> Wall Type
+    auto getWallTypeAt = [](int x, int y) -> std::string {
+        // Layout Configured by User:
+        // R0: Pole, H, H, H, H
+        // R1: V, ., ., ., V
+        // R2: V, ., ., ., V
+        // R3: V, ., ., ., V
+        // R4: V, ., ., ., Corner
+        
+        if (y == 0) {
+            if (x == 0) return "pole";
+            return "horizontal"; // x=1..4
+        }
+        else if (y >= 1 && y <= 3) {
+            if (x == 0) return "vertical";
+            if (x == 4) return "vertical";
+            return ""; // Middle is empty
+        }
+        else if (y == 4) {
+            if (x == 0) return "vertical";
+            if (x == 4) return "corner";
+            return "horizontal"; // Middle is horizontal
+        }
+        return "";
+    };
+
+    const int spritePadding = 2;
+    
+    for (int y = 0; y < GRID_SIZE; y++) {
+        for (int x = 0; x < GRID_SIZE; x++) {
+            std::string typeName = getWallTypeAt(x, y);
+            if (typeName.empty()) continue;
+            
+            // Draw item
+            if (m_items.find(typeName) != m_items.end() && !m_items[typeName].items.empty()) {
+                uint16_t itemId = m_items[typeName].items[0].itemId;
+                if (itemId > 0) {
+                    int drawX = startX + x * cellSize;
+                    int drawY = startY + y * cellSize;
+                    
+                    const ItemType& itemType = g_items.getItemType(itemId);
+                    if (itemType.id != 0) {
+                        Sprite* sprite = g_gui.gfx.getSprite(itemType.clientID);
+                        if (sprite) {
+                             // Correctly scale 32x32 sprite to cell size
+                             int targetW = cellSize - 2 * spritePadding;
+                             int targetH = cellSize - 2 * spritePadding;
+                             
+                             // Draw internal uses raw coordinates, we can use DrawTo with scaling if supported
+                             // Or render to bitmap and scale.
+                             // Using the previous method: render to bitmap then draw
+                            wxMemoryDC tempDC;
+                            wxBitmap tempBitmap(32, 32);
+                            tempDC.SelectObject(tempBitmap);
+                            tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+                            tempDC.Clear();
+                            sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32_SCALED, 0, 0);
+                            tempDC.SelectObject(wxNullBitmap);
+                            
+                            wxImage img = tempBitmap.ConvertToImage();
+                            if (img.IsOk()) {
+                                img.Rescale(targetW, targetH, wxIMAGE_QUALITY_NEAREST);
+                                dc.DrawBitmap(wxBitmap(img), drawX + spritePadding, drawY + spritePadding, true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+} 
+
+
+// ============================================================================
+// GroundGridPanel (Visual Copy of BorderGridPanel)
+// ============================================================================
+
+BEGIN_EVENT_TABLE(GroundGridPanel, wxPanel)
+    EVT_PAINT(GroundGridPanel::OnPaint)
+    EVT_LEFT_DOWN(GroundGridPanel::OnMouseClick)
+    EVT_LEFT_DCLICK(GroundGridPanel::OnLeftDClick)
+    EVT_RIGHT_DOWN(GroundGridPanel::OnRightClick)
+END_EVENT_TABLE()
+
+GroundGridPanel::GroundGridPanel(wxWindow* parent, wxWindowID id) :
+    wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE),
+    m_itemId(0),
+    m_chance(100),
+    m_isSelected(false)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
+}
+
+// ============================================================================
+// ChanceEditDialog - Modal for editing item chance
+// ============================================================================
+class ChanceEditDialog : public wxDialog {
+public:
+    ChanceEditDialog(wxWindow* parent, int initialValue) : 
+        wxDialog(parent, wxID_ANY, "Chance", wxDefaultPosition, wxSize(200, 120)) 
+    {
+        wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
+
+        m_spinCtrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(100, -1));
+        m_spinCtrl->SetRange(1, 1000000);
+        m_spinCtrl->SetValue(initialValue);
+        
+        // Center the spin control horizontally
+        wxBoxSizer* centerSizer = new wxBoxSizer(wxHORIZONTAL);
+        centerSizer->Add(m_spinCtrl, 1, wxALIGN_CENTER);
+        mainSizer->Add(centerSizer, 1, wxEXPAND | wxALL, 10);
+
+        // Buttons
+        wxStdDialogButtonSizer* btnSizer = new wxStdDialogButtonSizer();
+        btnSizer->AddButton(new wxButton(this, wxID_OK));
+        btnSizer->AddButton(new wxButton(this, wxID_CANCEL));
+        btnSizer->Realize();
+        mainSizer->Add(btnSizer, 0, wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, 10);
+
+        SetSizer(mainSizer);
+        Layout();
+        CenterOnParent();
+        
+        m_spinCtrl->SetFocus();
+        m_spinCtrl->SetSelection(-1, -1); // Select all text
+    }
+
+    int GetValue() const { return m_spinCtrl->GetValue(); }
+
+private:
+    wxSpinCtrl* m_spinCtrl;
+};
+
+// ============================================================================
+// GroundPreviewPanel
+// ============================================================================
+
+BEGIN_EVENT_TABLE(GroundPreviewPanel, wxPanel)
+    EVT_PAINT(GroundPreviewPanel::OnPaint)
+    EVT_TIMER(wxID_ANY, GroundPreviewPanel::OnTimer)
+END_EVENT_TABLE()
+
+GroundPreviewPanel::GroundPreviewPanel(wxWindow* parent, wxWindowID id) :
+    wxPanel(parent, id, wxDefaultPosition, wxSize(110, 110), wxNO_BORDER),
+    m_currentIndex(0),
+    m_animationTimer(this),
+    m_lastCycleTime(0)
+{
+    // Use system default background
+    m_animationTimer.Start(50); // 20 FPS
+}
+
+GroundPreviewPanel::~GroundPreviewPanel() {
+    if (m_animationTimer.IsRunning()) {
+        m_animationTimer.Stop();
+    }
+}
+
+void GroundPreviewPanel::SetWeightedItems(const std::vector<std::pair<uint16_t, int>>& items) {
+    m_displayItems.clear();
+    for (const auto& pair : items) {
+        if (pair.first != 0) {
+            m_displayItems.push_back(pair.first);
+        }
+    }
+    m_currentIndex = 0;
+    Refresh();
+}
+
+void GroundPreviewPanel::UpdateFromContainer(GroundGridContainer* container) {
+    if (container) {
+        SetWeightedItems(container->GetAllItemsWithChance());
+    }
+}
+
+void GroundPreviewPanel::OnTimer(wxTimerEvent& event) {
+    // 1. Handle Animation Refresh (Redraw every tick)
+    Refresh();
+
+    // 2. Handle Item Cycling (Every 1000ms)
+    long currentTime = wxGetLocalTimeMillis().GetValue();
+    if (currentTime - m_lastCycleTime >= 1000) {
+        if (!m_displayItems.empty()) {
+            m_currentIndex = (m_currentIndex + 1) % m_displayItems.size();
+        }
+        m_lastCycleTime = currentTime;
+    }
+}
+
+void GroundPreviewPanel::OnPaint(wxPaintEvent& event) {
+    wxBufferedPaintDC dc(this);
+    // Use parent's background to be seamless
+    if (GetParent()) {
+        dc.SetBackground(wxBrush(GetParent()->GetBackgroundColour()));
+    } else {
+        dc.SetBackground(wxBrush(GetBackgroundColour()));
+    }
+    dc.Clear();
+
+    if (m_displayItems.empty()) return;
+
+    // Safety check for index
+    if (m_currentIndex >= m_displayItems.size()) m_currentIndex = 0;
+
+    uint16_t itemId = m_displayItems[m_currentIndex];
+    if (itemId == 0) return;
+
+    const ItemType& itemType = g_items.getItemType(itemId);
+    if (itemType.id == 0) return;
+
+    Sprite* sprite = g_gui.gfx.getSprite(itemType.clientID);
+    if (!sprite) return;
+
+    int panelW, panelH;
+    GetSize(&panelW, &panelH);
+    
+    // Draw scaled sprite
+    // Create temp bitmap 32x32
+    wxMemoryDC tempDC;
+    wxBitmap tempBitmap(32, 32);
+    tempDC.SelectObject(tempBitmap);
+    tempDC.SetBackground(*wxTRANSPARENT_BRUSH); // Transparent background
+    tempDC.Clear();
+    
+    // Draw sprite to temp DC (0,0)
+    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0, 32, 32);
+    tempDC.SelectObject(wxNullBitmap);
+    
+    // Convert to image and rescale
+    wxImage img = tempBitmap.ConvertToImage();
+    if (img.IsOk()) {
+        // Scale to fit panel minus padding
+        int padding = 4;
+        int targetSize = std::min(panelW, panelH) - (2 * padding);
+        if (targetSize < 32) targetSize = 32;
+
+        img.Rescale(targetSize, targetSize, wxIMAGE_QUALITY_NEAREST);
+        wxBitmap scaledBmp(img);
+        
+        // Center draw
+        int x = (panelW - targetSize) / 2;
+        int y = (panelH - targetSize) / 2;
+        dc.DrawBitmap(scaledBmp, x, y, true);
+    }
+}
+
+GroundGridPanel::~GroundGridPanel() {}
+
+void GroundGridPanel::SetItemId(uint16_t id) {
+    m_itemId = id;
+    Refresh();
+}
+
+void GroundGridPanel::Clear() {
+    m_itemId = 0;
+    m_chance = 100;
+    SetSelected(false);
+    Refresh();
+}
+
+void GroundGridPanel::SetSelected(bool selected) {
+    if (m_isSelected != selected) {
+        m_isSelected = selected;
+        Refresh();
+    }
+}
+
+void GroundGridPanel::SetChance(int chance) {
+    m_chance = chance;
+}
+
+wxSize GroundGridPanel::DoGetBestSize() const {
+    // 64px cell + 5px margin on each side = 74x74
+    return wxSize(74, 74);
+}
+
+void GroundGridPanel::OnLeftDClick(wxMouseEvent& event) {
+    if (m_itemId == 0) return; // Ignore empty cells
+
+    ChanceEditDialog dlg(this, m_chance);
+    if (dlg.ShowModal() == wxID_OK) {
+        int newChance = dlg.GetValue();
+        if (newChance != m_chance) {
+            m_chance = newChance;
+            Refresh(); // Redraw (maybe show tooltip with chance?)
+            // We could refresh tooltip if we had one
+            SetToolTip(wxString::Format("Item ID: %d\nChance: %d", m_itemId, m_chance));
+        }
+    }
+}
+
+void GroundGridPanel::OnMouseClick(wxMouseEvent& event) {
+    wxSize size = GetClientSize();
+    int w = size.GetWidth();
+    int h = size.GetHeight();
+    int margin = 5;
+    
+    // Use fixed size for individual cells to avoid excessive spacing
+    int cellSize = 64;
+    
+    // Start at top-left with margin (documentation standard)
+    int gridX = margin;
+    int gridY = margin;
+    
+    int clickX = event.GetX();
+    int clickY = event.GetY();
+    
+    // Check if click is within the grid cell
+    if (clickX >= gridX && clickX < gridX + cellSize &&
+        clickY >= gridY && clickY < gridY + cellSize) {
+        
+        // Get the currently selected brush from the GUI
+        Brush* brush = g_gui.GetCurrentBrush();
+        if (brush && brush->isRaw()) {
+            RAWBrush* rawBrush = dynamic_cast<RAWBrush*>(brush);
+            if (rawBrush) {
+                m_itemId = rawBrush->getItemID();
+                Refresh();
+                
+                // No auto-append: a nova variação só é criada via botão "Add Variation"
+            }
+        }
+    }
+}
+void GroundGridPanel::OnRightClick(wxMouseEvent& event) {
+    wxSize size = GetClientSize();
+    int w = size.GetWidth();
+    int h = size.GetHeight();
+    int margin = 5;
+    
+    // Fixed cell size matching OnPaint
+    int cellSize = 64;
+    
+    // Start at top-left with margin (matching OnPaint)
+    int gridX = margin;
+    int gridY = margin;
+    
+    int clickX = event.GetX();
+    int clickY = event.GetY();
+    
+    // Check if click is within the grid cell
+    if (clickX >= gridX && clickX < gridX + cellSize &&
+        clickY >= gridY && clickY < gridY + cellSize) {
+        
+        // If the cell is not empty, request removal from container
+        if (!IsEmpty()) {
+            wxWindow* parent = GetParent();
+            GroundGridContainer* container = dynamic_cast<GroundGridContainer*>(parent);
+            if (container) {
+                container->RemoveCell(this);
+            }
+        }
+    }
+}
+void GroundGridPanel::OnPaint(wxPaintEvent& event) {
+    wxAutoBufferedPaintDC dc(this);
+    
+    // Use system background color like Border Editor
+    dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE)));
+    dc.Clear();
+
+    wxSize size = GetClientSize();
+    int w = size.GetWidth();
+    int h = size.GetHeight();
+    int margin = 5;
+    
+    // Match sizing of individual grid cells (standard 64px)
+    int cellSize = 64;
+    
+    // Start at top-left with margin (documentation standard)
+    int x = margin;
+    int y = margin;
+    
+    // Use GraphicsContext for opacity (75% = 191 alpha)
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
+    if (gc) {
+        gc->SetAntialiasMode(wxANTIALIAS_NONE);
+        
+        // Draw grid lines (like Border Editor) with 75% opacity
+        wxColour grayText = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+        gc->SetPen(wxPen(wxColour(grayText.Red(), grayText.Green(), grayText.Blue(), 191)));
+        gc->SetBrush(*wxTRANSPARENT_BRUSH);
+        
+        // Draw 1x1 grid (rectangle)
+        gc->DrawRectangle(x, y, cellSize, cellSize);
+        
+        // Draw the assigned item sprite if set
+        if (m_itemId > 0) {
+            const ItemType& type = g_items.getItemType(m_itemId);
+            if (type.id != 0) {
+                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+                if (sprite) {
+                    // Sprite rendering with scaling to fit cell
+                    const int spritePadding = 2;
+                    const int spriteSize = cellSize - 2 * spritePadding;
+                    
+                    wxMemoryDC tempDC;
+                    wxBitmap tempBitmap(32, 32);
+                    tempDC.SelectObject(tempBitmap);
+                    tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+                    tempDC.Clear();
+                    
+                    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
+                    tempDC.SelectObject(wxNullBitmap);
+                    
+                    wxImage img = tempBitmap.ConvertToImage();
+                    if (img.IsOk()) {
+                        img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
+                        wxBitmap scaledBmp(img);
+                        
+                        // Draw bitmap with 75% opacity
+                        gc->DrawBitmap(scaledBmp, x + spritePadding, y + spritePadding, spriteSize, spriteSize);
+                    }
+                }
+            }
+        }
+    } else {
+        // Fallback to normal DC if GC fails
+        dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT)));
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawRectangle(x, y, cellSize, cellSize);
+        
+        if (m_itemId > 0) {
+            const ItemType& type = g_items.getItemType(m_itemId);
+            if (type.id != 0) {
+                Sprite* sprite = g_gui.gfx.getSprite(type.clientID);
+                if (sprite) {
+                    const int spritePadding = 2;
+                    const int spriteSize = cellSize - 2 * spritePadding;
+                    
+                    wxMemoryDC tempDC;
+                    wxBitmap tempBitmap(32, 32);
+                    tempDC.SelectObject(tempBitmap);
+                    tempDC.SetBackground(*wxTRANSPARENT_BRUSH);
+                    tempDC.Clear();
+                    
+                    sprite->DrawTo(&tempDC, SPRITE_SIZE_32x32, 0, 0);
+                    tempDC.SelectObject(wxNullBitmap);
+                    
+                    wxImage img = tempBitmap.ConvertToImage();
+                    if (img.IsOk()) {
+                        img.Rescale(spriteSize, spriteSize, wxIMAGE_QUALITY_NEAREST);
+                        wxBitmap scaledBmp(img);
+                        dc.DrawBitmap(scaledBmp, x + spritePadding, y + spritePadding, true);
+                    }
+                }
+            }
+        }
+    }
+
+    // Draw Chance Value Overlay (if item exists)
+    if (m_itemId > 0) {
+        wxString chanceText = wxString::Format("%d", m_chance);
+        wxFont font(8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD);
+        dc.SetFont(font);
+        
+        wxSize textSize = dc.GetTextExtent(chanceText);
+        // Position at bottom-right of the cell
+        int textX = x + cellSize - textSize.GetWidth() - 4;
+        int textY = y + cellSize - textSize.GetHeight() - 4;
+        
+        // Draw shadow (black)
+        dc.SetTextForeground(*wxBLACK);
+        dc.DrawText(chanceText, textX + 1, textY + 1);
+        
+        // Draw text (white)
+        dc.SetTextForeground(*wxWHITE);
+        dc.DrawText(chanceText, textX, textY);
+    }
+
+    // Draw selection border if selected
+    if (m_isSelected) {
+        dc.SetPen(wxPen(*wxBLUE, 3)); // Thick blue border
+        dc.SetBrush(*wxTRANSPARENT_BRUSH);
+        dc.DrawRectangle(x, y, cellSize, cellSize);
+    }
+}
+
+// ============================================================================
+// GroundGridContainer - Manages multiple GroundGridPanel cells with auto-expansion
+// ============================================================================
+
+GroundGridContainer::GroundGridContainer(wxWindow* parent, wxWindowID id) :
+    wxScrolledWindow(parent, id, wxDefaultPosition, wxDefaultSize, wxHSCROLL | wxBORDER_NONE),
+    m_gridSizer(nullptr),
+    m_selectedCell(nullptr)
+{
+    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
+    
+    // Create horizontal sizer for the grid cells
+    m_gridSizer = new wxBoxSizer(wxHORIZONTAL);
+    SetSizer(m_gridSizer);
+    
+    // Set scroll rate
+    SetScrollRate(10, 0);  // Only horizontal scrolling
+    
+    // Create first empty cell
+    CreateNewCell();
+}
+
+GroundGridContainer::~GroundGridContainer() {
+    m_gridCells.clear();
+}
+
+void GroundGridContainer::CreateNewCell() {
+    GroundGridPanel* cell = new GroundGridPanel(this);
+    cell->SetMinSize(wxSize(74, 74));  // 64px cell + 10px margins
+
+    m_gridSizer->Add(cell, 0, wxALL | wxALIGN_TOP, 1);
+    m_gridCells.push_back(cell);
+
+    FitInside();
+    Layout();
+}
+
+void GroundGridContainer::EnsureEmptyCell() {
+    if (m_gridCells.empty()) {
+        CreateNewCell();
+    }
+}
+
+void GroundGridContainer::AppendEmptyCell() {
+    CreateNewCell();
+    FitInside();
+    Layout();
+    Refresh();
+}
+
+void GroundGridContainer::RemoveCell(GroundGridPanel* cell) {
+    if (!cell) return;
+    
+    // Don't remove the only cell if it's already empty
+    if (m_gridCells.size() == 1 && cell->IsEmpty()) {
+        return;
+    }
+    
+    // Find the cell in our list
+    auto it = std::find(m_gridCells.begin(), m_gridCells.end(), cell);
+    if (it != m_gridCells.end()) {
+        // Remove from sizer
+        m_gridSizer->Detach(cell);
+        
+        if (m_selectedCell == cell) {
+            m_selectedCell = nullptr;
+             // Notify dialog validation?
+        }
+        
+        // Remove from our list
+        m_gridCells.erase(it);
+        
+        // Destroy the window
+        cell->Destroy();
+        
+        // Ensure we still have an empty cell at the end
+        EnsureEmptyCell();
+        
+        // Refresh layout
+        FitInside();
+        Layout();
+        Refresh();
+        
+        // Notify parent that content changed
+        wxCommandEvent event(wxEVT_GROUND_CONTAINER_CHANGE, GetId());
+        event.SetEventObject(this);
+        wxPostEvent(GetParent(), event);
+    }
+}
+
+void GroundGridContainer::AddItem(uint16_t itemId, int chance, bool allowAppend) {
+    if (itemId == 0) {
+        return;
+    }
+
+    for (GroundGridPanel* cell : m_gridCells) {
+        if (cell->IsEmpty()) {
+            cell->SetItemId(itemId);
+            cell->SetChance(chance);
+            return;
+        }
+    }
+
+    if (!allowAppend) {
+        return;
+    }
+
+    CreateNewCell();
+    GroundGridPanel* last = m_gridCells.back();
+    last->SetItemId(itemId);
+    last->SetChance(chance);
+}
+
+void GroundGridContainer::Clear() {
+    while (m_gridCells.size() > 1) {
+        GroundGridPanel* cell = m_gridCells.back();
+        m_gridSizer->Detach(cell);
+        cell->Destroy();
+        m_gridCells.pop_back();
+    }
+    
+    if (!m_gridCells.empty()) {
+        m_gridCells[0]->Clear();
+    }
+    
+    FitInside();
+    Layout();
+}
+
+std::vector<uint16_t> GroundGridContainer::GetAllItems() const {
+    std::vector<uint16_t> items;
+    for (const GroundGridPanel* cell : m_gridCells) {
+        if (!cell->IsEmpty()) {
+            items.push_back(cell->GetItemId());
+        }
+    }
+    return items;
+}
+
+std::vector<std::pair<uint16_t, int>> GroundGridContainer::GetAllItemsWithChance() const {
+    std::vector<std::pair<uint16_t, int>> items;
+    for (const GroundGridPanel* cell : m_gridCells) {
+        if (!cell->IsEmpty()) {
+            items.push_back({cell->GetItemId(), cell->GetChance()});
+        }
+    }
+    return items;
+}
+
+size_t GroundGridContainer::GetFilledCount() const {
+    size_t count = 0;
+    for (const GroundGridPanel* cell : m_gridCells) {
+        if (!cell->IsEmpty()) count++;
+    }
+    return count;
+}
+
+void GroundGridContainer::OnCellFilled(int index) {
+    EnsureEmptyCell();
+}
+
+void GroundGridContainer::RebuildGrids() {
+    FitInside();
+    Layout();
+    Refresh();
+}
+
+void GroundGridContainer::SetSelectedCell(GroundGridPanel* cell) {
+    if (m_selectedCell != cell) {
+        if (m_selectedCell) {
+            m_selectedCell->SetSelected(false);
+        }
+        m_selectedCell = cell;
+        if (m_selectedCell) {
+            m_selectedCell->SetSelected(true);
+            
+            // Try to notify the dialog to update chance control
+            // We need to walk up to find the dialog
+            wxWindow* win = GetParent();
+            while (win) {
+                BorderEditorPanel* dialog = dynamic_cast<BorderEditorPanel*>(win);
+                if (dialog) {
+                    wxCommandEvent evt(wxEVT_NULL); // Just update UI call
+                    // We can't easily fire an event to dialog from here without ID. 
+                    // Let's assume the dialog will poll or we can implement a callback system later if needed.
+                    // For now, let's just make sure m_groundItemChanceCtrl updates when user interacts.
+                    // Actually, simpler: Fire a custom event or reuse an existing one.
+                    // We can reuse wxEVT_COMMAND_LISTBOX_SELECTED on the container? No.
+                    
+                    // Direct update is easiest if we can access public method.
+                    // But we don't have public access.
+                    // Let's use a dummy event to trigger UI update.
+                    wxCommandEvent event(wxEVT_BUTTON, wxID_ANY); 
+                    event.SetEventObject(this); 
+                    // dialog->OnGridSelectionChanged(event); // If we had it.
+                    
+                    // Let's implement OnGridCellClicked properly in Dialog to handle this.
+                    // But Wait, GroundGridPanel::OnMouseClick is calling SetSelectedCell.
+                    // We should dispatch an event from container to parent.
+                    
+                    wxCommandEvent selEvent(wxEVT_COMMAND_LISTBOX_SELECTED, GetId());
+                    selEvent.SetEventObject(this);
+                    selEvent.SetInt(cell->GetChance()); // Pass chance as int
+                    win->GetEventHandler()->ProcessEvent(selEvent); // Send to parent (StaticBox) -> then to Dialog
+                    break;
+                }
+                win = win->GetParent();
+            }
+        }
+    }
+}
+
+// DISABLE Old Event Handlers
+void BorderEditorPanel::OnAddVariation(wxCommandEvent& event) {
+    if (m_activeTab != 1) {
+        return;
+    }
+    if (!m_groundGridContainer) {
+        return;
+    }
+
+    m_groundGridContainer->AppendEmptyCell();
+}
+void BorderEditorPanel::OnRemoveVariationBtn(wxCommandEvent& event) {}
+void BorderEditorPanel::OnPreviewTimer(wxTimerEvent& event) {}
+void BorderEditorPanel::RebuildVariationsList() {}
+void BorderEditorPanel::AddVariationRow(GroundVariation& variation, int index) {}
+
+void BorderEditorPanel::OnGroundPaletteSelect(wxCommandEvent& event) {
+    // When an item is selected from the palette, add it to the container
+    uint16_t itemId = static_cast<uint16_t>(event.GetInt());
+    if (itemId > 0 && m_groundGridContainer) {
+        m_groundGridContainer->AddItem(itemId, 100, false);
+        if (m_groundPreviewPanel) {
+            m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+        }
+    }
+}
+
+void BorderEditorPanel::OnGroundContainerChange(wxCommandEvent& event) {
+    if (m_groundPreviewPanel && m_groundGridContainer) {
+        m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+    }
+}
+
+void BorderEditorPanel::SaveGroundBrush() {
+    // Validate input
+    wxString name = m_groundNameCtrl->GetValue().Trim();
+    if (name.IsEmpty()) {
+        wxMessageBox("Please enter a name for the ground brush.", "Validation Error", wxOK | wxICON_WARNING);
+        return;
+    }
+    
+    std::vector<std::pair<uint16_t, int>> items = m_groundGridContainer ? m_groundGridContainer->GetAllItemsWithChance() : std::vector<std::pair<uint16_t, int>>();
+    if (items.empty()) {
+        wxMessageBox("Please add at least one item to the ground brush by clicking on tiles in the palette.", 
+                     "Validation Error", wxOK | wxICON_WARNING);
+        return;
+    }
+    
+    int preSave = wxMessageBox(
+        "This action will save the ground brush and reload data files (F5). Continue?",
+        "Confirm Save",
+        wxYES_NO | wxICON_QUESTION | wxSTAY_ON_TOP,
+        this
+    );
+    if (preSave != wxYES) {
+        return;
+    }
+
+    // Get form values
+    int serverLookId = m_serverLookIdCtrl->GetValue();
+    int zOrder = m_zOrderCtrl->GetValue();
+    wxString alignment = (m_borderAlignmentSelection == 1) ? "inner" : "outer";
+    bool includeToNone = m_includeToNoneCheck->GetValue();
+    bool includeInner = m_includeInnerCheck->GetValue();
+    
+    // Build XML path
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + 
+                          "materials" + wxFileName::GetPathSeparator() + 
+                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+    
+    // Load existing file or create new structure
+    pugi::xml_document doc;
+    pugi::xml_node materials;
+    
+    if (wxFileExists(groundsFile)) {
+        pugi::xml_parse_result result = doc.load_file(nstr(groundsFile).c_str());
+        if (result) {
+            materials = doc.child("materials");
+        }
+    }
+    
+    if (!materials) {
+        materials = doc.append_child("materials");
+    }
+    
+    // Check if brush with this name already exists
+    pugi::xml_node existingBrush;
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        if (wxString(brushNode.attribute("name").as_string()) == name) {
+            existingBrush = brushNode;
+            break;
+        }
+    }
+    
+    // Create or update brush node
+    pugi::xml_node brushNode = existingBrush ? existingBrush : materials.append_child("brush");
+    
+    if (!existingBrush) {
+        brushNode.append_attribute("type") = "ground";
+    }
+    brushNode.attribute("name") = nstr(name).c_str();
+    if (!brushNode.attribute("name")) {
+        brushNode.append_attribute("name") = nstr(name).c_str();
+    }
+    
+    // Set or update server_lookid
+    if (serverLookId > 0) {
+        if (brushNode.attribute("server_lookid")) {
+            brushNode.attribute("server_lookid") = serverLookId;
+        } else {
+            brushNode.append_attribute("server_lookid") = serverLookId;
+        }
+    }
+    
+    // Set z-order
+    if (brushNode.attribute("z-order")) {
+        brushNode.attribute("z-order") = zOrder;
+    } else {
+        brushNode.append_attribute("z-order") = zOrder;
+    }
+    
+    // Remove existing item children and add new ones
+    while (brushNode.child("item")) {
+        brushNode.remove_child("item");
+    }
+    
+    // Add all items from the container
+    int totalScale = 0;
+    
+    // First pass: Calculate total weight if needed, though we save raw values usually
+    // Canary format usually expects 'chance' as a relative weight or specific probability?
+    // Looking at brush loading code: total_chance += chance;
+    // So it's cumulative weight. We can save the raw int values user entered.
+    
+    for (const auto& itemPair : items) {
+        uint16_t itemId = itemPair.first;
+        int chance = itemPair.second;
+        
+        pugi::xml_node itemNode = brushNode.append_child("item");
+        itemNode.append_attribute("id") = itemId;
+        itemNode.append_attribute("chance") = chance;
+    }
+    
+    // Add border node if not exists
+    pugi::xml_node borderNode = brushNode.child("border");
+    if (!borderNode) {
+        borderNode = brushNode.append_child("border");
+    }
+    
+    // Set border attributes
+    if (borderNode.attribute("align")) {
+        borderNode.attribute("align") = nstr(alignment).c_str();
+    } else {
+        borderNode.append_attribute("align") = nstr(alignment).c_str();
+    }
+    
+    if (includeToNone) {
+        if (!borderNode.attribute("to")) {
+            borderNode.append_attribute("to") = "none";
+        } else {
+            borderNode.attribute("to") = "none";
+        }
+    }
+    
+    // Save the file
+    if (doc.save_file(nstr(groundsFile).c_str())) {
+        TriggerReloadDataFiles();
+        ReloadCurrentBrushEditorXml(name);
+
+        wxMessageBox(
+            wxString::Format("Ground brush '%s' saved successfully.", name),
+            "Success",
+            wxOK | wxICON_INFORMATION | wxSTAY_ON_TOP,
+            this
+        );
+    } else {
+        wxMessageBox("Failed to save ground brush file.", "Error", wxOK | wxICON_ERROR);
+    }
+}
+
+void BorderEditorPanel::LoadBorderByMainTileId(uint16_t tileId) {
+    ClearItems(false);
+    if (tileId == 0) {
+        return;
+    }
+
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
+                          "materials" + wxFileName::GetPathSeparator() +
+                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+
+    if (!wxFileExists(groundsFile)) {
+        return;
+    }
+
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(groundsFile).c_str())) {
+        return;
+    }
+
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) {
+        return;
+    }
+
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute typeAttr = brushNode.attribute("type");
+        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+            continue;
+        }
+
+        uint16_t mainTileId = 0;
+        if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+            mainTileId = a.as_uint();
+        } else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+            mainTileId = a.as_uint();
+        }
+
+        if (mainTileId != tileId) {
+            continue;
+        }
+
+        for (pugi::xml_node borderNode = brushNode.child("border"); borderNode; borderNode = borderNode.next_sibling("border")) {
+            pugi::xml_attribute idAttr = borderNode.attribute("id");
+            if (!idAttr) {
+                continue;
+            }
+
+            wxString align = wxString(borderNode.attribute("align").as_string());
+            if (align.IsEmpty() || align == "outer") {
+                LoadBorderById(idAttr.as_int());
+                return;
+            }
+        }
+
+        return;
+    }
+}
+
+void BorderEditorPanel::LoadGroundBrushByMainTileId(uint16_t tileId) {
+    ClearGroundItems(false);
+    if (tileId == 0) {
+        return;
+    }
+
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() +
+                          "materials" + wxFileName::GetPathSeparator() +
+                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+
+    if (!wxFileExists(groundsFile)) {
+        return;
+    }
+
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(groundsFile).c_str())) {
+        return;
+    }
+
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) {
+        return;
+    }
+
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute typeAttr = brushNode.attribute("type");
+        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") {
+            continue;
+        }
+
+        pugi::xml_attribute nameAttr = brushNode.attribute("name");
+        if (!nameAttr) {
+            continue;
+        }
+
+        uint16_t mainTileId = 0;
+        if (pugi::xml_attribute a = brushNode.attribute("server_lookid")) {
+            mainTileId = a.as_uint();
+        } else if (pugi::xml_attribute a = brushNode.attribute("lookid")) {
+            mainTileId = a.as_uint();
+        }
+
+        if (mainTileId == tileId) {
+            LoadGroundBrushByName(wxString(nameAttr.as_string()));
+            return;
+        }
+    }
+}
+
+void BorderEditorPanel::LoadWallBrushByMainTileId(uint16_t tileId) {
+    ClearWallItems(false);
+    if (tileId == 0) {
+        return;
+    }
+
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString wallsFile = dataDir + wxFileName::GetPathSeparator() +
+                        "materials" + wxFileName::GetPathSeparator() +
+                        "brushs" + wxFileName::GetPathSeparator() + "walls.xml";
+
+    if (!wxFileExists(wallsFile)) {
+        return;
+    }
+
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(wallsFile).c_str())) {
+        return;
+    }
+
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) {
+        return;
+    }
+
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute nameAttr = brushNode.attribute("name");
+        if (!nameAttr) {
+            continue;
+        }
+
+        pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
+        if (lookIdAttr && lookIdAttr.as_uint() == tileId) {
+            LoadWallBrushByName(wxString(nameAttr.as_string()));
+            return;
+        }
+    }
+}
+
+void BorderEditorPanel::LoadGroundBrushByName(const wxString& name) {
+    if (name.IsEmpty()) return;
+    
+    wxString dataDir = g_gui.GetDataDirectory();
+    wxString groundsFile = dataDir + wxFileName::GetPathSeparator() + 
+                          "materials" + wxFileName::GetPathSeparator() + 
+                          "brushs" + wxFileName::GetPathSeparator() + "grounds.xml";
+    
+    if (!wxFileExists(groundsFile)) return;
+    
+    pugi::xml_document doc;
+    if (!doc.load_file(nstr(groundsFile).c_str())) return;
+    
+    ClearGroundItems(false); // Don't clear browser selection logic
+    
+    pugi::xml_node materials = doc.child("materials");
+    if (!materials) return;
+    
+    // Find the brush by name
+    for (pugi::xml_node brushNode = materials.child("brush"); brushNode; brushNode = brushNode.next_sibling("brush")) {
+        pugi::xml_attribute typeAttr = brushNode.attribute("type");
+        if (!typeAttr || std::string(typeAttr.as_string()) != "ground") continue;
+        
+        pugi::xml_attribute nameAttr = brushNode.attribute("name");
+        if (!nameAttr || wxString(nameAttr.as_string()) != name) continue;
+        
+        // Found the brush - populate the form
+        m_groundNameCtrl->SetValue(name);
+        
+        // Server look ID
+        pugi::xml_attribute lookIdAttr = brushNode.attribute("server_lookid");
+        if (!lookIdAttr) {
+            lookIdAttr = brushNode.attribute("lookid");
+        }
+        m_serverLookIdCtrl->SetValue(lookIdAttr ? lookIdAttr.as_int() : 0);
+        
+        // Z-order
+        pugi::xml_attribute zOrderAttr = brushNode.attribute("z-order");
+        m_zOrderCtrl->SetValue(zOrderAttr ? zOrderAttr.as_int() : 0);
+        
+        // Get first item ID and set in grid
+        // Load all items into the container
+        if (m_groundGridContainer) {
+            m_groundGridContainer->Clear();
+            for (pugi::xml_node itemNode = brushNode.child("item"); itemNode; itemNode = itemNode.next_sibling("item")) {
+                uint16_t itemId = itemNode.attribute("id").as_uint();
+                int chance = itemNode.attribute("chance").as_int();
+                if (chance <= 0) chance = 100; // Default
+                
+                if (itemId > 0) {
+                    m_groundGridContainer->AddItem(itemId, chance, true);
+                }
+            }
+        }
+        
+        // Border settings
+        pugi::xml_node borderNode = brushNode.child("border");
+        if (borderNode) {
+            wxString align = wxString(borderNode.attribute("align").as_string());
+            if (align == "inner") {
+                m_borderAlignmentSelection = 1;
+                if(m_borderAlignmentButton) m_borderAlignmentButton->SetLabel("Inner \u25BC");
+            } else {
+                m_borderAlignmentSelection = 0;
+                if(m_borderAlignmentButton) m_borderAlignmentButton->SetLabel("Outer \u25BC");
+            }
+            
+            wxString toValue = wxString(borderNode.attribute("to").as_string());
+            m_includeToNoneCheck->SetValue(toValue == "none");
+        }
+        
+        if (m_groundPreviewPanel && m_groundGridContainer) {
+            m_groundPreviewPanel->UpdateFromContainer(m_groundGridContainer);
+        }
+        break;
+    }
+}

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -1766,6 +1766,7 @@ void BorderEditorPanel::SaveWallBrush() {
 		ShowErrorDialog("Failed to save wall brush file.", ErrorSeverity::Error);
 		return;
 	}
+	InvalidateXmlCache(wallsFile);
 
 	DiscardDraft(2, mainTileId);
 
@@ -5658,6 +5659,7 @@ void BorderEditorPanel::SaveGroundBrush() {
 		ShowErrorDialog("Failed to save ground brush file.", ErrorSeverity::Error);
 		return;
 	}
+	InvalidateXmlCache(groundsFile);
 
 	DiscardDraft(1, mainTileId);
 

--- a/source/brush_editor_window.cpp
+++ b/source/brush_editor_window.cpp
@@ -4070,25 +4070,54 @@ static wxString FindTilesetByPreferredOrContains(const wxString &preferred, cons
 static std::vector<std::pair<wxString, wxString>> GetBrowserTilesetOptions() {
 	std::vector<std::pair<wxString, wxString>> options;
 
-	wxString mountains = FindTilesetByPreferredOrContains("Grounds - Mountains", { "mountain", "montain" });
-	if (!mountains.IsEmpty()) {
-		options.push_back({ "Mountains", mountains });
+	// Iterate over all tilesets and find those with terrain or doodad category
+	// that have at least one brush with variation, wall, or border support
+	for (const auto &pair : g_materials.tilesets) {
+		wxString tilesetName = wxString(pair.first);
+		Tileset* tileset = pair.second;
+		if (!tileset) {
+			continue;
+		}
+
+		bool hasValidBrush = false;
+
+		// Check terrain category
+		const TilesetCategory* terrainCat = tileset->getCategory(TILESET_TERRAIN);
+		if (terrainCat && !terrainCat->brushlist.empty()) {
+			for (Brush* brush : terrainCat->brushlist) {
+				if (!brush) {
+					continue;
+				}
+				if (brush->getMaxVariation() > 0 || brush->isWall() || brush->needBorders()) {
+					hasValidBrush = true;
+					break;
+				}
+			}
+		}
+
+		// Check doodad category
+		if (!hasValidBrush) {
+			const TilesetCategory* doodadCat = tileset->getCategory(TILESET_DOODAD);
+			if (doodadCat && !doodadCat->brushlist.empty()) {
+				for (Brush* brush : doodadCat->brushlist) {
+					if (!brush) {
+						continue;
+					}
+					if (brush->getMaxVariation() > 0 || brush->isWall() || brush->needBorders()) {
+						hasValidBrush = true;
+						break;
+					}
+				}
+			}
+		}
+
+		if (hasValidBrush) {
+			options.push_back({ tilesetName, tilesetName });
+		}
 	}
 
-	wxString nature = FindTilesetByPreferredOrContains("Grounds - Nature", { "nature" });
-	if (!nature.IsEmpty()) {
-		options.push_back({ "Nature", nature });
-	}
-
-	wxString ornamented = FindTilesetByPreferredOrContains("Grounds - Ornamented", { "ornament" });
-	if (!ornamented.IsEmpty()) {
-		options.push_back({ "Ornamented", ornamented });
-	}
-
-	wxString wall = FindTilesetByPreferredOrContains("Walls", { "wall" });
-	if (!wall.IsEmpty()) {
-		options.push_back({ "Wall", wall });
-	}
+	// Sort alphabetically
+	std::sort(options.begin(), options.end(), [](const auto &a, const auto &b) { return a.first < b.first; });
 
 	return options;
 }

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -307,6 +307,9 @@ protected:
 	bool RebuildBrushCatalog();
 	bool EnsureBrushCatalogUpToDate();
 	void MarkBrushCatalogDirty();
+	void InvalidateTilesetCache(int tab = -1);
+	void EnsureActiveTabBrowserLoaded();
+	void EnsureActiveTabPaletteLoaded();
 	void FilterBrowserList(const wxString &query);
 	void UpdateBrowserLabel();
 	void UpdateInspectorHeader();
@@ -324,6 +327,9 @@ protected:
 	bool PersistPaletteDefinition(const wxString &tilesetName, TilesetCategoryType categoryType, bool create);
 	bool RestoreBrowserSelection(const wxString &selectionKey);
 	void ReloadCurrentBrushEditorXml(const wxString &selectionKey);
+	bool ApplyGroundBrushFromCatalog(const wxString &name);
+	bool ApplyWallBrushFromCatalog(const wxString &name);
+	const std::vector<std::pair<wxString, wxString>>& GetBrowserTilesetOptionsCached();
 
 	void LoadBorderByMainTileId(uint16_t tileId);
 	void LoadGroundBrushByMainTileId(uint16_t tileId);
@@ -408,6 +414,10 @@ private:
 	wxArrayString m_cachedBrowserLists[3];
 	wxArrayString m_cachedBrowserIds[3];
 	std::vector<uint16_t> m_cachedBrowserPreviewIds[3];
+	wxArrayString m_cachedTilesetListData[3];
+	std::vector<std::pair<wxString, wxString>> m_cachedBrowserTilesetOptions[3];
+	bool m_tilesetListDirty[3] = { true, true, true };
+	bool m_browserTilesetOptionsDirty[3] = { true, true, true };
 	bool m_tabInitialized[3] = { false, false, false };
 
 	// Animation timer for preview

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -1,0 +1,688 @@
+// brush_editor_window.h - Provides a visual editor for brushs
+
+#ifndef RME_BRUSH_EDITOR_WINDOW_H_
+#define RME_BRUSH_EDITOR_WINDOW_H_
+
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+#include <wx/statbox.h>
+#include <wx/stattext.h>
+#include <wx/textctrl.h>
+#include <wx/button.h>
+#include <wx/listbox.h>
+#include <wx/spinctrl.h>
+#include <wx/bmpbuttn.h>
+#include <wx/artprov.h>
+#include <wx/grid.h>
+#include <wx/panel.h>
+#include <wx/checkbox.h>
+#include <wx/combobox.h>
+#include <wx/notebook.h>
+#include <wx/simplebook.h>
+#include <wx/tglbtn.h>
+#include <wx/choice.h>
+#include <wx/srchctrl.h>
+#include <vector>
+#include <map>
+#include <set>
+#include <wx/treectrl.h>
+#include <wx/checklst.h>
+
+// Forward declarations
+class BorderItemButton;
+class BorderGridPanel;
+class GroundGridPanel;
+class GroundGridContainer;
+class BorderPreviewPanel;
+class GroundPreviewPanel;
+class WallVisualPanel;
+class BrushPalettePanel;
+class BrushBrowserGridPanel;
+
+// Represents a border edge position
+enum BorderEdgePosition {
+    EDGE_NONE = -1,
+    EDGE_N,   // North
+    EDGE_E,   // East
+    EDGE_S,   // South
+    EDGE_W,   // West
+    EDGE_CNW, // Corner Northwest
+    EDGE_CNE, // Corner Northeast
+    EDGE_CSE, // Corner Southeast
+    EDGE_CSW, // Corner Southwest
+    EDGE_DNW, // Diagonal Northwest
+    EDGE_DNE, // Diagonal Northeast
+    EDGE_DSE, // Diagonal Southeast
+    EDGE_DSW, // Diagonal Southwest
+    EDGE_COUNT
+};
+
+// Alignment options for borders
+enum BorderAlignment {
+    ALIGN_OUTER,
+    ALIGN_INNER
+};
+
+// Utility function to convert border edge string to position
+BorderEdgePosition edgeStringToPosition(const std::string& edgeStr);
+
+// Utility function to convert border position to string
+std::string edgePositionToString(BorderEdgePosition pos);
+
+// Represents a border item
+struct BorderItem {
+    BorderEdgePosition position;
+    uint16_t itemId;
+    
+    BorderItem() : position(EDGE_NONE), itemId(0) {}
+    BorderItem(BorderEdgePosition pos, uint16_t id) : position(pos), itemId(id) {}
+    
+    bool operator==(const BorderItem& other) const {
+        return position == other.position && itemId == other.itemId;
+    }
+    
+    bool operator!=(const BorderItem& other) const {
+        return !(*this == other);
+    }
+};
+
+// Represents a ground item with chance
+struct GroundItem {
+    uint16_t itemId;
+    int chance;
+    
+    GroundItem() : itemId(0), chance(10) {}
+    GroundItem(uint16_t id, int c) : itemId(id), chance(c) {}
+    
+    bool operator==(const GroundItem& other) const {
+        return itemId == other.itemId && chance == other.chance;
+    }
+    
+    bool operator!=(const GroundItem& other) const {
+        return !(*this == other);
+    }
+};
+
+// Represents a wall type group (e.g., "vertical", "horizontal")
+struct WallTypeData {
+    std::string typeName;
+    std::vector<GroundItem> items; // Reuse GroundItem as it has {itemId, chance}
+};
+
+// Represents a wall item position
+struct WallItem {
+    int x; // Grid X (0-2)
+    int y; // Grid Y (0-2)
+    uint16_t itemId;
+    
+    WallItem() : x(-1), y(-1), itemId(0) {}
+    WallItem(int _x, int _y, uint16_t id) : x(_x), y(_y), itemId(id) {}
+};
+
+// Tree item data to store asset info
+class BorderAssetItemData : public wxTreeItemData {
+public:
+    enum AssetType {
+        FOLDER,
+        BORDER,
+        GROUND,
+        WALL
+    };
+    
+    BorderAssetItemData(AssetType type, int id = 0, const wxString& name = "") 
+        : m_type(type), m_id(id), m_name(name) {}
+        
+    AssetType GetType() const { return m_type; }
+    int GetId() const { return m_id; }
+    wxString GetName() const { return m_name; }
+    
+private:
+    AssetType m_type;
+    int m_id;
+    wxString m_name;
+};
+
+// Represents a single tile in a composite variation
+struct CompositeTile {
+    int x, y;
+    uint16_t itemId;
+
+    bool operator<(const CompositeTile& other) const {
+        if (x != other.x) return x < other.x;
+        return y < other.y;
+    }
+};
+
+// Represents a variation (composite block)
+struct GroundVariation {
+    int chance;
+    std::vector<CompositeTile> tiles;
+    
+    GroundVariation() : chance(10) {}
+};
+
+class SimpleRawPalettePanel;
+
+// Dialog for filtering visible tilesets
+class TilesetFilterDialog : public wxDialog {
+public:
+    TilesetFilterDialog(wxWindow* parent, 
+                       const wxArrayString& allTilesets,
+                       const std::set<wxString>& enabledTilesets,
+                       const wxString& modeLabel);
+    
+    std::set<wxString> GetEnabledTilesets() const;
+    
+private:
+    wxCheckListBox* m_tilesetList;
+    wxArrayString m_allTilesets;
+    
+    void OnSelectAll(wxCommandEvent& event);
+    void OnSelectNone(wxCommandEvent& event);
+    void OnListItemClick(wxCommandEvent& event);
+};
+
+wxDECLARE_EVENT(wxEVT_GROUND_CONTAINER_CHANGE, wxCommandEvent);
+
+// Forward declarations
+class WallGridPanel;
+class WallVisualPanel;
+
+class BrushEditorPanel : public wxPanel {
+public:
+    BrushEditorPanel(wxWindow* parent);
+    virtual ~BrushEditorPanel();
+
+    // Event handlers
+    void OnItemIdChanged(wxCommandEvent& event);
+    void OnPositionSelected(wxCommandEvent& event);
+    void OnAddItem(wxCommandEvent& event);
+    void OnClear(wxCommandEvent& event);
+    void OnSave(wxCommandEvent& event);
+    void OnClose(wxCommandEvent& event);
+    void OnBrowse(wxCommandEvent& event);
+    void OnLoadBorder(wxCommandEvent& event);
+    void OnGridCellClicked(wxMouseEvent& event);
+    void OnWallGridSelect(wxCommandEvent& event);
+    void OnPageChanged(wxBookCtrlEvent& event);
+    void OnAddGroundItem(wxCommandEvent& event);
+    void OnRemoveGroundItem(wxCommandEvent& event);
+    void OnGroundBrowse(wxCommandEvent& event);
+    void OnGroundTilesetSelect(wxCommandEvent& event);
+    
+    // Wall events
+    void OnWallBrowse(wxCommandEvent& event);
+    
+    // Restored Ground events
+    void OnGroundPaletteSelect(wxCommandEvent& event);
+    void OnOpenTilesetFilter(wxCommandEvent& event);
+    void OnGroundGridSelect(wxCommandEvent& event);
+    void OnGroundTilesetListSelect(wxCommandEvent& event);
+
+    
+    // Button + Menu Handlers
+    void OnRawCategoryButtonClick(wxCommandEvent& event);
+    void OnRawCategoryMenuSelect(wxCommandEvent& event);
+    
+    void OnGroundTilesetButtonClick(wxCommandEvent& event);
+    void OnGroundTilesetMenuSelect(wxCommandEvent& event);
+    
+    void OnWallTilesetButtonClick(wxCommandEvent& event);
+    void OnWallTilesetMenuSelect(wxCommandEvent& event);
+    
+    void OnBorderAlignmentButtonClick(wxCommandEvent& event);
+    void OnBorderAlignmentMenuSelect(wxCommandEvent& event);
+    
+    void OnAddWallItem(wxCommandEvent& event);
+    void OnRemoveWallItem(wxCommandEvent& event);
+    
+    // Sidebar events
+    void OnAssetTreeSelection(wxTreeEvent& event);
+    void OnAssetSearch(wxCommandEvent& event);
+    
+    // Browser sidebar events
+    void OnBorderBrowserSelection(wxCommandEvent& event);
+    void OnBrowserGridSelection(wxCommandEvent& event);
+    void OnBrowserSearch(wxCommandEvent& event);
+    void OnBrowserTilesetFilterButtonClick(wxCommandEvent& event);
+    
+    // Mode switcher events
+    void OnModeSwitch(wxCommandEvent& event);
+
+protected:
+    void CreateGUIControls();
+    void LoadExistingBorders();
+    void LoadExistingGroundBrushes();
+    void LoadTilesets();
+    void SaveBorder();
+    void SaveGroundBrush();
+    bool ValidateBorder();
+    void LoadBorderById(int borderId);
+    void LoadGroundBrushByName(const wxString& name);
+    void LoadWallBrushByName(const wxString& name);
+    bool ValidateGroundBrush();
+    bool ValidateWallBrush();
+    void LoadExistingWallBrushes();
+    void SaveWallBrush();
+    void ClearWallItems(bool clearBrowser = true);
+    void UpdateWallItemsList();
+    void UpdatePreview();
+    void ClearItems(bool clearBrowser = true);
+    void ClearGroundItems(bool clearBrowser = true);
+    void UpdateGroundItemsList();
+    
+    // Sidebar helpers
+    void PopulateAssetTree();
+    void FilterAssetTree(const wxString& query);
+    
+    // Browser population methods
+    void PopulateBorderList();
+    void PopulateGroundList();
+    void PopulateWallList();
+    void PopulateUnifiedList();
+    void FilterBrowserList(const wxString& query);
+    void UpdateBrowserLabel();
+    bool RestoreBrowserSelection(const wxString& selectionKey);
+    void ReloadCurrentBrushEditorXml(const wxString& selectionKey);
+
+    void LoadBorderByMainTileId(uint16_t tileId);
+    void LoadGroundBrushByMainTileId(uint16_t tileId);
+    void LoadWallBrushByMainTileId(uint16_t tileId);
+
+private:
+    // ===== State =====
+    int m_maxBorderId;
+    int m_nextBorderId;
+    int m_currentBorderId;  // Currently edited border ID (replaces m_idCtrl)
+    int m_activeTab;        // 0 = border, 1 = ground, 2 = wall
+    uint16_t m_selectedBrowserTileId;
+    
+    // Storage for unfiltered browser list items
+    wxArrayString m_fullBrowserList;
+    wxArrayString m_fullBrowserIds;
+    std::vector<uint16_t> m_fullBrowserPreviewIds;
+    
+    // Animation timer for preview
+    wxTimer* m_previewTimer;
+
+    // ===== UI Controls =====
+    wxSimplebook* m_notebook;
+    
+    // Mode switcher buttons
+    wxToggleButton* m_borderModeBtn;
+    wxToggleButton* m_groundModeBtn;
+    wxToggleButton* m_wallModeBtn;
+    
+    // Common controls
+    wxTextCtrl* m_nameCtrl;
+    wxTextCtrl* m_groundNameCtrl;
+    wxButton* m_newButton;  // "New Border/Ground/Wall" button with dynamic label
+    
+    // Sidebar (Tree view - legacy, may not be used)
+    wxTextCtrl* m_searchCtrl;
+    wxTreeCtrl* m_assetTree;
+    wxTreeItemId m_rootId;
+    wxTreeItemId m_bordersRootId;
+    wxTreeItemId m_groundsRootId;
+    wxTreeItemId m_wallsRootId;
+    
+    // ===== Border Tab =====
+    wxPanel* m_borderPanel;
+    wxListBox* m_borderBrowserList;     // Sidebar browser for existing items (hidden)
+    BrushBrowserGridPanel* m_browserGrid;
+    wxButton* m_browserTilesetFilterButton;
+    wxString m_browserTilesetFilter;
+    wxSearchCtrl* m_browserSearchCtrl;  // Search control for sidebar
+    wxStaticText* m_browserLabel;       // Dynamic label for sidebar
+    wxCheckBox* m_isOptionalCheck;
+    wxCheckBox* m_isGroundCheck;
+    wxCheckBox* m_groupCheck;           // NEW: Replaces m_groupCtrl SpinCtrl
+    BorderGridPanel* m_gridPanel;
+    BorderPreviewPanel* m_previewPanel;
+    // Palette panels
+    SimpleRawPalettePanel* m_itemPalettePanel;
+    SimpleRawPalettePanel* m_groundPalette;     
+    GroundGridContainer* m_groundGridContainer;
+    GroundPreviewPanel* m_groundPreviewPanel; 
+    SimpleRawPalettePanel* m_wallPalette;
+    wxButton* m_wallTilesetButton;
+    
+    // Border items data
+    std::vector<BorderItem> m_borderItems;
+    std::map<BorderEdgePosition, BorderItemButton*> m_borderButtons;
+    
+    // ===== Ground Tab =====
+    wxPanel* m_groundPanel;
+    wxSpinCtrl* m_serverLookIdCtrl;
+    wxSpinCtrl* m_zOrderCtrl;
+    wxButton* m_borderAlignmentButton;
+    wxCheckBox* m_includeToNoneCheck;
+
+    wxCheckBox* m_includeInnerCheck;
+    wxButton* m_groundTilesetButton;
+    wxArrayString m_tilesetListData;
+    wxButton* m_rawCategoryButton;
+    
+    // Button state data
+    wxArrayString m_rawCategoryNames;
+    int m_rawCategorySelection = 0;
+    int m_groundTilesetSelection = 0;
+    int m_wallTilesetSelection = 0;
+    int m_borderAlignmentSelection = 0; // 0=Outer, 1=Inner
+    
+    // Ground items data
+    std::vector<GroundItem> m_groundItems;
+    std::map<wxString, wxString> m_tilesets;
+    long long m_lastInteractionTime;
+    
+    // Composite/Variation support
+    std::vector<GroundVariation> m_groundVariations;
+    int m_currentVariationIndex;
+    
+    void UpdateVariationControls();
+    void RenderCurrentVariation();
+    
+    // Composite/Variation support
+    // UI for Scrollable List of Variations
+    wxScrolledWindow* m_variationsScrolledWindow;
+    wxBoxSizer* m_variationsSizer;
+    class VariationPreviewPanel* m_variationPreview;
+    wxButton* m_addVariationBtn;
+
+    // Helper to rebuild the list UI from m_groundVariations
+    void RebuildVariationsList();
+    void OnRemoveVariationBtn(wxCommandEvent& event); // Handle removal from specific row
+    
+    // Internal helper to add one UI row
+    void AddVariationRow(GroundVariation& variation, int index);
+    
+    void OnPreviewTimer(wxTimerEvent& event);
+    
+    void OnAddVariation(wxCommandEvent& event);
+    
+    // Tileset filter whitelists (per-mode) - only enabled tilesets
+    std::set<wxString> m_borderEnabledTilesets;
+    std::set<wxString> m_groundEnabledTilesets;
+    std::set<wxString> m_wallEnabledTilesets;
+    wxBitmapButton* m_tilesetFilterBtn;  // Filter button
+    
+    // Filter config persistence
+    void SaveFilterConfig();
+    void LoadFilterConfig();
+
+    // BrushPalettePanel* m_groundPalette;  // Removed duplicate
+    
+    // ===== Wall Tab =====
+    wxPanel* m_wallPanel;
+    wxTextCtrl* m_wallNameCtrl; // Added name control for walls
+    wxSpinCtrl* m_wallServerLookIdCtrl;
+    wxSpinCtrl* m_wallGroupCtrl;
+    wxSpinCtrl* m_wallZOrderCtrl;
+    wxSpinCtrl* m_wallItemIdCtrl;
+    wxSpinCtrl* m_wallItemChanceCtrl;
+    wxListBox* m_wallItemsList;
+    wxCheckBox* m_wallIsOptionalCheck;
+    wxCheckBox* m_wallIsGroundCheck;
+    WallVisualPanel* m_wallVisualPanel;
+    WallGridPanel* m_wallGridPanel; // Visual selector for wall types
+    
+    // Wall items data
+    std::map<std::string, WallTypeData> m_wallTypes;
+    wxString m_currentWallType;
+    int m_currentWallItemId = 0; // Stores currently selected palette item ID
+    void OnWallTilesetSelect(wxCommandEvent& event);
+    void OnWallPaletteSelect(wxCommandEvent& event);
+    void OnGroundContainerChange(wxCommandEvent& event);
+
+    DECLARE_EVENT_TABLE()
+};
+
+// Custom button to represent a border item
+class BorderItemButton : public wxButton {
+public:
+    BorderItemButton(wxWindow* parent, BorderEdgePosition position, wxWindowID id = wxID_ANY);
+    virtual ~BorderItemButton();
+    
+    void SetItemId(uint16_t id);
+    uint16_t GetItemId() const { return m_itemId; }
+    BorderEdgePosition GetPosition() const { return m_position; }
+    
+    void OnPaint(wxPaintEvent& event);
+    
+private:
+    uint16_t m_itemId;
+    BorderEdgePosition m_position;
+    
+    DECLARE_EVENT_TABLE()
+};
+
+// Palette Filtering
+enum PaletteFilterMode {
+    FILTER_NONE = 0,
+    FILTER_GROUND = 1,
+    FILTER_WALL = 2
+};
+
+// Grid panel to visually show border item positions
+class SimpleRawPalettePanel : public wxScrolledWindow {
+public:
+    SimpleRawPalettePanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~SimpleRawPalettePanel();
+
+    void LoadTileset(const wxString& categoryName, PaletteFilterMode filterMode = FILTER_NONE);
+    void SetItemIds(const std::vector<uint16_t>& ids);
+    void OnPaint(wxPaintEvent& event);
+    void OnLeftUp(wxMouseEvent& event);
+    void OnMotion(wxMouseEvent& event);
+    void OnLeave(wxMouseEvent& event);
+    void OnSize(wxSizeEvent& event);
+
+private:
+    std::vector<uint16_t> m_itemIds;
+    int m_cols = 1;
+    int m_rows = 1;
+    int m_itemSize = 32;
+    int m_padding = 2;
+    int m_hoverIndex = -1;
+
+    void RecalculateLayout();
+    int HitTest(const wxPoint& pt) const;
+
+    DECLARE_EVENT_TABLE()
+};
+
+// Grid panel to visually show border item positions
+class BorderGridPanel : public wxPanel {
+public:
+    BorderGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~BorderGridPanel();
+    
+    void SetItemId(BorderEdgePosition pos, uint16_t itemId);
+    uint16_t GetItemId(BorderEdgePosition pos) const;
+    void Clear();
+    
+    // Selection management
+    void SetSelectedPosition(BorderEdgePosition pos);
+    BorderEdgePosition GetSelectedPosition() const { return m_selectedPosition; }
+    
+    // Override to ensure correct sizing
+    virtual wxSize DoGetBestSize() const override;
+    
+    void OnPaint(wxPaintEvent& event);
+    void OnMouseClick(wxMouseEvent& event);
+    void OnMouseDown(wxMouseEvent& event);
+    
+    // Made public so it can be accessed from other components
+    wxPoint GetPositionCoordinates(BorderEdgePosition pos) const;
+    BorderEdgePosition GetPositionFromCoordinates(int x, int y) const;
+    
+private:
+    std::map<BorderEdgePosition, uint16_t> m_items;
+    BorderEdgePosition m_selectedPosition;
+    
+    DECLARE_EVENT_TABLE()
+};
+
+// Panel to preview how the border would look
+class BorderPreviewPanel : public wxPanel {
+public:
+    BorderPreviewPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~BorderPreviewPanel();
+    
+    void SetBorderItems(const std::vector<BorderItem>& items);
+    void Clear();
+    
+    void OnPaint(wxPaintEvent& event);
+    
+private:
+    std::vector<BorderItem> m_borderItems;
+    
+    DECLARE_EVENT_TABLE()
+};
+
+// Panel to select wall types (Visual Grid)
+class WallGridPanel : public wxPanel {
+public:
+    WallGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~WallGridPanel();
+    
+    void SetWallTypes(const std::map<std::string, WallTypeData>& types);
+    void SetSelectedType(const std::string& type);
+    std::string GetSelectedType() const { return m_selectedType; }
+    
+    void OnPaint(wxPaintEvent& event);
+    void OnMouseClick(wxMouseEvent& event);
+    
+private:
+    std::map<std::string, WallTypeData> m_types;
+    std::string m_selectedType;
+    
+    DECLARE_EVENT_TABLE()
+};
+
+// Panel to visually edit wall brushes
+class WallVisualPanel : public wxPanel {
+public:
+    WallVisualPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~WallVisualPanel();
+    
+    void SetWallItems(const std::map<std::string, WallTypeData>& items);
+    void Clear();
+    
+    void OnPaint(wxPaintEvent& event);
+    
+private:
+    std::map<std::string, WallTypeData> m_items;
+    
+    DECLARE_EVENT_TABLE()
+};
+
+
+
+// ============================================================================
+// GroundPreviewPanel - Animates and cycles through selected items
+// ============================================================================
+class GroundPreviewPanel : public wxPanel {
+public:
+    GroundPreviewPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~GroundPreviewPanel();
+    
+    void SetWeightedItems(const std::vector<std::pair<uint16_t, int>>& items);
+    void UpdateFromContainer(GroundGridContainer* container);
+
+protected:
+    void OnPaint(wxPaintEvent& event);
+    void OnTimer(wxTimerEvent& event);
+
+private:
+    std::vector<uint16_t> m_displayItems;
+    size_t m_currentIndex;
+    wxTimer m_animationTimer;
+    long m_lastCycleTime;
+    
+    DECLARE_EVENT_TABLE()
+};
+
+// ============================================================================
+// GroundGridPanel (Visual Replica of BorderGridPanel)
+// ============================================================================
+class GroundGridPanel : public wxPanel {
+public:
+    GroundGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~GroundGridPanel();
+    
+    // Item management
+    void SetItemId(uint16_t id);
+    uint16_t GetItemId() const { return m_itemId; }
+    void Clear();
+    bool IsEmpty() const { return m_itemId == 0; }
+    
+    // Event handlers
+    void OnPaint(wxPaintEvent& event);
+    void OnMouseClick(wxMouseEvent& event);
+    void OnRightClick(wxMouseEvent& event);
+    void OnLeftDClick(wxMouseEvent& event);
+    
+    // Layout helper
+    wxSize DoGetBestSize() const override;
+
+    // Selection & Chance
+    void SetSelected(bool selected);
+    bool IsSelected() const { return m_isSelected; }
+    void SetChance(int chance);
+    int GetChance() const { return m_chance; }
+
+private:
+    uint16_t m_itemId;  // Currently assigned item ID
+    int m_chance;       // Spawn chance for this item
+    bool m_isSelected;  // Selection state
+    
+    DECLARE_EVENT_TABLE()
+};
+
+// ============================================================================
+// GroundGridContainer - Manages multiple GroundGridPanel cells with auto-expansion
+// ============================================================================
+class GroundGridContainer : public wxScrolledWindow {
+public:
+    GroundGridContainer(wxWindow* parent, wxWindowID id = wxID_ANY);
+    virtual ~GroundGridContainer();
+    
+    // Item management
+    void AddItem(uint16_t itemId, int chance = 100, bool allowAppend = false);
+    void RemoveCell(GroundGridPanel* cell);
+    void Clear();
+    
+    // Get all filled items
+    std::vector<uint16_t> GetAllItems() const;
+    // Get all items with their chances
+    std::vector<std::pair<uint16_t, int>> GetAllItemsWithChance() const;
+    size_t GetFilledCount() const;
+
+    // Selection
+    void SetSelectedCell(GroundGridPanel* cell);
+    GroundGridPanel* GetSelectedCell() const { return m_selectedCell; }
+    
+    // Called when a cell is filled - auto-adds new empty cell
+    // Called when a cell is filled - auto-adds new empty cell
+    void OnCellFilled(int index);
+    
+    // Make sure there's always one empty cell at the end
+    void EnsureEmptyCell();
+
+    // Adds a new empty cell at the end (explicit "Add variation")
+    void AppendEmptyCell();
+    
+    // Rebuild grid layout after changes
+    void RebuildGrids();
+
+private:
+    std::vector<GroundGridPanel*> m_gridCells;
+    wxBoxSizer* m_gridSizer;
+    GroundGridPanel* m_selectedCell;
+    
+    void CreateNewCell();          // Create a new grid cell
+};
+
+
+#endif // RME_BRUSH_EDITOR_WINDOW_H_

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -25,6 +25,8 @@
 #include <vector>
 #include <map>
 #include <set>
+#include <unordered_map>
+#include <utility>
 #include <wx/treectrl.h>
 #include <wx/checklst.h>
 
@@ -290,6 +292,50 @@ protected:
     void LoadWallBrushByMainTileId(uint16_t tileId);
 
 private:
+    struct BorderDraftState {
+        bool dirty = false;
+        int currentBorderId = 0;
+        wxString name;
+        bool group = false;
+        bool optional = false;
+        bool ground = false;
+        std::vector<BorderItem> items;
+    };
+
+    struct GroundDraftState {
+        bool dirty = false;
+        wxString name;
+        int serverLookId = 0;
+        int zOrder = 0;
+        int borderAlignmentSelection = 0;
+        bool includeToNone = true;
+        bool includeInner = false;
+        std::vector<std::pair<uint16_t, int>> items;
+    };
+
+    struct WallDraftState {
+        bool dirty = false;
+        wxString name;
+        int serverLookId = 0;
+        std::map<std::string, WallTypeData> wallTypes;
+        std::string selectedType;
+    };
+
+    void SaveDraft(int tab, uint16_t tileId, bool markDirty);
+    bool RestoreDraft(int tab, uint16_t tileId);
+    void DiscardDraft(int tab, uint16_t tileId);
+    void SaveCurrentDraft(bool markDirty);
+    void DiscardCurrentDraft();
+
+    void OnBorderDraftChange(wxCommandEvent& event);
+    void OnGroundDraftChange(wxCommandEvent& event);
+    void OnWallDraftChange(wxCommandEvent& event);
+
+    bool m_isRestoringDraft = false;
+    std::unordered_map<uint16_t, BorderDraftState> m_borderDrafts;
+    std::unordered_map<uint16_t, GroundDraftState> m_groundDrafts;
+    std::unordered_map<uint16_t, WallDraftState> m_wallDrafts;
+
     // ===== State =====
     int m_maxBorderId;
     int m_nextBorderId;

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -295,7 +295,7 @@ private:
     struct BorderDraftState {
         bool dirty = false;
         int currentBorderId = 0;
-        wxString name;
+        wxString borderName;
         bool group = false;
         bool optional = false;
         bool ground = false;
@@ -305,7 +305,6 @@ private:
     struct GroundDraftState {
         bool dirty = false;
         wxString name;
-        int serverLookId = 0;
         int zOrder = 0;
         int borderAlignmentSelection = 0;
         bool includeToNone = true;
@@ -315,8 +314,7 @@ private:
 
     struct WallDraftState {
         bool dirty = false;
-        wxString name;
-        int serverLookId = 0;
+        wxString brushName;
         std::map<std::string, WallTypeData> wallTypes;
         std::string selectedType;
     };
@@ -360,9 +358,10 @@ private:
     wxToggleButton* m_wallModeBtn;
     
     // Common controls
-    wxTextCtrl* m_nameCtrl;
     wxTextCtrl* m_groundNameCtrl;
     wxButton* m_newButton;  // "New Border/Ground/Wall" button with dynamic label
+
+    wxString m_loadedBorderName;
     
     // Sidebar (Tree view - legacy, may not be used)
     wxTextCtrl* m_searchCtrl;
@@ -399,7 +398,6 @@ private:
     
     // ===== Ground Tab =====
     wxPanel* m_groundPanel;
-    wxSpinCtrl* m_serverLookIdCtrl;
     wxSpinCtrl* m_zOrderCtrl;
     wxButton* m_borderAlignmentButton;
     wxCheckBox* m_includeToNoneCheck;
@@ -460,8 +458,6 @@ private:
     
     // ===== Wall Tab =====
     wxPanel* m_wallPanel;
-    wxTextCtrl* m_wallNameCtrl; // Added name control for walls
-    wxSpinCtrl* m_wallServerLookIdCtrl;
     wxSpinCtrl* m_wallGroupCtrl;
     wxSpinCtrl* m_wallZOrderCtrl;
     wxSpinCtrl* m_wallItemIdCtrl;

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -29,6 +29,7 @@
 #include <utility>
 #include <wx/treectrl.h>
 #include <wx/checklst.h>
+#include "brush_editor_model.h"
 
 // Forward declarations
 class BorderItemButton;
@@ -249,10 +250,24 @@ public:
 	void OnBorderBrowserSelection(wxCommandEvent &event);
 	void OnBrowserGridSelection(wxCommandEvent &event);
 	void OnBrowserSearch(wxCommandEvent &event);
+	void OnBrowserPaletteCategoryButtonClick(wxCommandEvent &event);
 	void OnBrowserTilesetFilterButtonClick(wxCommandEvent &event);
+	void OnBrowserNewEntity(wxCommandEvent &event);
+	void OnBrowserDuplicateEntity(wxCommandEvent &event);
+	void OnBrowserReloadEntity(wxCommandEvent &event);
+	void OnBrowserDeleteEntity(wxCommandEvent &event);
+	void OnBrowserPaletteSelection(wxCommandEvent &event);
+	void OnBrowserApplyPaletteFilter(wxCommandEvent &event);
+	void OnBrowserViewModeChanged(wxCommandEvent &event);
+	void OnBrowserClearPaletteFilter(wxCommandEvent &event);
+	void OnBrowserAttachPalette(wxCommandEvent &event);
+	void OnBrowserDetachPalette(wxCommandEvent &event);
+	void OnBrowserNewPalette(wxCommandEvent &event);
+	void OnBrowserDeletePalette(wxCommandEvent &event);
 
 	// Mode switcher events
 	void OnModeSwitch(wxCommandEvent &event);
+	void OnInspectorSectionClick(wxCommandEvent &event);
 
 protected:
 	void CreateGUIControls();
@@ -285,8 +300,28 @@ protected:
 	void PopulateGroundList();
 	void PopulateWallList();
 	void PopulateUnifiedList();
+	void CacheBrowserDataForActiveTab();
+	bool RestoreCachedBrowserDataForTab(int tab);
+	bool PopulateUnifiedListFromCatalog();
+	bool PopulatePaletteBrowserListFromCatalog();
+	bool RebuildBrushCatalog();
+	bool EnsureBrushCatalogUpToDate();
+	void MarkBrushCatalogDirty();
 	void FilterBrowserList(const wxString &query);
 	void UpdateBrowserLabel();
+	void UpdateInspectorHeader();
+	void UpdateBrowserViewButtons();
+	void UpdateBrowserActionButtons();
+	void UpdateInspectorSectionButtons();
+	void RefreshBrowserPaletteList();
+	void ApplyBrowserPaletteFilter(const wxString &paletteName);
+	void SetActiveInspectorSection(int section);
+	wxString GetSelectedPaletteKey() const;
+	const BrushEditorPaletteDefinition* FindPaletteDefinitionForLabel(const wxString &paletteLabel) const;
+	wxString FindTilesetSourceFile(const wxString &tilesetName) const;
+	wxString GetCustomPaletteFilePath() const;
+	bool PersistBrushPaletteMembership(const wxString &brushName, const wxString &paletteLabel, bool attach);
+	bool PersistPaletteDefinition(const wxString &tilesetName, TilesetCategoryType categoryType, bool create);
 	bool RestoreBrowserSelection(const wxString &selectionKey);
 	void ReloadCurrentBrushEditorXml(const wxString &selectionKey);
 
@@ -323,10 +358,18 @@ private:
 	};
 
 	void SaveDraft(int tab, uint16_t tileId, bool markDirty);
+	void SaveDraft(int tab, const wxString &brushName, bool markDirty);
 	bool RestoreDraft(int tab, uint16_t tileId);
+	bool RestoreDraft(int tab, const wxString &brushName);
 	void DiscardDraft(int tab, uint16_t tileId);
+	void DiscardDraft(int tab, const wxString &brushName);
 	void SaveCurrentDraft(bool markDirty);
 	void DiscardCurrentDraft();
+	wxString GetSelectionKeyForTab(int tab) const;
+	bool HasSelectionForTab(int tab) const;
+	void SetSelectionKeyForTab(int tab, const wxString &selectionKey);
+	void ClearSelectionForTab(int tab);
+	void LoadSelectionForTab(int tab, const wxString &selectionKey);
 
 	void OnBorderDraftChange(wxCommandEvent &event);
 	void OnGroundDraftChange(wxCommandEvent &event);
@@ -334,8 +377,8 @@ private:
 
 	bool m_isRestoringDraft = false;
 	std::unordered_map<uint16_t, BorderDraftState> m_borderDrafts;
-	std::unordered_map<uint16_t, GroundDraftState> m_groundDrafts;
-	std::unordered_map<uint16_t, WallDraftState> m_wallDrafts;
+	std::map<wxString, GroundDraftState> m_groundDrafts;
+	std::map<wxString, WallDraftState> m_wallDrafts;
 
 	// ===== State =====
 	int m_maxBorderId;
@@ -343,17 +386,45 @@ private:
 	int m_currentBorderId; // Currently edited border ID (replaces m_idCtrl)
 	int m_activeTab; // 0 = border, 1 = ground, 2 = wall
 	uint16_t m_selectedBrowserTileId;
+	wxString m_selectedBrowserBrushName;
+	wxString m_browserSelectionKeys[3];
+	int m_browserViewMode = 0; // 0 = brushes, 1 = palettes
+	int m_activeInspectorSection = 0; // 0 = general, 1 = palettes, 2 = editor, 3 = preview
 
 	// Storage for unfiltered browser list items
 	wxArrayString m_fullBrowserList;
 	wxArrayString m_fullBrowserIds;
 	std::vector<uint16_t> m_fullBrowserPreviewIds;
+	BrushEditorCatalog m_catalog;
+	wxArrayString m_catalogWarnings;
+	bool m_catalogDirty = true;
+	bool m_browserPaletteListDirty = true;
+	int m_browserPaletteListBuiltForTab = -1;
+	wxString m_browserPaletteListBuiltForCategory;
+	wxString m_browserPaletteSelections[3];
+	wxString m_browserTilesetFiltersByTab[3];
+	wxString m_browserPaletteCategoriesByTab[3];
+	wxString m_browserSearchQueriesByTab[3];
+	wxArrayString m_cachedBrowserLists[3];
+	wxArrayString m_cachedBrowserIds[3];
+	std::vector<uint16_t> m_cachedBrowserPreviewIds[3];
+	bool m_tabInitialized[3] = { false, false, false };
 
 	// Animation timer for preview
 	wxTimer* m_previewTimer;
 
 	// ===== UI Controls =====
 	wxSimplebook* m_notebook;
+	wxStaticText* m_inspectorTitleLabel;
+	wxStaticText* m_inspectorMetaLabel;
+	wxButton* m_inspectorGeneralButton;
+	wxButton* m_inspectorPaletteButton;
+	wxButton* m_inspectorEditorButton;
+	wxButton* m_inspectorPreviewButton;
+	wxStaticText* m_inspectorGeneralStateLabel;
+	wxStaticText* m_inspectorPalettesStateLabel;
+	wxStaticText* m_inspectorFlagsStateLabel;
+	wxStaticText* m_inspectorAdvancedStateLabel;
 
 	// Mode switcher buttons
 	wxToggleButton* m_borderModeBtn;
@@ -362,6 +433,7 @@ private:
 
 	// Common controls
 	wxTextCtrl* m_groundNameCtrl;
+	wxTextCtrl* m_wallNameCtrl;
 	wxButton* m_newButton; // "New Border/Ground/Wall" button with dynamic label
 
 	wxString m_loadedBorderName;
@@ -378,10 +450,27 @@ private:
 	wxPanel* m_borderPanel;
 	wxListBox* m_borderBrowserList; // Sidebar browser for existing items (hidden)
 	BrushBrowserGridPanel* m_browserGrid;
+	wxButton* m_browserPaletteCategoryButton;
 	wxButton* m_browserTilesetFilterButton;
+	wxString m_browserPaletteCategoryFilter;
 	wxString m_browserTilesetFilter;
+	wxToggleButton* m_browserBrushesViewBtn;
+	wxToggleButton* m_browserPalettesViewBtn;
 	wxSearchCtrl* m_browserSearchCtrl; // Search control for sidebar
-	wxStaticText* m_browserLabel; // Dynamic label for sidebar
+	wxStaticText* m_browserLabel; // Selection title in browser sidebar
+	wxStaticText* m_browserMetaLabel; // Selection meta in browser sidebar
+	wxButton* m_browserNewEntityButton;
+	wxButton* m_browserDuplicateButton;
+	wxButton* m_browserDeleteButton;
+	wxButton* m_browserSaveButton;
+	wxButton* m_browserReloadButton;
+	wxListBox* m_browserPaletteList;
+	wxButton* m_browserNewPaletteButton;
+	wxButton* m_browserDeletePaletteButton;
+	wxButton* m_browserAttachPaletteButton;
+	wxButton* m_browserDetachPaletteButton;
+	wxButton* m_browserApplyPaletteFilterButton;
+	wxButton* m_browserClearPaletteFilterButton;
 	wxCheckBox* m_isOptionalCheck;
 	wxCheckBox* m_isGroundCheck;
 	wxCheckBox* m_groupCheck; // NEW: Replaces m_groupCtrl SpinCtrl
@@ -550,6 +639,8 @@ private:
 	int m_itemSize = 32;
 	int m_padding = 2;
 	int m_hoverIndex = -1;
+	wxString m_loadedCategoryName;
+	PaletteFilterMode m_loadedFilterMode = FILTER_NONE;
 
 	void RecalculateLayout();
 	int HitTest(const wxPoint &pt) const;

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -465,6 +465,15 @@ private:
 	void LogError(const wxString &message, ErrorSeverity severity);
 	void ShowErrorDialog(const wxString &message, ErrorSeverity severity);
 
+	// XML Cache
+	struct XmlCacheEntry {
+		pugi::xml_document doc;
+		wxDateTime lastModified;
+	};
+	std::unordered_map<wxString, XmlCacheEntry> m_xmlCache;
+	bool LoadXmlWithCache(const wxString &path, pugi::xml_document &doc);
+	void InvalidateXmlCache(const wxString &path);
+
 	// BrushPalettePanel* m_groundPalette;  // Removed duplicate
 
 	// ===== Wall Tab =====

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -43,124 +43,131 @@ class BrushBrowserGridPanel;
 
 // Represents a border edge position
 enum BorderEdgePosition {
-    EDGE_NONE = -1,
-    EDGE_N,   // North
-    EDGE_E,   // East
-    EDGE_S,   // South
-    EDGE_W,   // West
-    EDGE_CNW, // Corner Northwest
-    EDGE_CNE, // Corner Northeast
-    EDGE_CSE, // Corner Southeast
-    EDGE_CSW, // Corner Southwest
-    EDGE_DNW, // Diagonal Northwest
-    EDGE_DNE, // Diagonal Northeast
-    EDGE_DSE, // Diagonal Southeast
-    EDGE_DSW, // Diagonal Southwest
-    EDGE_COUNT
+	EDGE_NONE = -1,
+	EDGE_N, // North
+	EDGE_E, // East
+	EDGE_S, // South
+	EDGE_W, // West
+	EDGE_CNW, // Corner Northwest
+	EDGE_CNE, // Corner Northeast
+	EDGE_CSE, // Corner Southeast
+	EDGE_CSW, // Corner Southwest
+	EDGE_DNW, // Diagonal Northwest
+	EDGE_DNE, // Diagonal Northeast
+	EDGE_DSE, // Diagonal Southeast
+	EDGE_DSW, // Diagonal Southwest
+	EDGE_COUNT
 };
 
 // Alignment options for borders
 enum BorderAlignment {
-    ALIGN_OUTER,
-    ALIGN_INNER
+	ALIGN_OUTER,
+	ALIGN_INNER
 };
 
 // Utility function to convert border edge string to position
-BorderEdgePosition edgeStringToPosition(const std::string& edgeStr);
+BorderEdgePosition edgeStringToPosition(const std::string &edgeStr);
 
 // Utility function to convert border position to string
 std::string edgePositionToString(BorderEdgePosition pos);
 
 // Represents a border item
 struct BorderItem {
-    BorderEdgePosition position;
-    uint16_t itemId;
-    
-    BorderItem() : position(EDGE_NONE), itemId(0) {}
-    BorderItem(BorderEdgePosition pos, uint16_t id) : position(pos), itemId(id) {}
-    
-    bool operator==(const BorderItem& other) const {
-        return position == other.position && itemId == other.itemId;
-    }
-    
-    bool operator!=(const BorderItem& other) const {
-        return !(*this == other);
-    }
+	BorderEdgePosition position;
+	uint16_t itemId;
+
+	BorderItem() : position(EDGE_NONE), itemId(0) { }
+	BorderItem(BorderEdgePosition pos, uint16_t id) : position(pos), itemId(id) { }
+
+	bool operator==(const BorderItem &other) const {
+		return position == other.position && itemId == other.itemId;
+	}
+
+	bool operator!=(const BorderItem &other) const {
+		return !(*this == other);
+	}
 };
 
 // Represents a ground item with chance
 struct GroundItem {
-    uint16_t itemId;
-    int chance;
-    
-    GroundItem() : itemId(0), chance(10) {}
-    GroundItem(uint16_t id, int c) : itemId(id), chance(c) {}
-    
-    bool operator==(const GroundItem& other) const {
-        return itemId == other.itemId && chance == other.chance;
-    }
-    
-    bool operator!=(const GroundItem& other) const {
-        return !(*this == other);
-    }
+	uint16_t itemId;
+	int chance;
+
+	GroundItem() : itemId(0), chance(10) { }
+	GroundItem(uint16_t id, int c) : itemId(id), chance(c) { }
+
+	bool operator==(const GroundItem &other) const {
+		return itemId == other.itemId && chance == other.chance;
+	}
+
+	bool operator!=(const GroundItem &other) const {
+		return !(*this == other);
+	}
 };
 
 // Represents a wall type group (e.g., "vertical", "horizontal")
 struct WallTypeData {
-    std::string typeName;
-    std::vector<GroundItem> items; // Reuse GroundItem as it has {itemId, chance}
+	std::string typeName;
+	std::vector<GroundItem> items; // Reuse GroundItem as it has {itemId, chance}
 };
 
 // Represents a wall item position
 struct WallItem {
-    int x; // Grid X (0-2)
-    int y; // Grid Y (0-2)
-    uint16_t itemId;
-    
-    WallItem() : x(-1), y(-1), itemId(0) {}
-    WallItem(int _x, int _y, uint16_t id) : x(_x), y(_y), itemId(id) {}
+	int x; // Grid X (0-2)
+	int y; // Grid Y (0-2)
+	uint16_t itemId;
+
+	WallItem() : x(-1), y(-1), itemId(0) { }
+	WallItem(int _x, int _y, uint16_t id) : x(_x), y(_y), itemId(id) { }
 };
 
 // Tree item data to store asset info
 class BorderAssetItemData : public wxTreeItemData {
 public:
-    enum AssetType {
-        FOLDER,
-        BORDER,
-        GROUND,
-        WALL
-    };
-    
-    BorderAssetItemData(AssetType type, int id = 0, const wxString& name = "") 
-        : m_type(type), m_id(id), m_name(name) {}
-        
-    AssetType GetType() const { return m_type; }
-    int GetId() const { return m_id; }
-    wxString GetName() const { return m_name; }
-    
+	enum AssetType {
+		FOLDER,
+		BORDER,
+		GROUND,
+		WALL
+	};
+
+	BorderAssetItemData(AssetType type, int id = 0, const wxString &name = "") : m_type(type), m_id(id), m_name(name) { }
+
+	AssetType GetType() const {
+		return m_type;
+	}
+	int GetId() const {
+		return m_id;
+	}
+	wxString GetName() const {
+		return m_name;
+	}
+
 private:
-    AssetType m_type;
-    int m_id;
-    wxString m_name;
+	AssetType m_type;
+	int m_id;
+	wxString m_name;
 };
 
 // Represents a single tile in a composite variation
 struct CompositeTile {
-    int x, y;
-    uint16_t itemId;
+	int x, y;
+	uint16_t itemId;
 
-    bool operator<(const CompositeTile& other) const {
-        if (x != other.x) return x < other.x;
-        return y < other.y;
-    }
+	bool operator<(const CompositeTile &other) const {
+		if (x != other.x) {
+			return x < other.x;
+		}
+		return y < other.y;
+	}
 };
 
 // Represents a variation (composite block)
 struct GroundVariation {
-    int chance;
-    std::vector<CompositeTile> tiles;
-    
-    GroundVariation() : chance(10) {}
+	int chance;
+	std::vector<CompositeTile> tiles;
+
+	GroundVariation() : chance(10) { }
 };
 
 class SimpleRawPalettePanel;
@@ -168,20 +175,17 @@ class SimpleRawPalettePanel;
 // Dialog for filtering visible tilesets
 class TilesetFilterDialog : public wxDialog {
 public:
-    TilesetFilterDialog(wxWindow* parent, 
-                       const wxArrayString& allTilesets,
-                       const std::set<wxString>& enabledTilesets,
-                       const wxString& modeLabel);
-    
-    std::set<wxString> GetEnabledTilesets() const;
-    
+	TilesetFilterDialog(wxWindow* parent, const wxArrayString &allTilesets, const std::set<wxString> &enabledTilesets, const wxString &modeLabel);
+
+	std::set<wxString> GetEnabledTilesets() const;
+
 private:
-    wxCheckListBox* m_tilesetList;
-    wxArrayString m_allTilesets;
-    
-    void OnSelectAll(wxCommandEvent& event);
-    void OnSelectNone(wxCommandEvent& event);
-    void OnListItemClick(wxCommandEvent& event);
+	wxCheckListBox* m_tilesetList;
+	wxArrayString m_allTilesets;
+
+	void OnSelectAll(wxCommandEvent &event);
+	void OnSelectNone(wxCommandEvent &event);
+	void OnListItemClick(wxCommandEvent &event);
 };
 
 wxDECLARE_EVENT(wxEVT_GROUND_CONTAINER_CHANGE, wxCommandEvent);
@@ -192,457 +196,470 @@ class WallVisualPanel;
 
 class BrushEditorPanel : public wxPanel {
 public:
-    BrushEditorPanel(wxWindow* parent);
-    virtual ~BrushEditorPanel();
+	BrushEditorPanel(wxWindow* parent);
+	virtual ~BrushEditorPanel();
 
-    // Event handlers
-    void OnItemIdChanged(wxCommandEvent& event);
-    void OnPositionSelected(wxCommandEvent& event);
-    void OnAddItem(wxCommandEvent& event);
-    void OnClear(wxCommandEvent& event);
-    void OnSave(wxCommandEvent& event);
-    void OnClose(wxCommandEvent& event);
-    void OnBrowse(wxCommandEvent& event);
-    void OnLoadBorder(wxCommandEvent& event);
-    void OnGridCellClicked(wxMouseEvent& event);
-    void OnWallGridSelect(wxCommandEvent& event);
-    void OnPageChanged(wxBookCtrlEvent& event);
-    void OnAddGroundItem(wxCommandEvent& event);
-    void OnRemoveGroundItem(wxCommandEvent& event);
-    void OnGroundBrowse(wxCommandEvent& event);
-    void OnGroundTilesetSelect(wxCommandEvent& event);
-    
-    // Wall events
-    void OnWallBrowse(wxCommandEvent& event);
-    
-    // Restored Ground events
-    void OnGroundPaletteSelect(wxCommandEvent& event);
-    void OnOpenTilesetFilter(wxCommandEvent& event);
-    void OnGroundGridSelect(wxCommandEvent& event);
-    void OnGroundTilesetListSelect(wxCommandEvent& event);
+	// Event handlers
+	void OnItemIdChanged(wxCommandEvent &event);
+	void OnPositionSelected(wxCommandEvent &event);
+	void OnAddItem(wxCommandEvent &event);
+	void OnClear(wxCommandEvent &event);
+	void OnSave(wxCommandEvent &event);
+	void OnClose(wxCommandEvent &event);
+	void OnBrowse(wxCommandEvent &event);
+	void OnLoadBorder(wxCommandEvent &event);
+	void OnGridCellClicked(wxMouseEvent &event);
+	void OnWallGridSelect(wxCommandEvent &event);
+	void OnPageChanged(wxBookCtrlEvent &event);
+	void OnAddGroundItem(wxCommandEvent &event);
+	void OnRemoveGroundItem(wxCommandEvent &event);
+	void OnGroundBrowse(wxCommandEvent &event);
+	void OnGroundTilesetSelect(wxCommandEvent &event);
 
-    
-    // Button + Menu Handlers
-    void OnRawCategoryButtonClick(wxCommandEvent& event);
-    void OnRawCategoryMenuSelect(wxCommandEvent& event);
-    
-    void OnGroundTilesetButtonClick(wxCommandEvent& event);
-    void OnGroundTilesetMenuSelect(wxCommandEvent& event);
-    
-    void OnWallTilesetButtonClick(wxCommandEvent& event);
-    void OnWallTilesetMenuSelect(wxCommandEvent& event);
-    
-    void OnBorderAlignmentButtonClick(wxCommandEvent& event);
-    void OnBorderAlignmentMenuSelect(wxCommandEvent& event);
-    
-    void OnAddWallItem(wxCommandEvent& event);
-    void OnRemoveWallItem(wxCommandEvent& event);
-    
-    // Sidebar events
-    void OnAssetTreeSelection(wxTreeEvent& event);
-    void OnAssetSearch(wxCommandEvent& event);
-    
-    // Browser sidebar events
-    void OnBorderBrowserSelection(wxCommandEvent& event);
-    void OnBrowserGridSelection(wxCommandEvent& event);
-    void OnBrowserSearch(wxCommandEvent& event);
-    void OnBrowserTilesetFilterButtonClick(wxCommandEvent& event);
-    
-    // Mode switcher events
-    void OnModeSwitch(wxCommandEvent& event);
+	// Wall events
+	void OnWallBrowse(wxCommandEvent &event);
+
+	// Restored Ground events
+	void OnGroundPaletteSelect(wxCommandEvent &event);
+	void OnOpenTilesetFilter(wxCommandEvent &event);
+	void OnGroundGridSelect(wxCommandEvent &event);
+	void OnGroundTilesetListSelect(wxCommandEvent &event);
+
+	// Button + Menu Handlers
+	void OnRawCategoryButtonClick(wxCommandEvent &event);
+	void OnRawCategoryMenuSelect(wxCommandEvent &event);
+
+	void OnGroundTilesetButtonClick(wxCommandEvent &event);
+	void OnGroundTilesetMenuSelect(wxCommandEvent &event);
+
+	void OnWallTilesetButtonClick(wxCommandEvent &event);
+	void OnWallTilesetMenuSelect(wxCommandEvent &event);
+
+	void OnBorderAlignmentButtonClick(wxCommandEvent &event);
+	void OnBorderAlignmentMenuSelect(wxCommandEvent &event);
+
+	void OnAddWallItem(wxCommandEvent &event);
+	void OnRemoveWallItem(wxCommandEvent &event);
+
+	// Sidebar events
+	void OnAssetTreeSelection(wxTreeEvent &event);
+	void OnAssetSearch(wxCommandEvent &event);
+
+	// Browser sidebar events
+	void OnBorderBrowserSelection(wxCommandEvent &event);
+	void OnBrowserGridSelection(wxCommandEvent &event);
+	void OnBrowserSearch(wxCommandEvent &event);
+	void OnBrowserTilesetFilterButtonClick(wxCommandEvent &event);
+
+	// Mode switcher events
+	void OnModeSwitch(wxCommandEvent &event);
 
 protected:
-    void CreateGUIControls();
-    void LoadExistingBorders();
-    void LoadExistingGroundBrushes();
-    void LoadTilesets();
-    void SaveBorder();
-    void SaveGroundBrush();
-    bool ValidateBorder();
-    void LoadBorderById(int borderId);
-    void LoadGroundBrushByName(const wxString& name);
-    void LoadWallBrushByName(const wxString& name);
-    bool ValidateGroundBrush();
-    bool ValidateWallBrush();
-    void LoadExistingWallBrushes();
-    void SaveWallBrush();
-    void ClearWallItems(bool clearBrowser = true);
-    void UpdateWallItemsList();
-    void UpdatePreview();
-    void ClearItems(bool clearBrowser = true);
-    void ClearGroundItems(bool clearBrowser = true);
-    void UpdateGroundItemsList();
-    
-    // Sidebar helpers
-    void PopulateAssetTree();
-    void FilterAssetTree(const wxString& query);
-    
-    // Browser population methods
-    void PopulateBorderList();
-    void PopulateGroundList();
-    void PopulateWallList();
-    void PopulateUnifiedList();
-    void FilterBrowserList(const wxString& query);
-    void UpdateBrowserLabel();
-    bool RestoreBrowserSelection(const wxString& selectionKey);
-    void ReloadCurrentBrushEditorXml(const wxString& selectionKey);
+	void CreateGUIControls();
+	void LoadExistingBorders();
+	void LoadExistingGroundBrushes();
+	void LoadTilesets();
+	void SaveBorder();
+	void SaveGroundBrush();
+	bool ValidateBorder();
+	void LoadBorderById(int borderId);
+	void LoadGroundBrushByName(const wxString &name);
+	void LoadWallBrushByName(const wxString &name);
+	bool ValidateGroundBrush();
+	bool ValidateWallBrush();
+	void LoadExistingWallBrushes();
+	void SaveWallBrush();
+	void ClearWallItems(bool clearBrowser = true);
+	void UpdateWallItemsList();
+	void UpdatePreview();
+	void ClearItems(bool clearBrowser = true);
+	void ClearGroundItems(bool clearBrowser = true);
+	void UpdateGroundItemsList();
 
-    void LoadBorderByMainTileId(uint16_t tileId);
-    void LoadGroundBrushByMainTileId(uint16_t tileId);
-    void LoadWallBrushByMainTileId(uint16_t tileId);
+	// Sidebar helpers
+	void PopulateAssetTree();
+	void FilterAssetTree(const wxString &query);
+
+	// Browser population methods
+	void PopulateBorderList();
+	void PopulateGroundList();
+	void PopulateWallList();
+	void PopulateUnifiedList();
+	void FilterBrowserList(const wxString &query);
+	void UpdateBrowserLabel();
+	bool RestoreBrowserSelection(const wxString &selectionKey);
+	void ReloadCurrentBrushEditorXml(const wxString &selectionKey);
+
+	void LoadBorderByMainTileId(uint16_t tileId);
+	void LoadGroundBrushByMainTileId(uint16_t tileId);
+	void LoadWallBrushByMainTileId(uint16_t tileId);
 
 private:
-    struct BorderDraftState {
-        bool dirty = false;
-        int currentBorderId = 0;
-        wxString borderName;
-        bool group = false;
-        bool optional = false;
-        bool ground = false;
-        std::vector<BorderItem> items;
-    };
+	struct BorderDraftState {
+		bool dirty = false;
+		int currentBorderId = 0;
+		wxString borderName;
+		bool group = false;
+		bool optional = false;
+		bool ground = false;
+		std::vector<BorderItem> items;
+	};
 
-    struct GroundDraftState {
-        bool dirty = false;
-        wxString name;
-        int zOrder = 0;
-        int borderAlignmentSelection = 0;
-        bool includeToNone = true;
-        bool includeInner = false;
-        std::vector<std::pair<uint16_t, int>> items;
-    };
+	struct GroundDraftState {
+		bool dirty = false;
+		wxString name;
+		int zOrder = 0;
+		int borderAlignmentSelection = 0;
+		bool includeToNone = true;
+		bool includeInner = false;
+		std::vector<std::pair<uint16_t, int>> items;
+	};
 
-    struct WallDraftState {
-        bool dirty = false;
-        wxString brushName;
-        std::map<std::string, WallTypeData> wallTypes;
-        std::string selectedType;
-    };
+	struct WallDraftState {
+		bool dirty = false;
+		wxString brushName;
+		std::map<std::string, WallTypeData> wallTypes;
+		std::string selectedType;
+	};
 
-    void SaveDraft(int tab, uint16_t tileId, bool markDirty);
-    bool RestoreDraft(int tab, uint16_t tileId);
-    void DiscardDraft(int tab, uint16_t tileId);
-    void SaveCurrentDraft(bool markDirty);
-    void DiscardCurrentDraft();
+	void SaveDraft(int tab, uint16_t tileId, bool markDirty);
+	bool RestoreDraft(int tab, uint16_t tileId);
+	void DiscardDraft(int tab, uint16_t tileId);
+	void SaveCurrentDraft(bool markDirty);
+	void DiscardCurrentDraft();
 
-    void OnBorderDraftChange(wxCommandEvent& event);
-    void OnGroundDraftChange(wxCommandEvent& event);
-    void OnWallDraftChange(wxCommandEvent& event);
+	void OnBorderDraftChange(wxCommandEvent &event);
+	void OnGroundDraftChange(wxCommandEvent &event);
+	void OnWallDraftChange(wxCommandEvent &event);
 
-    bool m_isRestoringDraft = false;
-    std::unordered_map<uint16_t, BorderDraftState> m_borderDrafts;
-    std::unordered_map<uint16_t, GroundDraftState> m_groundDrafts;
-    std::unordered_map<uint16_t, WallDraftState> m_wallDrafts;
+	bool m_isRestoringDraft = false;
+	std::unordered_map<uint16_t, BorderDraftState> m_borderDrafts;
+	std::unordered_map<uint16_t, GroundDraftState> m_groundDrafts;
+	std::unordered_map<uint16_t, WallDraftState> m_wallDrafts;
 
-    // ===== State =====
-    int m_maxBorderId;
-    int m_nextBorderId;
-    int m_currentBorderId;  // Currently edited border ID (replaces m_idCtrl)
-    int m_activeTab;        // 0 = border, 1 = ground, 2 = wall
-    uint16_t m_selectedBrowserTileId;
-    
-    // Storage for unfiltered browser list items
-    wxArrayString m_fullBrowserList;
-    wxArrayString m_fullBrowserIds;
-    std::vector<uint16_t> m_fullBrowserPreviewIds;
-    
-    // Animation timer for preview
-    wxTimer* m_previewTimer;
+	// ===== State =====
+	int m_maxBorderId;
+	int m_nextBorderId;
+	int m_currentBorderId; // Currently edited border ID (replaces m_idCtrl)
+	int m_activeTab; // 0 = border, 1 = ground, 2 = wall
+	uint16_t m_selectedBrowserTileId;
 
-    // ===== UI Controls =====
-    wxSimplebook* m_notebook;
-    
-    // Mode switcher buttons
-    wxToggleButton* m_borderModeBtn;
-    wxToggleButton* m_groundModeBtn;
-    wxToggleButton* m_wallModeBtn;
-    
-    // Common controls
-    wxTextCtrl* m_groundNameCtrl;
-    wxButton* m_newButton;  // "New Border/Ground/Wall" button with dynamic label
+	// Storage for unfiltered browser list items
+	wxArrayString m_fullBrowserList;
+	wxArrayString m_fullBrowserIds;
+	std::vector<uint16_t> m_fullBrowserPreviewIds;
 
-    wxString m_loadedBorderName;
-    
-    // Sidebar (Tree view - legacy, may not be used)
-    wxTextCtrl* m_searchCtrl;
-    wxTreeCtrl* m_assetTree;
-    wxTreeItemId m_rootId;
-    wxTreeItemId m_bordersRootId;
-    wxTreeItemId m_groundsRootId;
-    wxTreeItemId m_wallsRootId;
-    
-    // ===== Border Tab =====
-    wxPanel* m_borderPanel;
-    wxListBox* m_borderBrowserList;     // Sidebar browser for existing items (hidden)
-    BrushBrowserGridPanel* m_browserGrid;
-    wxButton* m_browserTilesetFilterButton;
-    wxString m_browserTilesetFilter;
-    wxSearchCtrl* m_browserSearchCtrl;  // Search control for sidebar
-    wxStaticText* m_browserLabel;       // Dynamic label for sidebar
-    wxCheckBox* m_isOptionalCheck;
-    wxCheckBox* m_isGroundCheck;
-    wxCheckBox* m_groupCheck;           // NEW: Replaces m_groupCtrl SpinCtrl
-    BorderGridPanel* m_gridPanel;
-    BorderPreviewPanel* m_previewPanel;
-    // Palette panels
-    SimpleRawPalettePanel* m_itemPalettePanel;
-    SimpleRawPalettePanel* m_groundPalette;     
-    GroundGridContainer* m_groundGridContainer;
-    GroundPreviewPanel* m_groundPreviewPanel; 
-    SimpleRawPalettePanel* m_wallPalette;
-    wxButton* m_wallTilesetButton;
-    
-    // Border items data
-    std::vector<BorderItem> m_borderItems;
-    std::map<BorderEdgePosition, BorderItemButton*> m_borderButtons;
-    
-    // ===== Ground Tab =====
-    wxPanel* m_groundPanel;
-    wxSpinCtrl* m_zOrderCtrl;
-    wxButton* m_borderAlignmentButton;
-    wxCheckBox* m_includeToNoneCheck;
+	// Animation timer for preview
+	wxTimer* m_previewTimer;
 
-    wxCheckBox* m_includeInnerCheck;
-    wxButton* m_groundTilesetButton;
-    wxArrayString m_tilesetListData;
-    wxButton* m_rawCategoryButton;
-    
-    // Button state data
-    wxArrayString m_rawCategoryNames;
-    int m_rawCategorySelection = 0;
-    int m_groundTilesetSelection = 0;
-    int m_wallTilesetSelection = 0;
-    int m_borderAlignmentSelection = 0; // 0=Outer, 1=Inner
-    
-    // Ground items data
-    std::vector<GroundItem> m_groundItems;
-    std::map<wxString, wxString> m_tilesets;
-    long long m_lastInteractionTime;
-    
-    // Composite/Variation support
-    std::vector<GroundVariation> m_groundVariations;
-    int m_currentVariationIndex;
-    
-    void UpdateVariationControls();
-    void RenderCurrentVariation();
-    
-    // Composite/Variation support
-    // UI for Scrollable List of Variations
-    wxScrolledWindow* m_variationsScrolledWindow;
-    wxBoxSizer* m_variationsSizer;
-    class VariationPreviewPanel* m_variationPreview;
-    wxButton* m_addVariationBtn;
+	// ===== UI Controls =====
+	wxSimplebook* m_notebook;
 
-    // Helper to rebuild the list UI from m_groundVariations
-    void RebuildVariationsList();
-    void OnRemoveVariationBtn(wxCommandEvent& event); // Handle removal from specific row
-    
-    // Internal helper to add one UI row
-    void AddVariationRow(GroundVariation& variation, int index);
-    
-    void OnPreviewTimer(wxTimerEvent& event);
-    
-    void OnAddVariation(wxCommandEvent& event);
-    
-    // Tileset filter whitelists (per-mode) - only enabled tilesets
-    std::set<wxString> m_borderEnabledTilesets;
-    std::set<wxString> m_groundEnabledTilesets;
-    std::set<wxString> m_wallEnabledTilesets;
-    wxBitmapButton* m_tilesetFilterBtn;  // Filter button
-    
-    // Filter config persistence
-    void SaveFilterConfig();
-    void LoadFilterConfig();
+	// Mode switcher buttons
+	wxToggleButton* m_borderModeBtn;
+	wxToggleButton* m_groundModeBtn;
+	wxToggleButton* m_wallModeBtn;
 
-    // BrushPalettePanel* m_groundPalette;  // Removed duplicate
-    
-    // ===== Wall Tab =====
-    wxPanel* m_wallPanel;
-    wxSpinCtrl* m_wallGroupCtrl;
-    wxSpinCtrl* m_wallZOrderCtrl;
-    wxSpinCtrl* m_wallItemIdCtrl;
-    wxSpinCtrl* m_wallItemChanceCtrl;
-    wxListBox* m_wallItemsList;
-    wxCheckBox* m_wallIsOptionalCheck;
-    wxCheckBox* m_wallIsGroundCheck;
-    WallVisualPanel* m_wallVisualPanel;
-    WallGridPanel* m_wallGridPanel; // Visual selector for wall types
-    
-    // Wall items data
-    std::map<std::string, WallTypeData> m_wallTypes;
-    wxString m_currentWallType;
-    int m_currentWallItemId = 0; // Stores currently selected palette item ID
-    void OnWallTilesetSelect(wxCommandEvent& event);
-    void OnWallPaletteSelect(wxCommandEvent& event);
-    void OnGroundContainerChange(wxCommandEvent& event);
+	// Common controls
+	wxTextCtrl* m_groundNameCtrl;
+	wxButton* m_newButton; // "New Border/Ground/Wall" button with dynamic label
 
-    DECLARE_EVENT_TABLE()
+	wxString m_loadedBorderName;
+
+	// Sidebar (Tree view - legacy, may not be used)
+	wxTextCtrl* m_searchCtrl;
+	wxTreeCtrl* m_assetTree;
+	wxTreeItemId m_rootId;
+	wxTreeItemId m_bordersRootId;
+	wxTreeItemId m_groundsRootId;
+	wxTreeItemId m_wallsRootId;
+
+	// ===== Border Tab =====
+	wxPanel* m_borderPanel;
+	wxListBox* m_borderBrowserList; // Sidebar browser for existing items (hidden)
+	BrushBrowserGridPanel* m_browserGrid;
+	wxButton* m_browserTilesetFilterButton;
+	wxString m_browserTilesetFilter;
+	wxSearchCtrl* m_browserSearchCtrl; // Search control for sidebar
+	wxStaticText* m_browserLabel; // Dynamic label for sidebar
+	wxCheckBox* m_isOptionalCheck;
+	wxCheckBox* m_isGroundCheck;
+	wxCheckBox* m_groupCheck; // NEW: Replaces m_groupCtrl SpinCtrl
+	BorderGridPanel* m_gridPanel;
+	BorderPreviewPanel* m_previewPanel;
+	// Palette panels
+	SimpleRawPalettePanel* m_itemPalettePanel;
+	SimpleRawPalettePanel* m_groundPalette;
+	GroundGridContainer* m_groundGridContainer;
+	GroundPreviewPanel* m_groundPreviewPanel;
+	SimpleRawPalettePanel* m_wallPalette;
+	wxButton* m_wallTilesetButton;
+
+	// Border items data
+	std::vector<BorderItem> m_borderItems;
+	std::map<BorderEdgePosition, BorderItemButton*> m_borderButtons;
+
+	// ===== Ground Tab =====
+	wxPanel* m_groundPanel;
+	wxSpinCtrl* m_zOrderCtrl;
+	wxButton* m_borderAlignmentButton;
+	wxCheckBox* m_includeToNoneCheck;
+
+	wxCheckBox* m_includeInnerCheck;
+	wxButton* m_groundTilesetButton;
+	wxArrayString m_tilesetListData;
+	wxButton* m_rawCategoryButton;
+
+	// Button state data
+	wxArrayString m_rawCategoryNames;
+	int m_rawCategorySelection = 0;
+	int m_groundTilesetSelection = 0;
+	int m_wallTilesetSelection = 0;
+	int m_borderAlignmentSelection = 0; // 0=Outer, 1=Inner
+
+	// Ground items data
+	std::vector<GroundItem> m_groundItems;
+	std::map<wxString, wxString> m_tilesets;
+	long long m_lastInteractionTime;
+
+	// Composite/Variation support
+	std::vector<GroundVariation> m_groundVariations;
+	int m_currentVariationIndex;
+
+	void UpdateVariationControls();
+	void RenderCurrentVariation();
+
+	// Composite/Variation support
+	// UI for Scrollable List of Variations
+	wxScrolledWindow* m_variationsScrolledWindow;
+	wxBoxSizer* m_variationsSizer;
+	class VariationPreviewPanel* m_variationPreview;
+	wxButton* m_addVariationBtn;
+
+	// Helper to rebuild the list UI from m_groundVariations
+	void RebuildVariationsList();
+	void OnRemoveVariationBtn(wxCommandEvent &event); // Handle removal from specific row
+
+	// Internal helper to add one UI row
+	void AddVariationRow(GroundVariation &variation, int index);
+
+	void OnPreviewTimer(wxTimerEvent &event);
+
+	void OnAddVariation(wxCommandEvent &event);
+
+	// Tileset filter whitelists (per-mode) - only enabled tilesets
+	std::set<wxString> m_borderEnabledTilesets;
+	std::set<wxString> m_groundEnabledTilesets;
+	std::set<wxString> m_wallEnabledTilesets;
+	wxBitmapButton* m_tilesetFilterBtn; // Filter button
+
+	// Filter config persistence
+	void SaveFilterConfig();
+	void LoadFilterConfig();
+
+	// Error Handling
+	enum class ErrorSeverity { Info,
+							   Warning,
+							   Error,
+							   Critical };
+	void LogError(const wxString &message, ErrorSeverity severity);
+	void ShowErrorDialog(const wxString &message, ErrorSeverity severity);
+
+	// BrushPalettePanel* m_groundPalette;  // Removed duplicate
+
+	// ===== Wall Tab =====
+	wxPanel* m_wallPanel;
+	wxSpinCtrl* m_wallGroupCtrl;
+	wxSpinCtrl* m_wallZOrderCtrl;
+	wxSpinCtrl* m_wallItemIdCtrl;
+	wxSpinCtrl* m_wallItemChanceCtrl;
+	wxListBox* m_wallItemsList;
+	wxCheckBox* m_wallIsOptionalCheck;
+	wxCheckBox* m_wallIsGroundCheck;
+	WallVisualPanel* m_wallVisualPanel;
+	WallGridPanel* m_wallGridPanel; // Visual selector for wall types
+
+	// Wall items data
+	std::map<std::string, WallTypeData> m_wallTypes;
+	wxString m_currentWallType;
+	int m_currentWallItemId = 0; // Stores currently selected palette item ID
+	void OnWallTilesetSelect(wxCommandEvent &event);
+	void OnWallPaletteSelect(wxCommandEvent &event);
+	void OnGroundContainerChange(wxCommandEvent &event);
+
+	DECLARE_EVENT_TABLE()
 };
 
 // Custom button to represent a border item
 class BorderItemButton : public wxButton {
 public:
-    BorderItemButton(wxWindow* parent, BorderEdgePosition position, wxWindowID id = wxID_ANY);
-    virtual ~BorderItemButton();
-    
-    void SetItemId(uint16_t id);
-    uint16_t GetItemId() const { return m_itemId; }
-    BorderEdgePosition GetPosition() const { return m_position; }
-    
-    void OnPaint(wxPaintEvent& event);
-    
+	BorderItemButton(wxWindow* parent, BorderEdgePosition position, wxWindowID id = wxID_ANY);
+	virtual ~BorderItemButton();
+
+	void SetItemId(uint16_t id);
+	uint16_t GetItemId() const {
+		return m_itemId;
+	}
+	BorderEdgePosition GetPosition() const {
+		return m_position;
+	}
+
+	void OnPaint(wxPaintEvent &event);
+
 private:
-    uint16_t m_itemId;
-    BorderEdgePosition m_position;
-    
-    DECLARE_EVENT_TABLE()
+	uint16_t m_itemId;
+	BorderEdgePosition m_position;
+
+	DECLARE_EVENT_TABLE()
 };
 
 // Palette Filtering
 enum PaletteFilterMode {
-    FILTER_NONE = 0,
-    FILTER_GROUND = 1,
-    FILTER_WALL = 2
+	FILTER_NONE = 0,
+	FILTER_GROUND = 1,
+	FILTER_WALL = 2
 };
 
 // Grid panel to visually show border item positions
 class SimpleRawPalettePanel : public wxScrolledWindow {
 public:
-    SimpleRawPalettePanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~SimpleRawPalettePanel();
+	SimpleRawPalettePanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~SimpleRawPalettePanel();
 
-    void LoadTileset(const wxString& categoryName, PaletteFilterMode filterMode = FILTER_NONE);
-    void SetItemIds(const std::vector<uint16_t>& ids);
-    void OnPaint(wxPaintEvent& event);
-    void OnLeftUp(wxMouseEvent& event);
-    void OnMotion(wxMouseEvent& event);
-    void OnLeave(wxMouseEvent& event);
-    void OnSize(wxSizeEvent& event);
+	void LoadTileset(const wxString &categoryName, PaletteFilterMode filterMode = FILTER_NONE);
+	void SetItemIds(const std::vector<uint16_t> &ids);
+	void OnPaint(wxPaintEvent &event);
+	void OnLeftUp(wxMouseEvent &event);
+	void OnMotion(wxMouseEvent &event);
+	void OnLeave(wxMouseEvent &event);
+	void OnSize(wxSizeEvent &event);
 
 private:
-    std::vector<uint16_t> m_itemIds;
-    int m_cols = 1;
-    int m_rows = 1;
-    int m_itemSize = 32;
-    int m_padding = 2;
-    int m_hoverIndex = -1;
+	std::vector<uint16_t> m_itemIds;
+	int m_cols = 1;
+	int m_rows = 1;
+	int m_itemSize = 32;
+	int m_padding = 2;
+	int m_hoverIndex = -1;
 
-    void RecalculateLayout();
-    int HitTest(const wxPoint& pt) const;
+	void RecalculateLayout();
+	int HitTest(const wxPoint &pt) const;
 
-    DECLARE_EVENT_TABLE()
+	DECLARE_EVENT_TABLE()
 };
 
 // Grid panel to visually show border item positions
 class BorderGridPanel : public wxPanel {
 public:
-    BorderGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~BorderGridPanel();
-    
-    void SetItemId(BorderEdgePosition pos, uint16_t itemId);
-    uint16_t GetItemId(BorderEdgePosition pos) const;
-    void Clear();
-    
-    // Selection management
-    void SetSelectedPosition(BorderEdgePosition pos);
-    BorderEdgePosition GetSelectedPosition() const { return m_selectedPosition; }
-    
-    // Override to ensure correct sizing
-    virtual wxSize DoGetBestSize() const override;
-    
-    void OnPaint(wxPaintEvent& event);
-    void OnMouseClick(wxMouseEvent& event);
-    void OnMouseDown(wxMouseEvent& event);
-    
-    // Made public so it can be accessed from other components
-    wxPoint GetPositionCoordinates(BorderEdgePosition pos) const;
-    BorderEdgePosition GetPositionFromCoordinates(int x, int y) const;
-    
+	BorderGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~BorderGridPanel();
+
+	void SetItemId(BorderEdgePosition pos, uint16_t itemId);
+	uint16_t GetItemId(BorderEdgePosition pos) const;
+	void Clear();
+
+	// Selection management
+	void SetSelectedPosition(BorderEdgePosition pos);
+	BorderEdgePosition GetSelectedPosition() const {
+		return m_selectedPosition;
+	}
+
+	// Override to ensure correct sizing
+	virtual wxSize DoGetBestSize() const override;
+
+	void OnPaint(wxPaintEvent &event);
+	void OnMouseClick(wxMouseEvent &event);
+	void OnMouseDown(wxMouseEvent &event);
+
+	// Made public so it can be accessed from other components
+	wxPoint GetPositionCoordinates(BorderEdgePosition pos) const;
+	BorderEdgePosition GetPositionFromCoordinates(int x, int y) const;
+
 private:
-    std::map<BorderEdgePosition, uint16_t> m_items;
-    BorderEdgePosition m_selectedPosition;
-    
-    DECLARE_EVENT_TABLE()
+	std::map<BorderEdgePosition, uint16_t> m_items;
+	BorderEdgePosition m_selectedPosition;
+
+	DECLARE_EVENT_TABLE()
 };
 
 // Panel to preview how the border would look
 class BorderPreviewPanel : public wxPanel {
 public:
-    BorderPreviewPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~BorderPreviewPanel();
-    
-    void SetBorderItems(const std::vector<BorderItem>& items);
-    void Clear();
-    
-    void OnPaint(wxPaintEvent& event);
-    
+	BorderPreviewPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~BorderPreviewPanel();
+
+	void SetBorderItems(const std::vector<BorderItem> &items);
+	void Clear();
+
+	void OnPaint(wxPaintEvent &event);
+
 private:
-    std::vector<BorderItem> m_borderItems;
-    
-    DECLARE_EVENT_TABLE()
+	std::vector<BorderItem> m_borderItems;
+
+	DECLARE_EVENT_TABLE()
 };
 
 // Panel to select wall types (Visual Grid)
 class WallGridPanel : public wxPanel {
 public:
-    WallGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~WallGridPanel();
-    
-    void SetWallTypes(const std::map<std::string, WallTypeData>& types);
-    void SetSelectedType(const std::string& type);
-    std::string GetSelectedType() const { return m_selectedType; }
-    
-    void OnPaint(wxPaintEvent& event);
-    void OnMouseClick(wxMouseEvent& event);
-    
+	WallGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~WallGridPanel();
+
+	void SetWallTypes(const std::map<std::string, WallTypeData> &types);
+	void SetSelectedType(const std::string &type);
+	std::string GetSelectedType() const {
+		return m_selectedType;
+	}
+
+	void OnPaint(wxPaintEvent &event);
+	void OnMouseClick(wxMouseEvent &event);
+
 private:
-    std::map<std::string, WallTypeData> m_types;
-    std::string m_selectedType;
-    
-    DECLARE_EVENT_TABLE()
+	std::map<std::string, WallTypeData> m_types;
+	std::string m_selectedType;
+
+	DECLARE_EVENT_TABLE()
 };
 
 // Panel to visually edit wall brushes
 class WallVisualPanel : public wxPanel {
 public:
-    WallVisualPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~WallVisualPanel();
-    
-    void SetWallItems(const std::map<std::string, WallTypeData>& items);
-    void Clear();
-    
-    void OnPaint(wxPaintEvent& event);
-    
+	WallVisualPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~WallVisualPanel();
+
+	void SetWallItems(const std::map<std::string, WallTypeData> &items);
+	void Clear();
+
+	void OnPaint(wxPaintEvent &event);
+
 private:
-    std::map<std::string, WallTypeData> m_items;
-    
-    DECLARE_EVENT_TABLE()
+	std::map<std::string, WallTypeData> m_items;
+
+	DECLARE_EVENT_TABLE()
 };
-
-
 
 // ============================================================================
 // GroundPreviewPanel - Animates and cycles through selected items
 // ============================================================================
 class GroundPreviewPanel : public wxPanel {
 public:
-    GroundPreviewPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~GroundPreviewPanel();
-    
-    void SetWeightedItems(const std::vector<std::pair<uint16_t, int>>& items);
-    void UpdateFromContainer(GroundGridContainer* container);
+	GroundPreviewPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~GroundPreviewPanel();
+
+	void SetWeightedItems(const std::vector<std::pair<uint16_t, int>> &items);
+	void UpdateFromContainer(GroundGridContainer* container);
 
 protected:
-    void OnPaint(wxPaintEvent& event);
-    void OnTimer(wxTimerEvent& event);
+	void OnPaint(wxPaintEvent &event);
+	void OnTimer(wxTimerEvent &event);
 
 private:
-    std::vector<uint16_t> m_displayItems;
-    size_t m_currentIndex;
-    wxTimer m_animationTimer;
-    long m_lastCycleTime;
-    
-    DECLARE_EVENT_TABLE()
+	std::vector<uint16_t> m_displayItems;
+	size_t m_currentIndex;
+	wxTimer m_animationTimer;
+	long m_lastCycleTime;
+
+	DECLARE_EVENT_TABLE()
 };
 
 // ============================================================================
@@ -650,36 +667,44 @@ private:
 // ============================================================================
 class GroundGridPanel : public wxPanel {
 public:
-    GroundGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~GroundGridPanel();
-    
-    // Item management
-    void SetItemId(uint16_t id);
-    uint16_t GetItemId() const { return m_itemId; }
-    void Clear();
-    bool IsEmpty() const { return m_itemId == 0; }
-    
-    // Event handlers
-    void OnPaint(wxPaintEvent& event);
-    void OnMouseClick(wxMouseEvent& event);
-    void OnRightClick(wxMouseEvent& event);
-    void OnLeftDClick(wxMouseEvent& event);
-    
-    // Layout helper
-    wxSize DoGetBestSize() const override;
+	GroundGridPanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~GroundGridPanel();
 
-    // Selection & Chance
-    void SetSelected(bool selected);
-    bool IsSelected() const { return m_isSelected; }
-    void SetChance(int chance);
-    int GetChance() const { return m_chance; }
+	// Item management
+	void SetItemId(uint16_t id);
+	uint16_t GetItemId() const {
+		return m_itemId;
+	}
+	void Clear();
+	bool IsEmpty() const {
+		return m_itemId == 0;
+	}
+
+	// Event handlers
+	void OnPaint(wxPaintEvent &event);
+	void OnMouseClick(wxMouseEvent &event);
+	void OnRightClick(wxMouseEvent &event);
+	void OnLeftDClick(wxMouseEvent &event);
+
+	// Layout helper
+	wxSize DoGetBestSize() const override;
+
+	// Selection & Chance
+	void SetSelected(bool selected);
+	bool IsSelected() const {
+		return m_isSelected;
+	}
+	void SetChance(int chance);
+	int GetChance() const {
+		return m_chance;
+	}
 
 private:
-    uint16_t m_itemId;  // Currently assigned item ID
-    int m_chance;       // Spawn chance for this item
-    bool m_isSelected;  // Selection state
-    
-    DECLARE_EVENT_TABLE()
+	uint16_t m_itemId; // Currently assigned item ID
+	int m_chance; // Spawn chance for this item
+	bool m_isSelected; // Selection state
+
+	DECLARE_EVENT_TABLE()
 };
 
 // ============================================================================
@@ -687,44 +712,45 @@ private:
 // ============================================================================
 class GroundGridContainer : public wxScrolledWindow {
 public:
-    GroundGridContainer(wxWindow* parent, wxWindowID id = wxID_ANY);
-    virtual ~GroundGridContainer();
-    
-    // Item management
-    void AddItem(uint16_t itemId, int chance = 100, bool allowAppend = false);
-    void RemoveCell(GroundGridPanel* cell);
-    void Clear();
-    
-    // Get all filled items
-    std::vector<uint16_t> GetAllItems() const;
-    // Get all items with their chances
-    std::vector<std::pair<uint16_t, int>> GetAllItemsWithChance() const;
-    size_t GetFilledCount() const;
+	GroundGridContainer(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~GroundGridContainer();
 
-    // Selection
-    void SetSelectedCell(GroundGridPanel* cell);
-    GroundGridPanel* GetSelectedCell() const { return m_selectedCell; }
-    
-    // Called when a cell is filled - auto-adds new empty cell
-    // Called when a cell is filled - auto-adds new empty cell
-    void OnCellFilled(int index);
-    
-    // Make sure there's always one empty cell at the end
-    void EnsureEmptyCell();
+	// Item management
+	void AddItem(uint16_t itemId, int chance = 100, bool allowAppend = false);
+	void RemoveCell(GroundGridPanel* cell);
+	void Clear();
 
-    // Adds a new empty cell at the end (explicit "Add variation")
-    void AppendEmptyCell();
-    
-    // Rebuild grid layout after changes
-    void RebuildGrids();
+	// Get all filled items
+	std::vector<uint16_t> GetAllItems() const;
+	// Get all items with their chances
+	std::vector<std::pair<uint16_t, int>> GetAllItemsWithChance() const;
+	size_t GetFilledCount() const;
+
+	// Selection
+	void SetSelectedCell(GroundGridPanel* cell);
+	GroundGridPanel* GetSelectedCell() const {
+		return m_selectedCell;
+	}
+
+	// Called when a cell is filled - auto-adds new empty cell
+	// Called when a cell is filled - auto-adds new empty cell
+	void OnCellFilled(int index);
+
+	// Make sure there's always one empty cell at the end
+	void EnsureEmptyCell();
+
+	// Adds a new empty cell at the end (explicit "Add variation")
+	void AppendEmptyCell();
+
+	// Rebuild grid layout after changes
+	void RebuildGrids();
 
 private:
-    std::vector<GroundGridPanel*> m_gridCells;
-    wxBoxSizer* m_gridSizer;
-    GroundGridPanel* m_selectedCell;
-    
-    void CreateNewCell();          // Create a new grid cell
-};
+	std::vector<GroundGridPanel*> m_gridCells;
+	wxBoxSizer* m_gridSizer;
+	GroundGridPanel* m_selectedCell;
 
+	void CreateNewCell(); // Create a new grid cell
+};
 
 #endif // RME_BRUSH_EDITOR_WINDOW_H_

--- a/source/brush_editor_window.h
+++ b/source/brush_editor_window.h
@@ -251,7 +251,6 @@ public:
 	void OnBrowserGridSelection(wxCommandEvent &event);
 	void OnBrowserSearch(wxCommandEvent &event);
 	void OnBrowserPaletteCategoryButtonClick(wxCommandEvent &event);
-	void OnBrowserTilesetFilterButtonClick(wxCommandEvent &event);
 	void OnBrowserNewEntity(wxCommandEvent &event);
 	void OnBrowserDuplicateEntity(wxCommandEvent &event);
 	void OnBrowserReloadEntity(wxCommandEvent &event);
@@ -461,7 +460,6 @@ private:
 	wxListBox* m_borderBrowserList; // Sidebar browser for existing items (hidden)
 	BrushBrowserGridPanel* m_browserGrid;
 	wxButton* m_browserPaletteCategoryButton;
-	wxButton* m_browserTilesetFilterButton;
 	wxString m_browserPaletteCategoryFilter;
 	wxString m_browserTilesetFilter;
 	wxToggleButton* m_browserBrushesViewBtn;

--- a/source/main_menubar.cpp
+++ b/source/main_menubar.cpp
@@ -30,8 +30,10 @@
 #include "lua/lua_script_manager.h"
 #include "lua/lua_scripts_window.h"
 #include "gui.h"
+#include "brush_editor_window.h"
 
 #include <wx/chartype.h>
+#include <wx/display.h>
 
 #include "items.h"
 #include "editor.h"
@@ -64,6 +66,7 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 	MAKE_ACTION(IMPORT_NPCS, wxITEM_NORMAL, OnImportNpcData);
 	MAKE_ACTION(IMPORT_MINIMAP, wxITEM_NORMAL, OnImportMinimap);
 	MAKE_ACTION(IMPORT_BITMAP_TO_MAP, wxITEM_NORMAL, OnImportBitmapToMap);
+	MAKE_ACTION(BRUSH_EDITOR, wxITEM_NORMAL, OnBrushEditor);
 
 	MAKE_ACTION(EXPORT_MINIMAP, wxITEM_NORMAL, OnExportMinimap);
 	MAKE_ACTION(EXPORT_TILESETS, wxITEM_NORMAL, OnExportTilesets);
@@ -2207,6 +2210,63 @@ void MainMenuBar::OnActionsHistoryWindow(wxCommandEvent &WXUNUSED(event)) {
 
 void MainMenuBar::OnNewPalette(wxCommandEvent &event) {
 	g_gui.NewPalette();
+}
+
+void MainMenuBar::OnBrushEditor(wxCommandEvent &WXUNUSED(event)) {
+	auto maximizeBrushEditorPane = [&](wxWindow* paneWindow) {
+		if (!g_gui.aui_manager || !paneWindow) {
+			return;
+		}
+
+		wxAuiPaneInfo& info = g_gui.aui_manager->GetPane(paneWindow);
+		if (!info.IsOk()) {
+			return;
+		}
+
+		int displayIndex = wxNOT_FOUND;
+		if (g_gui.root) {
+			displayIndex = wxDisplay::GetFromWindow(g_gui.root);
+		}
+		if (displayIndex == wxNOT_FOUND) {
+			displayIndex = wxDisplay::GetFromWindow(paneWindow);
+		}
+		if (displayIndex == wxNOT_FOUND) {
+			displayIndex = 0;
+		}
+
+		wxDisplay display(displayIndex);
+		wxRect rect = display.GetClientArea();
+
+		info.Float();
+		info.FloatingPosition(rect.GetTopLeft());
+		info.FloatingSize(rect.GetSize());
+		info.BestSize(rect.GetSize());
+		info.Show();
+	};
+
+	if (brush_editor_dialog) {
+		maximizeBrushEditorPane(brush_editor_dialog);
+		g_gui.aui_manager->Update();
+	} else {
+		brush_editor_dialog = new BrushEditorPanel(g_gui.root);
+		brush_editor_dialog->Bind(wxEVT_DESTROY, [this](wxWindowDestroyEvent& event) {
+			if (event.GetEventObject() == brush_editor_dialog) {
+				brush_editor_dialog = nullptr;
+			}
+			event.Skip();
+		});
+
+		g_gui.aui_manager->AddPane(brush_editor_dialog, wxAuiPaneInfo().
+			Name("BrushEditor").
+			Caption("Brush Editor").
+			Float().
+			Dockable(true).
+			CloseButton(true).
+			BestSize(850, 650));
+
+		maximizeBrushEditorPane(brush_editor_dialog);
+		g_gui.aui_manager->Update();
+	}
 }
 
 void MainMenuBar::OnSelectTerrainPalette(wxCommandEvent &WXUNUSED(event)) {

--- a/source/main_menubar.h
+++ b/source/main_menubar.h
@@ -168,10 +168,12 @@ namespace MenuBar {
 		SEARCH_ON_MAP_WALLS_UPON_WALLS,
 		SEARCH_ON_SELECTION_WALLS_UPON_WALLS,
 		IMPORT_BITMAP_TO_MAP,
+		BRUSH_EDITOR,
 	};
 }
 
 class MainFrame;
+class BrushEditorPanel;
 
 class MainMenuBar : public wxEvtHandler {
 public:
@@ -292,6 +294,7 @@ public:
 	void OnActionsHistoryWindow(wxCommandEvent &event);
 	void OnNewPalette(wxCommandEvent &event);
 	void OnTakeScreenshot(wxCommandEvent &event);
+	void OnBrushEditor(wxCommandEvent &event);
 	void OnSelectTerrainPalette(wxCommandEvent &event);
 	void OnSelectDoodadPalette(wxCommandEvent &event);
 	void OnSelectItemPalette(wxCommandEvent &event);
@@ -330,6 +333,7 @@ protected:
 	MainFrame* frame;
 	wxMenuBar* menubar;
 	wxMenu* scriptsMenu = nullptr;
+	BrushEditorPanel* brush_editor_dialog = nullptr;
 
 	// Used so that calling Check on menu items don't trigger events (avoids infinite recursion)
 	bool checking_programmaticly;

--- a/source/palette_window.h
+++ b/source/palette_window.h
@@ -19,6 +19,7 @@
 #define RME_PALETTE_H_
 
 #include "palette_common.h"
+#include "settings.h"
 
 class BrushPalettePanel;
 class MonsterPalettePanel;


### PR DESCRIPTION
## Summary
Introduces the Brush Editor: a unified in-app tool to browse, edit, preview, and save brush-related data (borders, grounds, and walls) directly from the editor UI, reducing manual XML work and speeding up iteration.
Credits: @Habdel-Edenfield Autoborder Editor.

## What Is Included
- A dedicated Brush Editor window/panels to work with:
  - Borders (auto-borders)
  - Grounds (ground brushes / ground sets)
  - Walls (wall brush definitions)
- Visual editing via grid-based controls and live preview panels so changes can be validated immediately.
- Sidebar browsing and filtering to quickly find existing entries and focus the editor on a specific tile/brush.
- Save/load integration to persist edits back to the data files and refresh the editor state after saving.

## Key Behaviors
- Editing is designed to be interactive and iterative:
  - Changes are reflected in the UI preview as you edit.
  - Draft state can be preserved while navigating the tool (so you can move between tabs/entries without immediately committing to XML).
- Saving commits the current edited data to the corresponding XML and triggers reload so the editor reflects the canonical saved state.

## Testing
- Open the Brush Editor and browse existing borders/grounds/walls.
- Select an entry from the browser and verify the grid + preview reflect the loaded data.
- Modify items in the grid and confirm the preview updates.
- Switch tabs and return; verify in-progress edits behave as expected (drafts preserved until saved).
- Save changes and verify they persist after reload/reopening the editor.

## Notes
- Scope is limited to the Brush Editor tool and its persistence workflow.
- This PR is focused on enabling authoring/editing inside the application rather than manual XML editing.