### PR TITLE
fix: replace wxDirPickerCtrl with wxDirDialog to resolve GTK crash

### DIFF
--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -619,7 +619,7 @@ void PreferencesWindow::OnBrowseClientPath(wxCommandEvent &WXUNUSED(event)) {
 	if (dialog.ShowModal() == wxID_OK) {
 		wxString path = dialog.GetPath();
 		version_dir_picker->SetValue(path);
-		ClientAssets::setPath(path.ToUTF8().data());
+		ClientAssets::setPath(path);
 		spdlog::debug("New client directory selected: {}", path.ToUTF8().data());
 	}
 }

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -619,7 +619,6 @@ void PreferencesWindow::OnBrowseClientPath(wxCommandEvent &WXUNUSED(event)) {
 	if (dialog.ShowModal() == wxID_OK) {
 		wxString path = dialog.GetPath();
 		version_dir_picker->SetValue(path);
-		ClientAssets::setPath(path);
 		spdlog::debug("New client directory selected: {}", path.ToUTF8().data());
 	}
 }
@@ -767,6 +766,7 @@ void PreferencesWindow::Apply() {
 	g_settings.setString(Config::MONSTERS_LUA_DIRECTORY, nstr(monsters_lua_dir_picker->GetValue()));
 	g_settings.setString(Config::NPCS_LUA_DIRECTORY, nstr(npcs_lua_dir_picker->GetValue()));
 
+	ClientAssets::setPath(version_dir_picker->GetValue());
 	ClientAssets::save();
 	ClientAssets::load();
 

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -42,8 +42,7 @@ PreferencesWindow::PreferencesWindow(wxWindow* parent) :
 	book->AddPage(CreateEditorPage(), "Editor");
 	book->AddPage(CreateGraphicsPage(), "Graphics");
 	book->AddPage(CreateUIPage(), "Interface");
-	book->AddPage(CreateClientPage(), "Client Folder");
-	version_dir_picker->Bind(wxEVT_DIRPICKER_CHANGED, &PreferencesWindow::SelectNewAssetsFolder, this);
+	book->AddPage(CreateClientPage(), "Directories");
 
 	sizer->Add(book, 1, wxEXPAND | wxALL, 10);
 
@@ -545,17 +544,17 @@ wxNotebookPage* PreferencesWindow::CreateClientPage() {
 	auto* client_list_sizer = newd wxFlexGridSizer(2, 10, 10);
 	client_list_sizer->AddGrowableCol(1);
 
-	wxStaticText* tmp_text = newd wxStaticText(client_list_window, wxID_ANY, wxString("Select path:"));
+	wxStaticText* tmp_text = newd wxStaticText(client_list_window, wxID_ANY, wxString("Client directory:"));
 	client_list_sizer->Add(tmp_text, wxSizerFlags(0).Expand());
 
-	wxBoxSizer* path_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	wxBoxSizer* client_path_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	version_dir_picker = newd wxTextCtrl(client_list_window, wxID_ANY, ClientAssets::getPath());
 	version_dir_picker->SetEditable(false);
-	wxButton* browse_button = newd wxButton(client_list_window, wxID_ANY, "Browse...");
-	browse_button->Bind(wxEVT_BUTTON, &PreferencesWindow::OnBrowseClientPath, this);
-	path_sizer->Add(version_dir_picker, wxSizerFlags(1).Expand());
-	path_sizer->Add(browse_button, wxSizerFlags(0).Border(wxLEFT, 5));
-	client_list_sizer->Add(path_sizer, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
+	wxButton* client_browse_button = newd wxButton(client_list_window, wxID_ANY, "Browse...");
+	client_browse_button->Bind(wxEVT_BUTTON, &PreferencesWindow::OnBrowseClientPath, this);
+	client_path_sizer->Add(version_dir_picker, wxSizerFlags(1).Expand());
+	client_path_sizer->Add(client_browse_button, wxSizerFlags(0).Border(wxLEFT, 5));
+	client_list_sizer->Add(client_path_sizer, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
 
 	wxString tooltip;
 	tooltip << "The editor will look for client directory here.";
@@ -564,15 +563,29 @@ wxNotebookPage* PreferencesWindow::CreateClientPage() {
 
 	wxStaticText* monsters_lua_text = newd wxStaticText(client_list_window, wxID_ANY, wxString("Monsters Lua directory:"));
 	client_list_sizer->Add(monsters_lua_text, wxSizerFlags(0).Expand());
-	monsters_lua_dir_picker = newd wxDirPickerCtrl(client_list_window, wxID_ANY, wxstr(g_settings.getString(Config::MONSTERS_LUA_DIRECTORY)));
-	client_list_sizer->Add(monsters_lua_dir_picker, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
+
+	wxBoxSizer* monsters_path_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	monsters_lua_dir_picker = newd wxTextCtrl(client_list_window, wxID_ANY, wxstr(g_settings.getString(Config::MONSTERS_LUA_DIRECTORY)));
+	monsters_lua_dir_picker->SetEditable(false);
+	wxButton* monsters_browse_button = newd wxButton(client_list_window, wxID_ANY, "Browse...");
+	monsters_browse_button->Bind(wxEVT_BUTTON, &PreferencesWindow::OnBrowseMonstersPath, this);
+	monsters_path_sizer->Add(monsters_lua_dir_picker, wxSizerFlags(1).Expand());
+	monsters_path_sizer->Add(monsters_browse_button, wxSizerFlags(0).Border(wxLEFT, 5));
+	client_list_sizer->Add(monsters_path_sizer, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
 	monsters_lua_text->SetToolTip("Path to Canary server monster Lua files (e.g. data-otservbr-global/monster/)");
 	monsters_lua_dir_picker->SetToolTip("Path to Canary server monster Lua files (e.g. data-otservbr-global/monster/)");
 
 	wxStaticText* npcs_lua_text = newd wxStaticText(client_list_window, wxID_ANY, wxString("NPCs Lua directory:"));
 	client_list_sizer->Add(npcs_lua_text, wxSizerFlags(0).Expand());
-	npcs_lua_dir_picker = newd wxDirPickerCtrl(client_list_window, wxID_ANY, wxstr(g_settings.getString(Config::NPCS_LUA_DIRECTORY)));
-	client_list_sizer->Add(npcs_lua_dir_picker, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
+
+	wxBoxSizer* npcs_path_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	npcs_lua_dir_picker = newd wxTextCtrl(client_list_window, wxID_ANY, wxstr(g_settings.getString(Config::NPCS_LUA_DIRECTORY)));
+	npcs_lua_dir_picker->SetEditable(false);
+	wxButton* npcs_browse_button = newd wxButton(client_list_window, wxID_ANY, "Browse...");
+	npcs_browse_button->Bind(wxEVT_BUTTON, &PreferencesWindow::OnBrowseNpcsPath, this);
+	npcs_path_sizer->Add(npcs_lua_dir_picker, wxSizerFlags(1).Expand());
+	npcs_path_sizer->Add(npcs_browse_button, wxSizerFlags(0).Border(wxLEFT, 5));
+	client_list_sizer->Add(npcs_path_sizer, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
 	npcs_lua_text->SetToolTip("Path to Canary server NPC Lua files (e.g. data-otservbr-global/npc/)");
 	npcs_lua_dir_picker->SetToolTip("Path to Canary server NPC Lua files (e.g. data-otservbr-global/npc/)");
 
@@ -601,18 +614,31 @@ void PreferencesWindow::OnClickApply(wxCommandEvent &WXUNUSED(event)) {
 	Apply();
 }
 
-void PreferencesWindow::SelectNewAssetsFolder(wxCommandEvent &event) {
-	// Este método não é mais necessário com o novo approach
-	// O path é atualizado diretamente em OnBrowseClientPath
-}
-
 void PreferencesWindow::OnBrowseClientPath(wxCommandEvent &WXUNUSED(event)) {
 	wxDirDialog dialog(this, "Select client directory", version_dir_picker->GetValue(), wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
 	if (dialog.ShowModal() == wxID_OK) {
 		wxString path = dialog.GetPath();
 		version_dir_picker->SetValue(path);
 		ClientAssets::setPath(path.ToUTF8().data());
-		spdlog::debug("New directory selected: {}", path.ToUTF8().data());
+		spdlog::debug("New client directory selected: {}", path.ToUTF8().data());
+	}
+}
+
+void PreferencesWindow::OnBrowseMonstersPath(wxCommandEvent &WXUNUSED(event)) {
+	wxDirDialog dialog(this, "Select monsters Lua directory", monsters_lua_dir_picker->GetValue(), wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+	if (dialog.ShowModal() == wxID_OK) {
+		wxString path = dialog.GetPath();
+		monsters_lua_dir_picker->SetValue(path);
+		spdlog::debug("New monsters Lua directory selected: {}", path.ToUTF8().data());
+	}
+}
+
+void PreferencesWindow::OnBrowseNpcsPath(wxCommandEvent &WXUNUSED(event)) {
+	wxDirDialog dialog(this, "Select NPCs Lua directory", npcs_lua_dir_picker->GetValue(), wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+	if (dialog.ShowModal() == wxID_OK) {
+		wxString path = dialog.GetPath();
+		npcs_lua_dir_picker->SetValue(path);
+		spdlog::debug("New NPCs Lua directory selected: {}", path.ToUTF8().data());
 	}
 }
 
@@ -738,8 +764,8 @@ void PreferencesWindow::Apply() {
 	g_settings.setFloat(Config::SCROLL_SPEED, scroll_mul * scroll_speed_slider->GetValue() / 10.f);
 	g_settings.setFloat(Config::ZOOM_SPEED, zoom_speed_slider->GetValue() / 10.f);
 
-	g_settings.setString(Config::MONSTERS_LUA_DIRECTORY, nstr(monsters_lua_dir_picker->GetPath()));
-	g_settings.setString(Config::NPCS_LUA_DIRECTORY, nstr(npcs_lua_dir_picker->GetPath()));
+	g_settings.setString(Config::MONSTERS_LUA_DIRECTORY, nstr(monsters_lua_dir_picker->GetValue()));
+	g_settings.setString(Config::NPCS_LUA_DIRECTORY, nstr(npcs_lua_dir_picker->GetValue()));
 
 	ClientAssets::save();
 	ClientAssets::load();

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -548,14 +548,19 @@ wxNotebookPage* PreferencesWindow::CreateClientPage() {
 	wxStaticText* tmp_text = newd wxStaticText(client_list_window, wxID_ANY, wxString("Select path:"));
 	client_list_sizer->Add(tmp_text, wxSizerFlags(0).Expand());
 
-	wxDirPickerCtrl* dir_picker = newd wxDirPickerCtrl(client_list_window, wxID_ANY, ClientAssets::getPath());
-	version_dir_picker = dir_picker;
-	client_list_sizer->Add(dir_picker, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
+	wxBoxSizer* path_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	version_dir_picker = newd wxTextCtrl(client_list_window, wxID_ANY, ClientAssets::getPath());
+	version_dir_picker->SetEditable(false);
+	wxButton* browse_button = newd wxButton(client_list_window, wxID_ANY, "Browse...");
+	browse_button->Bind(wxEVT_BUTTON, &PreferencesWindow::OnBrowseClientPath, this);
+	path_sizer->Add(version_dir_picker, wxSizerFlags(1).Expand());
+	path_sizer->Add(browse_button, wxSizerFlags(0).Border(wxLEFT, 5));
+	client_list_sizer->Add(path_sizer, wxSizerFlags(0).Border(wxRIGHT, 10).Expand());
 
 	wxString tooltip;
 	tooltip << "The editor will look for client directory here.";
 	tmp_text->SetToolTip(tooltip);
-	dir_picker->SetToolTip(tooltip);
+	version_dir_picker->SetToolTip(tooltip);
 
 	wxStaticText* monsters_lua_text = newd wxStaticText(client_list_window, wxID_ANY, wxString("Monsters Lua directory:"));
 	client_list_sizer->Add(monsters_lua_text, wxSizerFlags(0).Expand());
@@ -597,14 +602,17 @@ void PreferencesWindow::OnClickApply(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void PreferencesWindow::SelectNewAssetsFolder(wxCommandEvent &event) {
-	wxDirPickerCtrl* dir_picker = static_cast<wxDirPickerCtrl*>(event.GetEventObject());
-	wxString path = dir_picker->GetPath();
-	if (!path.IsEmpty()) {
+	// Este método não é mais necessário com o novo approach
+	// O path é atualizado diretamente em OnBrowseClientPath
+}
+
+void PreferencesWindow::OnBrowseClientPath(wxCommandEvent &WXUNUSED(event)) {
+	wxDirDialog dialog(this, "Select client directory", version_dir_picker->GetValue(), wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+	if (dialog.ShowModal() == wxID_OK) {
+		wxString path = dialog.GetPath();
+		version_dir_picker->SetValue(path);
 		ClientAssets::setPath(path.ToUTF8().data());
 		spdlog::debug("New directory selected: {}", path.ToUTF8().data());
-	} else {
-		wxMessageDialog dialog(this, "Directory is empty, please, select a valid directory", "Error", wxOK | wxICON_ERROR);
-		dialog.ShowModal();
 	}
 }
 

--- a/source/preferences.h
+++ b/source/preferences.h
@@ -29,8 +29,9 @@ public:
 	void OnClickApply(wxCommandEvent &);
 	void OnClickOK(wxCommandEvent &);
 	void OnClickCancel(wxCommandEvent &);
-	void SelectNewAssetsFolder(wxCommandEvent &event);
 	void OnBrowseClientPath(wxCommandEvent &event);
+	void OnBrowseMonstersPath(wxCommandEvent &event);
+	void OnBrowseNpcsPath(wxCommandEvent &event);
 	void OnCollapsiblePane(wxCollapsiblePaneEvent &);
 	wxBookCtrl &getBookCtrl() {
 		return *book;
@@ -116,8 +117,8 @@ protected:
 	// Client info
 	wxChoice* default_version_choice;
 	wxTextCtrl* version_dir_picker;
-	wxDirPickerCtrl* monsters_lua_dir_picker;
-	wxDirPickerCtrl* npcs_lua_dir_picker;
+	wxTextCtrl* monsters_lua_dir_picker;
+	wxTextCtrl* npcs_lua_dir_picker;
 	wxCheckBox* check_sigs_chkbox;
 
 	// Create controls

--- a/source/preferences.h
+++ b/source/preferences.h
@@ -30,6 +30,7 @@ public:
 	void OnClickOK(wxCommandEvent &);
 	void OnClickCancel(wxCommandEvent &);
 	void SelectNewAssetsFolder(wxCommandEvent &event);
+	void OnBrowseClientPath(wxCommandEvent &event);
 	void OnCollapsiblePane(wxCollapsiblePaneEvent &);
 	wxBookCtrl &getBookCtrl() {
 		return *book;
@@ -114,7 +115,7 @@ protected:
 
 	// Client info
 	wxChoice* default_version_choice;
-	wxDirPickerCtrl* version_dir_picker;
+	wxTextCtrl* version_dir_picker;
 	wxDirPickerCtrl* monsters_lua_dir_picker;
 	wxDirPickerCtrl* npcs_lua_dir_picker;
 	wxCheckBox* check_sigs_chkbox;


### PR DESCRIPTION
## Summary  
Fixes crash when selecting directory paths in preferences dialog on Linux with wxWidgets 3.3.1 beta by replacing wxDirPickerCtrl with wxTextCtrl + wxButton combinations that manually open wxDirDialog.  
  
## What Is Included  
- Replaced all wxDirPickerCtrl instances (client, monsters, and NPCs) with wxTextCtrl + wxButton combinations  
- Added OnBrowseClientPath(), OnBrowseMonstersPath(), and OnBrowseNpcsPath() event handlers to open wxDirDialog manually  
- Updated UI layout to include browse buttons next to text fields  
- Renamed tab from "Client Folder" to "Directories" for clarity  
- Renamed label from "Select path:" to "Client directory:" for accuracy (since monsters/NPCs paths are server-side)  
- Removed obsolete SelectNewAssetsFolder() method  
- Updated Apply() method to use GetValue() instead of GetPath() for text controls  
  
## Key Behaviors  
- Directory selection now works reliably on Linux with wxWidgets 3.3.1 beta without crashes  
- Solution is cross-platform and works on Windows and macOS (follows existing pattern from ExportMiniMapWindow and ExportTilesetsWindow)  
- Text fields are read-only and only updated when user selects a directory via browse button  
  
## Testing  
- Tested on Linux with wxWidgets 3.3.1 beta - no longer crashes when selecting client, monsters, or NPCs directory paths  
- Verified that selected paths are correctly saved and loaded  
- Confirmed that the UI layout remains consistent and functional  
  
## Notes  
- This fix addresses a wxWidgets GTK-specific bug when wxDirPickerCtrl is used inside wxScrolledWindow  
- The manual wxDirDialog approach is more robust and portable across all platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reorganized Preferences dialog with a new "Directories" tab replacing the previous "Client Folder" tab
  * Enhanced directory selection interface: Client path, Monsters Lua directory, and NPCs Lua directory controls now use dedicated "Browse..." buttons paired with read-only text fields for improved usability and clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/remeres-map-editor/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->