### PR TITLE
docs: update README and add build guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ You can find the project for hosting your own server at [Canary](https://github.
 
 Getting Started
 =========
-* [Gitbook](https://docs.opentibiabr.com/opentibiabr/projects/remeres-map-editor).
 * [Wiki](https://github.com/opentibiabr/remeres-map-editor/wiki).
 
 I want to contribute

--- a/docs/compiling/compiling-on-debian.md
+++ b/docs/compiling/compiling-on-debian.md
@@ -1,0 +1,76 @@
+# Remere's Map Editor
+
+## Supported OS
+
+- Debian
+
+## 1. Install the required software
+
+The following command will install Git, CMake, a compiler and the libraries used by Remere's Map Editor. 
+
+Git will be used to download the source code, and CMake will be used to generate the build files.
+
+```bash
+sudo apt update
+sudo apt install git cmake build-essential autoconf autoconf-archive automake libtool ca-certificates curl zip unzip tar pkg-config ninja-build ccache bison linux-headers-$(uname -r) \
+libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev \
+libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev \
+libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-dev python3-distutils-extra python3-jinja2 libxrender-dev -y
+```
+
+## 2. Set up vcpkg
+
+```bash
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+./bootstrap-vcpkg.sh
+cd ..
+```
+
+### Configure environment for vcpkg (important)
+
+To ensure **CMake presets and CLion detect vcpkg automatically without modifying the preset**, export `VCPKG_ROOT` globally for the user:
+
+```bash
+echo "VCPKG_ROOT=/home/$USER/vcpkg" | sudo tee -a /etc/environment && source /etc/environment
+```
+Now **log out and log in again** (or reboot), then verify:
+
+```bash
+echo $VCPKG_ROOT
+# Expected output:
+# /home/<user>/vcpkg
+```
+Also validate the toolchain file exists:
+
+```bash
+test -f "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" && echo "vcpkg OK" || echo "vcpkg not found"
+```
+
+## 3. Download the source code
+
+```bash
+git clone --depth 1 https://github.com/opentibiabr/remeres-map-editor.git
+cd remeres-map-editor
+```
+
+## 4. Folder structure
+
+```bash
+.
+├── remeres-map-editor
+└── vcpkg
+```
+
+## 5. Configure and build
+
+```bash
+cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON
+cmake --build --preset linux-release -j4
+```
+
+> -- Running vcpkg install 
+
+**This step will take a long time on the first run, as it needs to download and install all the dependencies, so be patient!**
+
+---

--- a/docs/compiling/compiling-on-ubuntu-24.04.md
+++ b/docs/compiling/compiling-on-ubuntu-24.04.md
@@ -1,0 +1,76 @@
+# Remere's Map Editor
+
+## Supported OS
+
+- Ubuntu 24.04
+
+## 1. Install the required software
+
+The following command will install Git, CMake, a compiler and the libraries used by Remere's Map Editor. 
+
+Git will be used to download the source code, and CMake will be used to generate the build files.
+
+```bash
+sudo apt update
+sudo apt install git cmake build-essential autoconf autoconf-archive automake libtool ca-certificates curl zip unzip tar pkg-config ninja-build ccache bison linux-headers-$(uname -r) \
+libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev \
+libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev \
+libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-dev python3-distutils-extra libxrender-dev -y
+```
+
+## 2. Set up vcpkg
+
+```bash
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+./bootstrap-vcpkg.sh
+cd ..
+```
+
+### Configure environment for vcpkg (important)
+
+To ensure **CMake presets and CLion detect vcpkg automatically without modifying the preset**, export `VCPKG_ROOT` globally for the user:
+
+```bash
+echo "VCPKG_ROOT=/home/$USER/vcpkg" | sudo tee -a /etc/environment && source /etc/environment
+```
+Now **log out and log in again** (or reboot), then verify:
+
+```bash
+echo $VCPKG_ROOT
+# Expected output:
+# /home/<user>/vcpkg
+```
+Also validate the toolchain file exists:
+
+```bash
+test -f "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" && echo "vcpkg OK" || echo "vcpkg not found"
+```
+
+## 3. Download the source code
+
+```bash
+git clone --depth 1 https://github.com/opentibiabr/remeres-map-editor.git
+cd remeres-map-editor
+```
+
+## 4. Folder structure
+
+```bash
+.
+├── remeres-map-editor
+└── vcpkg
+```
+
+## 5. Configure and build
+
+```bash
+cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON
+cmake --build --preset linux-release -j4
+```
+
+> -- Running vcpkg install 
+
+**This step will take a long time on the first run, as it needs to download and install all the dependencies, so be patient!**
+
+---

--- a/docs/compiling/compiling-on-windows-(cmake).md
+++ b/docs/compiling/compiling-on-windows-(cmake).md
@@ -1,0 +1,64 @@
+# Remere's Map Editor
+
+## Supported OS
+
+- Windows 11
+
+## 1. Install the required software
+
+To compile on Windows, you will need to download and install:
+- [Git](https://git-scm.com/download/win)
+- [Visual Studio 2026 Community](https://visualstudio.microsoft.com/vs/) (compiler and english language pack)
+- [vcpkg](https://github.com/Microsoft/vcpkg) (package manager)
+
+You must install **Visual Studio 2026** with the "Desktop development with C++" workload selecting the following components:
+
+- MSVC Build Tools for x64/x86 (Latest)
+- C++ ATL for x64/x86 (Latest MSVC) 
+- C++ Build Insights
+- C++ profiling tools
+- C++ CMake tools for Windows
+- Windows 11 SDK
+
+**Important:** Do not select to install the option "vcpkg package manager" on Visual Studio.
+
+You must also install the **English** language pack.
+
+## 2. Set up vcpkg
+
+Make sure to follow full installation of `vcpkg`, per [Official Quickstart](https://github.com/Microsoft/vcpkg#quick-start) execute the following in _Powershell_:
+
+To open Powershell navigate to your desired directory e.g. `C:\` and choose `Open PowerShell window here` (shift + right click).
+
+Then you can safely proceed with configuring vcpkg:
+
+```powershell
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg integrate install
+```
+
+Execute the following command in _Powershell_ with Administrator permission to set vcpkg environment variable:
+
+**Note:** If you cloned vcpkg to a different directory, replace 'C:\vcpkg' in the command below with the correct path.
+
+```powershell
+[System.Environment]::SetEnvironmentVariable('VCPKG_ROOT','C:\vcpkg', [System.EnvironmentVariableTarget]::Machine)
+```
+
+## 3. Download the source code
+```powershell
+    cd C:\
+    git clone --depth 1 https://github.com/opentibiabr/remeres-map-editor.git
+```
+
+## 4. Build
+
+- Open Visual Studio. In "**Get started**", select "**Open a local folder**" and open the remere's map editor main folder.
+
+- Wait for the Visual Studio to load. It will automatically install the libraries and generate the cmake cache. (Be patient, the first cache may take a few minutes).
+
+- After the cmake cache is successfully generated, you can compile the Remere's Map Editor by going to the menu **Build** and choose **Build All**.
+
+---

--- a/docs/compiling/compiling-on-windows-(visual-studio-solution).md
+++ b/docs/compiling/compiling-on-windows-(visual-studio-solution).md
@@ -1,0 +1,64 @@
+# Remere's Map Editor
+
+## Supported OS
+
+- Windows 11
+
+## 1. Install the required software
+
+To compile on Windows, you will need to download and install:
+- [Git](https://git-scm.com/download/win)
+- [Visual Studio 2026 Community](https://visualstudio.microsoft.com/vs/) (compiler and english language pack)
+- [vcpkg](https://github.com/Microsoft/vcpkg) (package manager)
+
+You must install **Visual Studio 2026** with the "Desktop development with C++" workload selecting the following components:
+
+- MSVC Build Tools for x64/x86 (Latest)
+- C++ ATL for x64/x86 (Latest MSVC) 
+- C++ Build Insights
+- C++ profiling tools
+- C++ CMake tools for Windows
+- Windows 11 SDK
+
+**Important:** Do not select to install the option "vcpkg package manager" on Visual Studio.
+
+You must also install the **English** language pack.
+
+## 2. Set up vcpkg
+
+Make sure to follow full installation of `vcpkg`, per [Official Quickstart](https://github.com/Microsoft/vcpkg#quick-start) execute the following in _Powershell_:
+
+To open Powershell navigate to your desired directory e.g. `C:\` and choose `Open PowerShell window here` (shift + right click).
+
+Then you can safely proceed with configuring vcpkg:
+
+```powershell
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg integrate install
+```
+Execute the following command in _Powershell_ with Administrator permission to set vcpkg environment variable: 
+
+**Note:** If you cloned vcpkg to a different directory, replace 'C:\vcpkg' in the command below with the correct path.
+
+```powershell
+[System.Environment]::SetEnvironmentVariable('VCPKG_ROOT','C:\vcpkg', [System.EnvironmentVariableTarget]::Machine)
+```
+
+## 3. Download the source code
+
+```powershell
+cd C:\ 
+git clone --depth 1 https://github.com/opentibiabr/remeres-map-editor.git
+```
+
+## 4. Build
+
+- Open **```vcproj\RME.sln```**. This should launch Visual Studio.
+
+- Choose build configuration from the drop-downs (Release and x64).
+
+- To start compiling go to the menu Build and choose Build Solution.
+
+---

--- a/docs/compiling/compiling-on-wsl-debian.md
+++ b/docs/compiling/compiling-on-wsl-debian.md
@@ -1,0 +1,93 @@
+# Remere's Map Editor
+
+## Supported OS
+
+- Windows 11 + WSL2 with Debian
+
+## 1. Install the required software
+
+The following command will install Git, CMake, a compiler and the libraries used by Remere's Map Editor.
+
+Git will be used to download the source code, and CMake will be used to generate the build files.
+
+```bash
+sudo apt update
+sudo apt install git cmake build-essential autoconf autoconf-archive automake libtool ca-certificates curl zip unzip tar pkg-config ninja-build ccache bison linux-headers-amd64 \
+libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev \
+libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev \
+libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-dev python3-distutils-extra python3-jinja2 libxrender-dev -y
+```
+
+## 2. Set up vcpkg
+
+```bash
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+./bootstrap-vcpkg.sh
+cd ..
+```
+
+### Configure environment for vcpkg (important)
+
+To ensure **CMake presets and CLion detect vcpkg automatically without modifying the preset**, export `VCPKG_ROOT` globally for the user:
+
+```bash
+mkdir -p ~/.config/environment.d
+echo 'VCPKG_ROOT=$HOME/vcpkg' > ~/.config/environment.d/10-vcpkg.conf
+```
+
+Note: This approach requires systemd. If `systemctl status` shows "unit not found", enable systemd by editing `/etc/wsl.conf` (e.g., `sudo nano /etc/wsl.conf`) and adding:
+
+```ini
+[boot]
+systemd=true
+```
+
+Then run `wsl --shutdown` in _Powershell_ and restart WSL.
+
+Fallback (for non-systemd setups):
+```bash
+echo 'export VCPKG_ROOT=$HOME/vcpkg' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Now **log out and log in again** (or reboot), then verify:
+
+```bash
+echo $VCPKG_ROOT
+# Expected output:
+# /home/<user>/vcpkg
+```
+
+Also validate the toolchain file exists:
+
+```bash
+test -f "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" && echo "vcpkg OK" || echo "vcpkg not found"
+```
+
+## 3. Download the source code
+
+```bash
+git clone --depth 1 https://github.com/opentibiabr/remeres-map-editor.git
+cd remeres-map-editor
+```
+
+## 4. Folder structure
+
+```bash
+.
+├── remeres-map-editor
+└── vcpkg
+```
+
+## 5. Configure and build
+
+```bash
+cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON
+cmake --build --preset linux-release -j4
+```
+
+> -- Running vcpkg install 
+**This step will take a long time on the first run, as it needs to download and install all the dependencies, so be patient!**
+
+---

--- a/docs/compiling/compiling-on-wsl-ubuntu-24.04.md
+++ b/docs/compiling/compiling-on-wsl-ubuntu-24.04.md
@@ -1,0 +1,93 @@
+# Remere's Map Editor
+
+## Supported OS
+
+- Windows 11 + WSL2 with Ubuntu 24.04
+
+## 1. Install the required software
+
+The following command will install Git, CMake, a compiler and the libraries used by Remere's Map Editor.
+
+Git will be used to download the source code, and CMake will be used to generate the build files.
+
+```bash
+sudo apt update
+sudo apt install git cmake build-essential autoconf autoconf-archive automake libtool ca-certificates curl zip unzip tar pkg-config ninja-build ccache bison linux-headers-generic \
+libxi-dev libgl1-mesa-dev libegl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev \
+libxxf86vm-dev libx11-dev libxft-dev libxext-dev libwayland-dev libxkbcommon-dev libibus-1.0-dev libasound2-dev \
+libxmu-dev libdbus-1-dev libxtst-dev linux-libc-dev libarchive-dev libwxgtk3.2-dev python3-distutils-extra libxrender-dev -y
+```
+
+## 2. Set up vcpkg
+
+```bash
+git clone https://github.com/microsoft/vcpkg
+cd vcpkg
+./bootstrap-vcpkg.sh
+cd ..
+```
+
+### Configure environment for vcpkg (important)
+
+To ensure **CMake presets and CLion detect vcpkg automatically without modifying the preset**, export `VCPKG_ROOT` globally for the user:
+
+```bash
+mkdir -p ~/.config/environment.d
+echo 'VCPKG_ROOT=$HOME/vcpkg' > ~/.config/environment.d/10-vcpkg.conf
+```
+
+Note: This approach requires systemd. If `systemctl status` shows "unit not found", enable systemd by editing `/etc/wsl.conf` (e.g., `sudo nano /etc/wsl.conf`) and adding:
+
+```ini
+[boot]
+systemd=true
+```
+
+Then run `wsl --shutdown` in _Powershell_ and restart WSL.
+
+Fallback (for non-systemd setups):
+```bash
+echo 'export VCPKG_ROOT=$HOME/vcpkg' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Now **log out and log in again** (or reboot), then verify:
+
+```bash
+echo $VCPKG_ROOT
+# Expected output:
+# /home/<user>/vcpkg
+```
+
+Also validate the toolchain file exists:
+
+```bash
+test -f "$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" && echo "vcpkg OK" || echo "vcpkg not found"
+```
+
+## 3. Download the source code
+
+```bash
+git clone --depth 1 https://github.com/opentibiabr/remeres-map-editor.git
+cd remeres-map-editor
+```
+
+## 4. Folder structure
+
+```bash
+.
+├── remeres-map-editor
+└── vcpkg
+```
+
+## 5. Configure and build
+
+```bash
+cmake --preset linux-release -DTOGGLE_BIN_FOLDER=ON
+cmake --build --preset linux-release -j4
+```
+
+> -- Running vcpkg install 
+**This step will take a long time on the first run, as it needs to download and install all the dependencies, so be patient!**
+
+---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the legacy "Gitbook" link from the README "Getting Started" section; kept the "Wiki" link and added references to new compilation guides.
  * Added compilation guides: Ubuntu 24.04, Debian, Windows (CMake), Windows (Visual Studio solution), WSL Ubuntu 24.04, and WSL Debian — with environment and build setup guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/remeres-map-editor/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->