### PR TITLE
fix: remove wxSafeYield from creature Lua import

### DIFF
--- a/source/monsters.cpp
+++ b/source/monsters.cpp
@@ -337,9 +337,7 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 	wxArrayString luaFiles;
 	wxDir::GetAllFiles(directory, &luaFiles, "*.lua", wxDIR_FILES | wxDIR_DIRS | wxDIR_HIDDEN);
 
-	int fileCount = 0;
 	for (const auto &filePath : luaFiles) {
-		++fileCount;
 		std::string content = LuaParser::readFileContent(filePath.ToStdString());
 		if (content.empty()) {
 			warnings.push_back("Could not open: " + filePath);

--- a/source/monsters.cpp
+++ b/source/monsters.cpp
@@ -339,9 +339,7 @@ bool MonsterDatabase::loadFromLuaDir(const wxString &directory, wxString &error,
 
 	int fileCount = 0;
 	for (const auto &filePath : luaFiles) {
-		if (++fileCount % 50 == 0) {
-			wxSafeYield();
-		}
+		++fileCount;
 		std::string content = LuaParser::readFileContent(filePath.ToStdString());
 		if (content.empty()) {
 			warnings.push_back("Could not open: " + filePath);

--- a/source/npcs.cpp
+++ b/source/npcs.cpp
@@ -261,9 +261,7 @@ bool NpcDatabase::loadFromLuaDir(const wxString &directory, wxString &error, wxA
 
 	int fileCount = 0;
 	for (const auto &filePath : luaFiles) {
-		if (++fileCount % 50 == 0) {
-			wxSafeYield();
-		}
+		++fileCount;
 		std::string content = LuaParser::readFileContent(filePath.ToStdString());
 		if (content.empty()) {
 			warnings.push_back("Could not open: " + filePath);

--- a/source/npcs.cpp
+++ b/source/npcs.cpp
@@ -259,9 +259,7 @@ bool NpcDatabase::loadFromLuaDir(const wxString &directory, wxString &error, wxA
 	wxArrayString luaFiles;
 	wxDir::GetAllFiles(directory, &luaFiles, "*.lua", wxDIR_FILES | wxDIR_DIRS | wxDIR_HIDDEN);
 
-	int fileCount = 0;
 	for (const auto &filePath : luaFiles) {
-		++fileCount;
 		std::string content = LuaParser::readFileContent(filePath.ToStdString());
 		if (content.empty()) {
 			warnings.push_back("Could not open: " + filePath);


### PR DESCRIPTION
## Summary
This PR removes `wxSafeYield()` from the NPC and monster Lua import loops.

## Changes
- Remove `wxSafeYield()` from `NpcDatabase::loadFromLuaDir()`
- Remove `wxSafeYield()` from `MonsterDatabase::loadFromLuaDir()`

## Technical Notes
The Lua import logic remains unchanged.
This update only removes manual UI yielding from the file iteration loops.

## Validation
- Verified `source/npcs.cpp` has no new diagnostics
- Verified `source/monsters.cpp` has no new diagnostics

fix: #185 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the file loading process for monsters and NPCs by removing internal polling mechanisms during file iteration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/remeres-map-editor/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->