### PR TITLE
perf: otbm load save and preview/map renderization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+## Git Safety
+
+- Before committing or pushing, always check `git status --short --branch` and `git branch -vv`.
+- Never push directly to `origin/main`, including from the local `main` branch. Changes targeting `main` must go through a pull request.
+- A working branch must not track `origin/main` unless the current branch is exactly `main`.
+- Create new working branches under the GitHub username prefix `dudantas/`, not `codex/`, unless the user explicitly asks for another name.
+- For feature/fix branches, the upstream must point to the same remote branch name, for example `dudantas/example -> origin/dudantas/example`.
+- If a branch is tracking the wrong upstream, stop and fix it before committing or pushing:
+  - `git branch --unset-upstream <branch>`
+  - then push explicitly with `git push -u origin <branch>` only when the branch should be published.
+- Prefer explicit push targets for safety: `git push origin HEAD:<branch>`.
+- Never push to `origin/main` from a feature/fix branch. The repository may allow bypassing main protections, so this check is mandatory.
+
+## Commit Policy
+
+- Use Conventional Commit style for commit titles: `<type>(optional-scope): <summary>`.
+- Prefer these commit types: `feat`, `fix`, `perf`, `refactor`, `test`, `docs`, `build`, `ci`, `chore`, and `revert`.
+- Keep commit titles concise, imperative, and lowercase after the type, for example `fix: prevent inbox overflow`.
+- Do not end commit titles with a period.
+- Use a scope when it adds useful context, for example `fix(container): avoid stale child updates`.
+- For release-only changes, use `chore: update release version to X.Y.Z`.
+- Do not mix unrelated changes in the same commit unless the user explicitly asks for a single combined commit.
+- Before amending or rebasing commits that may already be pushed, check the remote state and prefer `--force-with-lease` when a rewrite is explicitly approved.
+
+## Build Policy
+
+- Do not compile, build, or run compile-triggering validation commands unless the user explicitly asks.
+- Prefer non-build checks such as `git diff --check`, focused file inspection, and static reasoning when the user did not ask for a build.
+
+## Precompiled Header Policy
+
+- This project uses `source/main.h` as the precompiled header through `source/CMakeLists.txt`.
+- Keep `#include "main.h"` as the first include in `.cpp` files that use the project precompiled header pattern.
+- When adding standard-library, wxWidgets, or third-party headers to several `.cpp` files, decide whether the header belongs in `source/main.h` instead of repeating local includes.
+- When adding a new local include only needed by one implementation file, keep it local to that `.cpp` and avoid adding it to `source/main.h`.
+- Prefer forward declarations in headers when possible. Do not move heavy includes into public headers unless the type definition is required there.
+- For hot-path or broad runtime changes, account for compile-time impact: do not scatter expensive includes across many translation units without updating the precompiled header strategy.
+
+## PR Communication Policy
+
+- Do not post any PR comments/reviews automatically.
+- Only post PR comments/reviews when the user explicitly asks.
+- All PR comments/reviews posted by agents must be in English.

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -258,6 +258,7 @@ target_sources(
           npcs.cpp
           numbertextctrl.cpp
           old_properties_window.cpp
+          object_pool.cpp
           palette_brushlist.cpp
           palette_common.cpp
           palette_monster.cpp

--- a/source/basemap.cpp
+++ b/source/basemap.cpp
@@ -121,8 +121,7 @@ void BaseMap::setTile(TileLocation* location, Tile* new_tile, bool remove) {
 	}
 
 	if (remove) {
-		std::unique_ptr<Tile> removedTile(old_tile);
-		removedTile.reset();
+		std::unique_ptr<Tile>{ old_tile };
 	}
 }
 
@@ -139,8 +138,7 @@ void BaseMap::setTile(int x, int y, int z, Tile* new_tile, bool remove) {
 	}
 
 	if (remove) {
-		std::unique_ptr<Tile> removedTile(old_tile);
-		removedTile.reset();
+		std::unique_ptr<Tile>{ old_tile };
 	}
 }
 

--- a/source/basemap.cpp
+++ b/source/basemap.cpp
@@ -121,7 +121,7 @@ void BaseMap::setTile(TileLocation* location, Tile* new_tile, bool remove) {
 	}
 
 	if (remove) {
-		std::unique_ptr<Tile>{ old_tile };
+		std::unique_ptr<Tile> { old_tile };
 	}
 }
 
@@ -138,7 +138,7 @@ void BaseMap::setTile(int x, int y, int z, Tile* new_tile, bool remove) {
 	}
 
 	if (remove) {
-		std::unique_ptr<Tile>{ old_tile };
+		std::unique_ptr<Tile> { old_tile };
 	}
 }
 

--- a/source/basemap.cpp
+++ b/source/basemap.cpp
@@ -20,6 +20,8 @@
 #include "tile.h"
 #include "basemap.h"
 
+#include <memory>
+
 BaseMap::BaseMap() :
 	allocator(),
 	tilecount(0),
@@ -119,7 +121,8 @@ void BaseMap::setTile(TileLocation* location, Tile* new_tile, bool remove) {
 	}
 
 	if (remove) {
-		delete old_tile;
+		std::unique_ptr<Tile> removedTile(old_tile);
+		removedTile.reset();
 	}
 }
 
@@ -136,7 +139,8 @@ void BaseMap::setTile(int x, int y, int z, Tile* new_tile, bool remove) {
 	}
 
 	if (remove) {
-		delete old_tile;
+		std::unique_ptr<Tile> removedTile(old_tile);
+		removedTile.reset();
 	}
 }
 

--- a/source/basemap.cpp
+++ b/source/basemap.cpp
@@ -99,6 +99,30 @@ TileLocation* BaseMap::createTileL(const Position &pos) {
 	return createTileL(pos.x, pos.y, pos.z);
 }
 
+void BaseMap::setTile(TileLocation* location, Tile* new_tile, bool remove) {
+	ASSERT(location);
+	ASSERT(!new_tile || new_tile->getX() == location->getX());
+	ASSERT(!new_tile || new_tile->getY() == location->getY());
+	ASSERT(!new_tile || new_tile->getZ() == location->getZ());
+
+	Tile* old_tile = location->tile;
+	location->tile = new_tile;
+
+	if ((remove && old_tile) || new_tile) {
+		updateUniqueIds(remove ? old_tile : nullptr, new_tile);
+	}
+
+	if (new_tile && !old_tile) {
+		++tilecount;
+	} else if (old_tile && !new_tile) {
+		--tilecount;
+	}
+
+	if (remove) {
+		delete old_tile;
+	}
+}
+
 void BaseMap::setTile(int x, int y, int z, Tile* new_tile, bool remove) {
 	ASSERT(!new_tile || new_tile->getX() == x);
 	ASSERT(!new_tile || new_tile->getY() == y);

--- a/source/basemap.h
+++ b/source/basemap.h
@@ -118,6 +118,7 @@ public:
 	}
 
 	// Assigns a tile, it might seem pointless to provide position, but it is not, as the passed tile may be nullptr
+	void setTile(TileLocation* location, Tile* new_tile, bool remove = false);
 	void setTile(int x, int y, int z, Tile* new_tile, bool remove = false);
 	void setTile(const Position &position, Tile* new_tile, bool remove = false);
 	void setTile(Tile* new_tile, bool remove = false);

--- a/source/basemap.h
+++ b/source/basemap.h
@@ -146,26 +146,31 @@ protected:
 	virtual void updateUniqueIds(Tile* old_tile, Tile* new_tile) { }
 
 	template <typename Fn>
-	void forEachTileLocation(QTreeNode &node, Fn &fn) {
-		if (node.isLeaf) {
-			for (int z = 0; z < rme::MapLayers; ++z) {
-				Floor* floor = node.array[z];
-				if (!floor) {
-					continue;
-				}
-
-				for (int index = 0; index < rme::MapLayers; ++index) {
-					TileLocation &location = floor->locs[index];
-					if (location.get()) {
-						fn(&location);
-					}
-				}
+	void forEachFloorTileLocation(Floor &floor, Fn &fn) {
+		for (TileLocation &location : floor.locs) {
+			if (location.get()) {
+				fn(&location);
 			}
+		}
+	}
+
+	template <typename Fn>
+	void forEachLeafTileLocation(const QTreeNode &node, Fn &fn) {
+		for (Floor* floor : node.array) {
+			if (floor) {
+				forEachFloorTileLocation(*floor, fn);
+			}
+		}
+	}
+
+	template <typename Fn>
+	void forEachTileLocation(const QTreeNode &node, Fn &fn) {
+		if (node.isLeaf) {
+			forEachLeafTileLocation(node, fn);
 			return;
 		}
 
-		for (int index = 0; index < rme::MapLayers; ++index) {
-			QTreeNode* child = node.child[index];
+		for (QTreeNode* child : node.child) {
 			if (child) {
 				forEachTileLocation(*child, fn);
 			}

--- a/source/basemap.h
+++ b/source/basemap.h
@@ -170,7 +170,7 @@ protected:
 			return;
 		}
 
-		for (QTreeNode* child : node.child) {
+		for (const QTreeNode* child : node.child) {
 			if (child) {
 				forEachTileLocation(*child, fn);
 			}

--- a/source/basemap.h
+++ b/source/basemap.h
@@ -92,6 +92,12 @@ public:
 	void clear(bool del = true);
 	MapIterator begin();
 	MapIterator end();
+
+	template <typename Fn>
+	void forEachTileLocation(Fn &fn) {
+		forEachTileLocation(root, fn);
+	}
+
 	uint64_t size() const noexcept {
 		return tilecount;
 	}
@@ -138,6 +144,33 @@ public:
 
 protected:
 	virtual void updateUniqueIds(Tile* old_tile, Tile* new_tile) { }
+
+	template <typename Fn>
+	void forEachTileLocation(QTreeNode &node, Fn &fn) {
+		if (node.isLeaf) {
+			for (int z = 0; z < rme::MapLayers; ++z) {
+				Floor* floor = node.array[z];
+				if (!floor) {
+					continue;
+				}
+
+				for (int index = 0; index < rme::MapLayers; ++index) {
+					TileLocation &location = floor->locs[index];
+					if (location.get()) {
+						fn(&location);
+					}
+				}
+			}
+			return;
+		}
+
+		for (int index = 0; index < rme::MapLayers; ++index) {
+			QTreeNode* child = node.child[index];
+			if (child) {
+				forEachTileLocation(*child, fn);
+			}
+		}
+	}
 
 	uint64_t tilecount;
 

--- a/source/con_vector.h
+++ b/source/con_vector.h
@@ -60,6 +60,13 @@ public:
 		return start[index];
 	}
 
+	const T* ptr(size_t index) const {
+		if (index >= sz) {
+			return nullptr;
+		}
+		return &start[index];
+	}
+
 	void set(size_t index, T value) {
 		locate(index) = value;
 	}

--- a/source/filehandle.cpp
+++ b/source/filehandle.cpp
@@ -652,24 +652,14 @@ NodeFileWriteHandle::~NodeFileWriteHandle() {
 }
 
 bool NodeFileWriteHandle::addNode(uint8_t nodetype) {
-	cache[local_write_index++] = NODE_START;
-	if (local_write_index >= cache_size) {
-		renewCache();
-	}
-
-	cache[local_write_index++] = nodetype;
-	if (local_write_index >= cache_size) {
-		renewCache();
-	}
+	writeCacheByte(NODE_START);
+	writeCacheByte(nodetype);
 
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::endNode() {
-	cache[local_write_index++] = NODE_END;
-	if (local_write_index >= cache_size) {
-		renewCache();
-	}
+	writeCacheByte(NODE_END);
 
 	return error_code == FILE_NO_ERROR;
 }

--- a/source/filehandle.cpp
+++ b/source/filehandle.cpp
@@ -429,18 +429,15 @@ void BinaryNode::load() {
 	size_t &cache_length = file->cache_length;
 	size_t &local_read_index = file->local_read_index;
 	while (true) {
-		if (local_read_index >= cache_length) {
-			if (!file->renewCache()) {
-				// Failed to renew, exit
-				file->error_code = FILE_PREMATURE_END;
-				return;
-			}
+		if (local_read_index >= cache_length && !file->renewCache()) {
+			// Failed to renew, exit
+			file->error_code = FILE_PREMATURE_END;
+			return;
 		}
 
 		const size_t chunk_start = local_read_index;
 		while (local_read_index < cache_length) {
-			const uint8_t op = cache[local_read_index];
-			if (op == NODE_START || op == NODE_END || op == ESCAPE_CHAR) {
+			if (const uint8_t op = cache[local_read_index]; op == NODE_START || op == NODE_END || op == ESCAPE_CHAR) {
 				break;
 			}
 			++local_read_index;
@@ -467,12 +464,10 @@ void BinaryNode::load() {
 			}
 
 			case ESCAPE_CHAR: {
-				if (local_read_index >= cache_length) {
-					if (!file->renewCache()) {
-						// Failed to renew, exit
-						file->error_code = FILE_PREMATURE_END;
-						return;
-					}
+				if (local_read_index >= cache_length && !file->renewCache()) {
+					// Failed to renew, exit
+					file->error_code = FILE_PREMATURE_END;
+					return;
 				}
 
 				op = cache[local_read_index];
@@ -685,8 +680,7 @@ bool NodeFileWriteHandle::addU8(uint8_t u8) {
 }
 
 bool NodeFileWriteHandle::addByte(uint8_t u8) {
-	writeByte(u8);
-	return error_code == FILE_NO_ERROR;
+	return addU8(u8);
 }
 
 bool NodeFileWriteHandle::addU16(uint16_t u16) {

--- a/source/filehandle.cpp
+++ b/source/filehandle.cpp
@@ -679,8 +679,9 @@ bool NodeFileWriteHandle::addU8(uint8_t u8) {
 	return error_code == FILE_NO_ERROR;
 }
 
-bool NodeFileWriteHandle::addByte(uint8_t u8) {
-	return addU8(u8);
+bool NodeFileWriteHandle::addByte(uint8_t u8) { // NOSONAR - keep this direct to avoid an extra call in the save hot path.
+	writeByte(u8);
+	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addU16(uint16_t u16) {

--- a/source/filehandle.cpp
+++ b/source/filehandle.cpp
@@ -437,8 +437,23 @@ void BinaryNode::load() {
 			}
 		}
 
-		uint8_t op = cache[local_read_index];
-		++local_read_index;
+		const size_t chunk_start = local_read_index;
+		while (local_read_index < cache_length) {
+			const uint8_t op = cache[local_read_index];
+			if (op == NODE_START || op == NODE_END || op == ESCAPE_CHAR) {
+				break;
+			}
+			++local_read_index;
+		}
+
+		if (local_read_index > chunk_start) {
+			data.append(reinterpret_cast<const char*>(cache + chunk_start), local_read_index - chunk_start);
+			if (local_read_index >= cache_length) {
+				continue;
+			}
+		}
+
+		uint8_t op = cache[local_read_index++];
 
 		switch (op) {
 			case NODE_START: {
@@ -462,14 +477,13 @@ void BinaryNode::load() {
 
 				op = cache[local_read_index];
 				++local_read_index;
-				break;
+				data.append(1, op);
+				continue;
 			}
 
 			default:
 				break;
 		}
-		// std::cout << "Appending..." << std::endl;
-		data.append(1, op);
 	}
 }
 

--- a/source/filehandle.cpp
+++ b/source/filehandle.cpp
@@ -680,27 +680,38 @@ bool NodeFileWriteHandle::endNode() {
 }
 
 bool NodeFileWriteHandle::addU8(uint8_t u8) {
-	writeBytes(&u8, sizeof(u8));
+	writeByte(u8);
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addByte(uint8_t u8) {
-	writeBytes(&u8, sizeof(u8));
+	writeByte(u8);
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addU16(uint16_t u16) {
-	writeBytes(reinterpret_cast<uint8_t*>(&u16), sizeof(u16));
+	writeByte(static_cast<uint8_t>(u16));
+	writeByte(static_cast<uint8_t>(u16 >> 8));
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addU32(uint32_t u32) {
-	writeBytes(reinterpret_cast<uint8_t*>(&u32), sizeof(u32));
+	writeByte(static_cast<uint8_t>(u32));
+	writeByte(static_cast<uint8_t>(u32 >> 8));
+	writeByte(static_cast<uint8_t>(u32 >> 16));
+	writeByte(static_cast<uint8_t>(u32 >> 24));
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addU64(uint64_t u64) {
-	writeBytes(reinterpret_cast<uint8_t*>(&u64), sizeof(u64));
+	writeByte(static_cast<uint8_t>(u64));
+	writeByte(static_cast<uint8_t>(u64 >> 8));
+	writeByte(static_cast<uint8_t>(u64 >> 16));
+	writeByte(static_cast<uint8_t>(u64 >> 24));
+	writeByte(static_cast<uint8_t>(u64 >> 32));
+	writeByte(static_cast<uint8_t>(u64 >> 40));
+	writeByte(static_cast<uint8_t>(u64 >> 48));
+	writeByte(static_cast<uint8_t>(u64 >> 56));
 	return error_code == FILE_NO_ERROR;
 }
 

--- a/source/filehandle.h
+++ b/source/filehandle.h
@@ -336,22 +336,59 @@ protected:
 	size_t cache_size;
 	size_t local_write_index;
 
+	FORCEINLINE void writeRawBytes(const uint8_t* ptr, size_t sz) {
+		while (sz != 0) {
+			if (local_write_index >= cache_size) {
+				renewCache();
+			}
+
+			const size_t available = cache_size - local_write_index;
+			const size_t writable = sz < available ? sz : available;
+			memcpy(cache + local_write_index, ptr, writable);
+			local_write_index += writable;
+			ptr += writable;
+			sz -= writable;
+
+			if (local_write_index >= cache_size) {
+				renewCache();
+			}
+		}
+	}
+
+	FORCEINLINE void writeEscapedByte(uint8_t byte) {
+		cache[local_write_index++] = ESCAPE_CHAR;
+		if (local_write_index >= cache_size) {
+			renewCache();
+		}
+
+		cache[local_write_index++] = byte;
+		if (local_write_index >= cache_size) {
+			renewCache();
+		}
+	}
+
 	FORCEINLINE void writeBytes(const uint8_t* ptr, size_t sz) {
-		if (sz) {
-			do {
-				if (*ptr == NODE_START || *ptr == NODE_END || *ptr == ESCAPE_CHAR) {
-					cache[local_write_index++] = ESCAPE_CHAR;
-					if (local_write_index >= cache_size) {
-						renewCache();
-					}
+		while (sz != 0) {
+			size_t plain_size = 0;
+			while (plain_size < sz) {
+				const uint8_t byte = ptr[plain_size];
+				if (byte == NODE_START || byte == NODE_END || byte == ESCAPE_CHAR) {
+					break;
 				}
-				cache[local_write_index++] = *ptr;
-				if (local_write_index >= cache_size) {
-					renewCache();
-				}
-				++ptr;
-				--sz;
-			} while (sz != 0);
+				++plain_size;
+			}
+
+			writeRawBytes(ptr, plain_size);
+			ptr += plain_size;
+			sz -= plain_size;
+
+			if (sz == 0) {
+				break;
+			}
+
+			writeEscapedByte(*ptr);
+			++ptr;
+			--sz;
 		}
 	}
 };

--- a/source/filehandle.h
+++ b/source/filehandle.h
@@ -367,6 +367,18 @@ protected:
 		}
 	}
 
+	FORCEINLINE void writeByte(uint8_t byte) {
+		if (byte == NODE_START || byte == NODE_END || byte == ESCAPE_CHAR) {
+			writeEscapedByte(byte);
+			return;
+		}
+
+		cache[local_write_index++] = byte;
+		if (local_write_index >= cache_size) {
+			renewCache();
+		}
+	}
+
 	FORCEINLINE void writeBytes(const uint8_t* ptr, size_t sz) {
 		while (sz != 0) {
 			size_t plain_size = 0;

--- a/source/filehandle.h
+++ b/source/filehandle.h
@@ -383,8 +383,7 @@ protected:
 		while (sz != 0) {
 			size_t plain_size = 0;
 			while (plain_size < sz) {
-				const uint8_t byte = ptr[plain_size];
-				if (byte == NODE_START || byte == NODE_END || byte == ESCAPE_CHAR) {
+				if (const uint8_t byte = ptr[plain_size]; byte == NODE_START || byte == NODE_END || byte == ESCAPE_CHAR) {
 					break;
 				}
 				++plain_size;

--- a/source/filehandle.h
+++ b/source/filehandle.h
@@ -348,10 +348,6 @@ protected:
 			local_write_index += writable;
 			ptr += writable;
 			sz -= writable;
-
-			if (local_write_index >= cache_size) {
-				renewCache();
-			}
 		}
 	}
 

--- a/source/filehandle.h
+++ b/source/filehandle.h
@@ -351,16 +351,17 @@ protected:
 		}
 	}
 
-	FORCEINLINE void writeEscapedByte(uint8_t byte) {
-		cache[local_write_index++] = ESCAPE_CHAR;
+	FORCEINLINE void writeCacheByte(uint8_t byte) {
 		if (local_write_index >= cache_size) {
 			renewCache();
 		}
 
 		cache[local_write_index++] = byte;
-		if (local_write_index >= cache_size) {
-			renewCache();
-		}
+	}
+
+	FORCEINLINE void writeEscapedByte(uint8_t byte) {
+		writeCacheByte(ESCAPE_CHAR);
+		writeCacheByte(byte);
 	}
 
 	FORCEINLINE void writeByte(uint8_t byte) {
@@ -369,10 +370,7 @@ protected:
 			return;
 		}
 
-		cache[local_write_index++] = byte;
-		if (local_write_index >= cache_size) {
-			renewCache();
-		}
+		writeCacheByte(byte);
 	}
 
 	FORCEINLINE void writeBytes(const uint8_t* ptr, size_t sz) {

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -30,6 +30,7 @@
 #include "materials.h"
 #include "doodad_brush.h"
 #include "spawn_monster_brush.h"
+#include "object_pool.h"
 
 #include "common_windows.h"
 #include "result_window.h"
@@ -536,6 +537,8 @@ void GUI::SaveMapAs() {
 }
 
 bool GUI::LoadMap(const FileName &fileName) {
+	rme::bindPooledObjectOwnerThread();
+
 	FinishWelcomeDialog();
 
 	if (GetCurrentEditor() && !GetCurrentMap().hasChanged() && !GetCurrentMap().hasFile()) {

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -545,13 +545,18 @@ bool GUI::LoadMap(const FileName &fileName) {
 		g_gui.CloseCurrentEditor();
 	}
 
+	rme::resetPooledObjectStats();
+
 	Editor* editor;
 	try {
 		editor = newd Editor(copybuffer, fileName);
 	} catch (std::runtime_error &e) {
+		rme::dumpPooledObjectStats();
 		PopupDialog(root, "Error!", wxString(e.what(), wxConvUTF8), wxOK);
 		return false;
 	}
+
+	rme::dumpPooledObjectStats();
 
 	auto* mapTab = newd MapTab(tabbook, editor);
 	mapTab->OnSwitchEditorMode(mode);

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -32,6 +32,8 @@
 #include "complexitem.h"
 #include "town.h"
 
+#include <algorithm>
+
 typedef uint8_t attribute_t;
 typedef uint32_t flags_t;
 
@@ -128,8 +130,7 @@ namespace {
 
 		while (true) {
 			const bool hasLeft = readNormalizedLineEndingChar(left, leftOffset, leftChar);
-			const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar);
-			if (hasLeft != hasRight) {
+			if (const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar); hasLeft != hasRight) {
 				return false;
 			}
 			if (!hasLeft) {
@@ -184,6 +185,124 @@ namespace {
 		}
 
 		return writeContentToFile(filepath, content);
+	}
+
+	struct TileAreaSaveState {
+		uint32_t tilesSaved = 0;
+		bool firstArea = true;
+		int localX = -1;
+		int localY = -1;
+		int localZ = -1;
+	};
+
+	void updateTileSaveProgress(const Map &map, TileAreaSaveState &state) {
+		++state.tilesSaved;
+		const uint64_t tileCount = map.getTileCount();
+		if (tileCount != 0 && state.tilesSaved % 8192 == 0) {
+			g_gui.SetLoadDone(int(state.tilesSaved / double(tileCount) * 100.0));
+		}
+	}
+
+	bool needsNewTileArea(const Position &position, const TileAreaSaveState &state) {
+		return position.x < state.localX || position.x >= state.localX + 256 || position.y < state.localY || position.y >= state.localY + 256 || position.z != state.localZ;
+	}
+
+	void beginTileArea(NodeFileWriteHandle &file, const Position &position, TileAreaSaveState &state) {
+		if (!state.firstArea) {
+			file.endNode();
+		}
+		state.firstArea = false;
+
+		file.addNode(OTBM_TILE_AREA);
+		file.addU16(state.localX = position.x & 0xFF00);
+		file.addU16(state.localY = position.y & 0xFF00);
+		file.addU8(state.localZ = position.z);
+	}
+
+	void saveTileGround(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
+		if (!tile.ground) {
+			return;
+		}
+
+		Item* ground = tile.ground;
+		const ItemType &groundType = ground->getItemType();
+		const uint16_t groundId = ground->getID();
+		if (groundId == 0 || groundType.isMetaItem()) {
+			return;
+		}
+
+		if (groundType.has_equivalent) {
+			const bool found = std::any_of(tile.items.begin(), tile.items.end(), [groundId](const Item* item) {
+				return item->getItemType().ground_equivalent == groundId;
+			});
+			if (!found) {
+				ground->serializeItemNode_OTBM(mapHandle, file);
+			}
+			return;
+		}
+
+		if (ground->isComplex()) {
+			ground->serializeItemNode_OTBM(mapHandle, file);
+			return;
+		}
+
+		file.addByte(OTBM_ATTR_ITEM);
+		ground->serializeItemCompact_OTBM(mapHandle, file);
+	}
+
+	void saveTileItems(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
+		for (Item* item : tile.items) {
+			const ItemType &itemType = item->getItemType();
+			if (itemType.isMetaItem() || item->getID() == 0) {
+				continue;
+			}
+			item->serializeItemNode_OTBM(mapHandle, file);
+		}
+	}
+
+	void saveTileZones(NodeFileWriteHandle &file, const Tile &tile) {
+		if (tile.zones.empty()) {
+			return;
+		}
+
+		file.addNode(OTBM_TILE_ZONE);
+		file.addU16(tile.zones.size());
+		for (const auto &zoneId : tile.zones) {
+			file.addU16(zoneId);
+		}
+		file.endNode();
+	}
+
+	void saveTileLocation(const IOMapOTBM &mapHandle, Map &map, NodeFileWriteHandle &file, TileAreaSaveState &state, TileLocation* tileLocation) {
+		updateTileSaveProgress(map, state);
+
+		Tile* saveTile = tileLocation->get();
+		if (!saveTile || saveTile->empty()) {
+			return;
+		}
+
+		const Position &position = saveTile->getPosition();
+		if (needsNewTileArea(position, state)) {
+			beginTileArea(file, position, state);
+		}
+
+		file.addNode(saveTile->isHouseTile() ? OTBM_HOUSETILE : OTBM_TILE);
+		file.addU8(saveTile->getX() & 0xFF);
+		file.addU8(saveTile->getY() & 0xFF);
+
+		if (saveTile->isHouseTile()) {
+			file.addU32(saveTile->getHouseID());
+		}
+
+		if (saveTile->getMapFlags()) {
+			file.addByte(OTBM_ATTR_TILE_FLAGS);
+			file.addU32(saveTile->getMapFlags());
+		}
+
+		saveTileGround(mapHandle, file, *saveTile);
+		saveTileItems(mapHandle, file, *saveTile);
+		saveTileZones(file, *saveTile);
+		file.endNode();
 	}
 }
 
@@ -1766,111 +1885,14 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 			f.addString(nstr(tmpName.GetFullName()));
 
 			// Start writing tiles
-			uint32_t tiles_saved = 0;
-			bool first = true;
-
-			int local_x = -1, local_y = -1, local_z = -1;
-
-			auto saveTileLocation = [&](TileLocation* tileLocation) {
-				// Update progressbar
-				++tiles_saved;
-				if (tiles_saved % 8192 == 0) {
-					g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
-				}
-
-				// Get tile
-				Tile* save_tile = tileLocation->get();
-
-				// Is it an empty tile that we can skip? (Leftovers...)
-				if (!save_tile || save_tile->empty()) {
-					return;
-				}
-
-				const Position &pos = save_tile->getPosition();
-
-				// Decide if newd node should be created
-				if (pos.x < local_x || pos.x >= local_x + 256 || pos.y < local_y || pos.y >= local_y + 256 || pos.z != local_z) {
-					// End last node
-					if (!first) {
-						f.endNode();
-					}
-					first = false;
-
-					// Start newd node
-					f.addNode(OTBM_TILE_AREA);
-					f.addU16(local_x = pos.x & 0xFF00);
-					f.addU16(local_y = pos.y & 0xFF00);
-					f.addU8(local_z = pos.z);
-				}
-				f.addNode(save_tile->isHouseTile() ? OTBM_HOUSETILE : OTBM_TILE);
-
-				f.addU8(save_tile->getX() & 0xFF);
-				f.addU8(save_tile->getY() & 0xFF);
-
-				if (save_tile->isHouseTile()) {
-					f.addU32(save_tile->getHouseID());
-				}
-
-				if (save_tile->getMapFlags()) {
-					f.addByte(OTBM_ATTR_TILE_FLAGS);
-					f.addU32(save_tile->getMapFlags());
-				}
-
-				if (save_tile->ground) {
-					Item* ground = save_tile->ground;
-					const ItemType &groundType = ground->getItemType();
-					const uint16_t groundId = ground->getID();
-					if (groundId == 0) {
-						// Skip invalid placeholder grounds without dropping the tile's items or zones.
-					} else if (groundType.isMetaItem()) {
-						// Do nothing, we don't save metaitems...
-					} else if (groundType.has_equivalent) {
-						bool found = false;
-						for (Item* item : save_tile->items) {
-							if (item->getItemType().ground_equivalent == groundId) {
-								// Do nothing
-								// Found equivalent
-								found = true;
-								break;
-							}
-						}
-
-						if (!found) {
-							ground->serializeItemNode_OTBM(self, f);
-						}
-					} else if (ground->isComplex()) {
-						ground->serializeItemNode_OTBM(self, f);
-					} else {
-						f.addByte(OTBM_ATTR_ITEM);
-						ground->serializeItemCompact_OTBM(self, f);
-					}
-				}
-
-				for (Item* item : save_tile->items) {
-					const ItemType &itemType = item->getItemType();
-					if (!itemType.isMetaItem()) {
-						const uint16_t itemId = item->getID();
-						if (itemId == 0) {
-							continue;
-						}
-						item->serializeItemNode_OTBM(self, f);
-					}
-				}
-				if (!save_tile->zones.empty()) {
-					f.addNode(OTBM_TILE_ZONE);
-					f.addU16(save_tile->zones.size());
-					for (const auto &zoneId : save_tile->zones) {
-						f.addU16(zoneId);
-					}
-					f.endNode();
-				}
-
-				f.endNode();
+			TileAreaSaveState tileAreaState;
+			auto writeTileLocation = [&](TileLocation* tileLocation) {
+				saveTileLocation(self, map, f, tileAreaState, tileLocation);
 			};
-			map.forEachTileLocation(saveTileLocation);
+			map.forEachTileLocation(writeTileLocation);
 
 			// Only close the last node if one has actually been created
-			if (!first) {
+			if (!tileAreaState.firstArea) {
 				f.endNode();
 			}
 

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1668,8 +1668,7 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 
 			int local_x = -1, local_y = -1, local_z = -1;
 
-			MapIterator map_iterator = map.begin();
-			while (map_iterator != map.end()) {
+			auto saveTileLocation = [&](TileLocation* tileLocation) {
 				// Update progressbar
 				++tiles_saved;
 				if (tiles_saved % 8192 == 0) {
@@ -1677,12 +1676,11 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 				}
 
 				// Get tile
-				Tile* save_tile = (*map_iterator)->get();
+				Tile* save_tile = tileLocation->get();
 
 				// Is it an empty tile that we can skip? (Leftovers...)
 				if (!save_tile || save_tile->empty()) {
-					++map_iterator;
-					continue;
+					return;
 				}
 
 				const Position &pos = save_tile->getPosition();
@@ -1732,19 +1730,19 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 
 						if (!found) {
 							if (ground->getID() == 0) {
-								continue;
+								return;
 							}
 							ground->serializeItemNode_OTBM(self, f);
 						}
 					} else if (ground->isComplex()) {
 						if (ground->getID() == 0) {
-							continue;
+							return;
 						}
 						ground->serializeItemNode_OTBM(self, f);
 					} else {
 						f.addByte(OTBM_ATTR_ITEM);
 						if (ground->getID() == 0) {
-							continue;
+							return;
 						}
 						ground->serializeItemCompact_OTBM(self, f);
 					}
@@ -1768,8 +1766,8 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 				}
 
 				f.endNode();
-				++map_iterator;
-			}
+			};
+			map.forEachTileLocation(saveTileLocation);
 
 			// Only close the last node if one has actually been created
 			if (!first) {

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -171,6 +171,20 @@ namespace {
 		return file.Close();
 	}
 
+	FORCEINLINE bool isWildcardOtbmIdentifier(const uint8_t* data) {
+		return data[0] == 0 && data[1] == 0 && data[2] == 0 && data[3] == 0;
+	}
+
+	FORCEINLINE bool hasValidOtbmPrefix(const uint8_t* data, size_t size) {
+		if (size < 5) {
+			return false;
+		}
+		if (!isWildcardOtbmIdentifier(data) && memcmp(data, "OTBM", 4) != 0) {
+			return false;
+		}
+		return data[4] == NODE_START;
+	}
+
 	bool saveXmlFileIfChanged(const pugi::xml_document &doc, const wxString &filepath) {
 		std::ostringstream stream;
 		doc.save(stream, "\t", pugi::format_default, pugi::encoding_utf8);
@@ -673,15 +687,17 @@ bool IOMapOTBM::getVersionInfo(const FileName &filename, MapVersion &out_ver) {
 				memset(buffer, 0, 8096);
 
 				// Read from the archive
-				int read_bytes = archive_read_data(a.get(), buffer, 8096);
+				const auto readBytes = archive_read_data(a.get(), buffer, 8096);
+				if (readBytes < 0) {
+					return false;
+				}
 
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < 4) {
+				if (!hasValidOtbmPrefix(buffer, static_cast<size_t>(readBytes))) {
 					return false;
 				}
 
 				// Create a read handle on it
-				std::shared_ptr<NodeFileReadHandle> f(new MemoryNodeFileReadHandle(buffer + 4, read_bytes - 4));
+				std::shared_ptr<NodeFileReadHandle> f(new MemoryNodeFileReadHandle(buffer + 4, static_cast<size_t>(readBytes) - 4));
 
 				// Read the version info
 				return getVersionInfo(f.get(), out_ver);
@@ -760,15 +776,13 @@ bool IOMapOTBM::loadMap(Map &map, const FileName &filename) {
 				std::shared_ptr<uint8_t> otbm_buffer(new uint8_t[otbm_size], [](uint8_t* p) { delete[] p; });
 
 				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < 4) {
+				const auto readBytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
+				if (readBytes < 0 || static_cast<size_t>(readBytes) < otbm_size) {
+					error("Could not read file.");
 					return false;
 				}
-
-				if (read_bytes < otbm_size) {
-					error("Could not read file.");
+				if (!hasValidOtbmPrefix(otbm_buffer.get(), static_cast<size_t>(readBytes))) {
+					error("Could not read OTBM file header.");
 					return false;
 				}
 
@@ -883,7 +897,7 @@ bool IOMapOTBM::loadMap(Map &map, const FileName &filename) {
 	}
 
 	const size_t otbmSize = otbmFile.size();
-	if (otbmSize < 4) {
+	if (otbmSize < 5) {
 		error("Could not read OTBM file header.");
 		return false;
 	}
@@ -894,9 +908,13 @@ bool IOMapOTBM::loadMap(Map &map, const FileName &filename) {
 		return false;
 	}
 
-	const bool wildcardIdentifier = otbmBuffer[0] == 0 && otbmBuffer[1] == 0 && otbmBuffer[2] == 0 && otbmBuffer[3] == 0;
-	if (!wildcardIdentifier && memcmp(otbmBuffer.data(), "OTBM", 4) != 0) {
+	const bool hasKnownIdentifier = isWildcardOtbmIdentifier(otbmBuffer.data()) || memcmp(otbmBuffer.data(), "OTBM", 4) == 0;
+	if (!hasKnownIdentifier) {
 		error("File magic number not recognized.");
+		return false;
+	}
+	if (otbmBuffer[4] != NODE_START) {
+		error("Could not read root node.");
 		return false;
 	}
 

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -56,135 +56,135 @@ void reform(Map* map, Tile* tile, Item* item) {
 }
 
 namespace {
-struct FloorLookupCache {
-	Floor* floor = nullptr;
-	int floorX = -1;
-	int floorY = -1;
-	int floorZ = -1;
-};
+	struct FloorLookupCache {
+		Floor* floor = nullptr;
+		int floorX = -1;
+		int floorY = -1;
+		int floorZ = -1;
+	};
 
-Tile* getCachedTile(Map &map, const Position &position, FloorLookupCache &cache) {
-	const int floorX = position.x & ~3;
-	const int floorY = position.y & ~3;
-	if (!cache.floor || cache.floorX != floorX || cache.floorY != floorY || cache.floorZ != position.z) {
-		QTreeNode* leaf = map.getLeaf(position.x, position.y);
-		cache.floor = leaf ? leaf->getFloor(position.z) : nullptr;
-		cache.floorX = floorX;
-		cache.floorY = floorY;
-		cache.floorZ = position.z;
-	}
-
-	if (!cache.floor) {
-		return nullptr;
-	}
-
-	return cache.floor->locs[(position.x & 3) * 4 + (position.y & 3)].get();
-}
-
-bool readFileContent(const wxString &filepath, std::string &content) {
-	if (!wxFileExists(filepath)) {
-		return false;
-	}
-
-	wxFile file(filepath, wxFile::read);
-	if (!file.IsOpened()) {
-		return false;
-	}
-
-	const wxFileOffset fileSize = file.Length();
-	if (fileSize < 0) {
-		return false;
-	}
-
-	content.resize(static_cast<size_t>(fileSize));
-	if (content.empty()) {
-		return true;
-	}
-
-	const auto bytesRead = file.Read(content.data(), content.size());
-	return static_cast<size_t>(bytesRead) == content.size();
-}
-
-bool readNormalizedLineEndingChar(const std::string &content, size_t &offset, char &out) {
-	if (offset >= content.size()) {
-		return false;
-	}
-
-	out = content[offset++];
-	if (out == '\r') {
-		if (offset < content.size() && content[offset] == '\n') {
-			++offset;
+	Tile* getCachedTile(Map &map, const Position &position, FloorLookupCache &cache) {
+		const int floorX = position.x & ~3;
+		const int floorY = position.y & ~3;
+		if (!cache.floor || cache.floorX != floorX || cache.floorY != floorY || cache.floorZ != position.z) {
+			QTreeNode* leaf = map.getLeaf(position.x, position.y);
+			cache.floor = leaf ? leaf->getFloor(position.z) : nullptr;
+			cache.floorX = floorX;
+			cache.floorY = floorY;
+			cache.floorZ = position.z;
 		}
-		out = '\n';
+
+		if (!cache.floor) {
+			return nullptr;
+		}
+
+		return cache.floor->locs[(position.x & 3) * 4 + (position.y & 3)].get();
 	}
-	return true;
-}
 
-bool contentMatchesIgnoringLineEndings(const std::string &left, const std::string &right) {
-	size_t leftOffset = 0;
-	size_t rightOffset = 0;
-	char leftChar = '\0';
-	char rightChar = '\0';
-
-	while (true) {
-		const bool hasLeft = readNormalizedLineEndingChar(left, leftOffset, leftChar);
-		const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar);
-		if (hasLeft != hasRight) {
+	bool readFileContent(const wxString &filepath, std::string &content) {
+		if (!wxFileExists(filepath)) {
 			return false;
 		}
-		if (!hasLeft) {
+
+		wxFile file(filepath, wxFile::read);
+		if (!file.IsOpened()) {
+			return false;
+		}
+
+		const wxFileOffset fileSize = file.Length();
+		if (fileSize < 0) {
+			return false;
+		}
+
+		content.resize(static_cast<size_t>(fileSize));
+		if (content.empty()) {
 			return true;
 		}
-		if (leftChar != rightChar) {
+
+		const auto bytesRead = file.Read(content.data(), content.size());
+		return static_cast<size_t>(bytesRead) == content.size();
+	}
+
+	bool readNormalizedLineEndingChar(const std::string &content, size_t &offset, char &out) {
+		if (offset >= content.size()) {
 			return false;
 		}
-	}
-}
 
-bool fileMatchesXmlContent(const wxString &filepath, const std::string &content) {
-	std::string existingContent;
-	if (!readFileContent(filepath, existingContent)) {
-		return false;
-	}
-
-	if (existingContent == content) {
+		out = content[offset++];
+		if (out == '\r') {
+			if (offset < content.size() && content[offset] == '\n') {
+				++offset;
+			}
+			out = '\n';
+		}
 		return true;
 	}
 
-	return contentMatchesIgnoringLineEndings(existingContent, content);
-}
+	bool contentMatchesIgnoringLineEndings(const std::string &left, const std::string &right) {
+		size_t leftOffset = 0;
+		size_t rightOffset = 0;
+		char leftChar = '\0';
+		char rightChar = '\0';
 
-bool writeContentToFile(const wxString &filepath, const std::string &content) {
-	wxFile file(filepath, wxFile::write);
-	if (!file.IsOpened()) {
-		return false;
-	}
-
-	if (!content.empty()) {
-		const auto bytesWritten = file.Write(content.data(), content.size());
-		if (static_cast<size_t>(bytesWritten) != content.size()) {
-			return false;
+		while (true) {
+			const bool hasLeft = readNormalizedLineEndingChar(left, leftOffset, leftChar);
+			const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar);
+			if (hasLeft != hasRight) {
+				return false;
+			}
+			if (!hasLeft) {
+				return true;
+			}
+			if (leftChar != rightChar) {
+				return false;
+			}
 		}
 	}
-	return file.Close();
-}
 
-bool saveXmlFileIfChanged(const pugi::xml_document &doc, const wxString &filepath) {
-	std::ostringstream stream;
-	doc.save(stream, "\t", pugi::format_default, pugi::encoding_utf8);
-	const std::string content = stream.str();
+	bool fileMatchesXmlContent(const wxString &filepath, const std::string &content) {
+		std::string existingContent;
+		if (!readFileContent(filepath, existingContent)) {
+			return false;
+		}
 
-	if (fileMatchesXmlContent(filepath, content)) {
-		return true;
+		if (existingContent == content) {
+			return true;
+		}
+
+		return contentMatchesIgnoringLineEndings(existingContent, content);
 	}
 
-	const wxString backupPath = filepath + "~";
-	if (!wxFileExists(filepath) && fileMatchesXmlContent(backupPath, content)) {
-		return wxRenameFile(backupPath, filepath, false);
+	bool writeContentToFile(const wxString &filepath, const std::string &content) {
+		wxFile file(filepath, wxFile::write);
+		if (!file.IsOpened()) {
+			return false;
+		}
+
+		if (!content.empty()) {
+			const auto bytesWritten = file.Write(content.data(), content.size());
+			if (static_cast<size_t>(bytesWritten) != content.size()) {
+				return false;
+			}
+		}
+		return file.Close();
 	}
 
-	return writeContentToFile(filepath, content);
-}
+	bool saveXmlFileIfChanged(const pugi::xml_document &doc, const wxString &filepath) {
+		std::ostringstream stream;
+		doc.save(stream, "\t", pugi::format_default, pugi::encoding_utf8);
+		const std::string content = stream.str();
+
+		if (fileMatchesXmlContent(filepath, content)) {
+			return true;
+		}
+
+		const wxString backupPath = filepath + "~";
+		if (!wxFileExists(filepath) && fileMatchesXmlContent(backupPath, content)) {
+			return wxRenameFile(backupPath, filepath, false);
+		}
+
+		return writeContentToFile(filepath, content);
+	}
 }
 
 // ============================================================================
@@ -991,8 +991,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 								if (item == nullptr) {
 									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
 								} else {
-									if (((itemType->isGroundTile() || itemType->ground_equivalent != 0) && tile->ground) ||
-											(itemType->alwaysOnBottom && !tile->items.empty())) {
+									if (((itemType->isGroundTile() || itemType->ground_equivalent != 0) && tile->ground) || (itemType->alwaysOnBottom && !tile->items.empty())) {
 										needsFullTileUpdate = true;
 									}
 									tile->addLoadedItem(item, *itemType);
@@ -1023,8 +1022,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
 								}
 								// reform(&map, tile, item);
-								if (((itemType->isGroundTile() || itemType->ground_equivalent != 0) && tile->ground) ||
-										(itemType->alwaysOnBottom && !tile->items.empty())) {
+								if (((itemType->isGroundTile() || itemType->ground_equivalent != 0) && tile->ground) || (itemType->alwaysOnBottom && !tile->items.empty())) {
 									needsFullTileUpdate = true;
 								}
 								tile->addLoadedItem(item, *itemType);

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -55,6 +55,33 @@ void reform(Map* map, Tile* tile, Item* item) {
 	*/
 }
 
+namespace {
+struct FloorLookupCache {
+	Floor* floor = nullptr;
+	int floorX = -1;
+	int floorY = -1;
+	int floorZ = -1;
+};
+
+Tile* getCachedTile(Map &map, const Position &position, FloorLookupCache &cache) {
+	const int floorX = position.x & ~3;
+	const int floorY = position.y & ~3;
+	if (!cache.floor || cache.floorX != floorX || cache.floorY != floorY || cache.floorZ != position.z) {
+		QTreeNode* leaf = map.getLeaf(position.x, position.y);
+		cache.floor = leaf ? leaf->getFloor(position.z) : nullptr;
+		cache.floorX = floorX;
+		cache.floorY = floorY;
+		cache.floorZ = position.z;
+	}
+
+	if (!cache.floor) {
+		return nullptr;
+	}
+
+	return cache.floor->locs[(position.x & 3) * 4 + (position.y & 3)].get();
+}
+}
+
 // ============================================================================
 // Item
 
@@ -1029,6 +1056,7 @@ bool IOMapOTBM::loadSpawnsMonster(Map &map, pugi::xml_document &doc) {
 		return false;
 	}
 
+	FloorLookupCache tileCache;
 	for (pugi::xml_node spawnNode = node.first_child(); spawnNode; spawnNode = spawnNode.next_sibling()) {
 		if (as_lower_str(spawnNode.name()) != "monster") {
 			continue;
@@ -1050,7 +1078,7 @@ bool IOMapOTBM::loadSpawnsMonster(Map &map, pugi::xml_document &doc) {
 			continue;
 		}
 
-		Tile* tile = map.getTile(spawnPosition);
+		Tile* tile = getCachedTile(map, spawnPosition, tileCache);
 		if (tile && tile->spawnMonster) {
 			warning("Duplicate monster spawn on position %d:%d:%d\n", tile->getX(), tile->getY(), tile->getZ());
 			continue;
@@ -1118,7 +1146,7 @@ bool IOMapOTBM::loadSpawnsMonster(Map &map, pugi::xml_document &doc) {
 			if (monsterPosition == spawnPosition) {
 				monsterTile = tile;
 			} else {
-				monsterTile = map.getTile(monsterPosition);
+				monsterTile = getCachedTile(map, monsterPosition, tileCache);
 			}
 
 			if (!monsterTile) {
@@ -1302,6 +1330,7 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 		return false;
 	}
 
+	FloorLookupCache tileCache;
 	for (pugi::xml_node spawnNpcNode = node.first_child(); spawnNpcNode; spawnNpcNode = spawnNpcNode.next_sibling()) {
 		if (as_lower_str(spawnNpcNode.name()) != "npc") {
 			continue;
@@ -1323,7 +1352,7 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 			continue;
 		}
 
-		Tile* spawnTile = map.getTile(spawnPosition);
+		Tile* spawnTile = getCachedTile(map, spawnPosition, tileCache);
 		if (spawnTile && spawnTile->spawnNpc) {
 			warning("Duplicate npc spawn on position %d:%d:%d\n", spawnTile->getX(), spawnTile->getY(), spawnTile->getZ());
 			continue;
@@ -1386,7 +1415,7 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 			if (npcPosition == spawnPosition) {
 				npcTile = spawnTile;
 			} else {
-				npcTile = map.getTile(npcPosition);
+				npcTile = getCachedTile(map, npcPosition, tileCache);
 			}
 
 			if (!npcTile) {

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -775,6 +775,10 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 				continue;
 			}
 
+			Floor* cachedFloor = nullptr;
+			int cachedFloorX = -1;
+			int cachedFloorY = -1;
+			int cachedFloorZ = -1;
 			for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
 				Tile* tile = nullptr;
 				uint8_t tile_type;
@@ -791,7 +795,16 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 					}
 					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
 
-					TileLocation* tileLocation = map.createTileL(pos);
+					const int floorX = pos.x & ~3;
+					const int floorY = pos.y & ~3;
+					if (!cachedFloor || cachedFloorX != floorX || cachedFloorY != floorY || cachedFloorZ != pos.z) {
+						cachedFloor = map.createLeaf(pos.x, pos.y)->createFloor(pos.x, pos.y, pos.z);
+						cachedFloorX = floorX;
+						cachedFloorY = floorY;
+						cachedFloorZ = pos.z;
+					}
+
+					TileLocation* tileLocation = &cachedFloor->locs[(pos.x & 3) * 4 + (pos.y & 3)];
 					if (tileLocation->get()) {
 						warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
 						continue;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -616,12 +616,31 @@ bool IOMapOTBM::loadMap(Map &map, const FileName &filename) {
 	}
 #endif
 
-	DiskNodeFileReadHandle f(nstr(filename.GetFullPath()), StringVector(1, "OTBM"));
-	if (!f.isOk()) {
-		error(("Couldn't open file for reading\nThe error reported was: " + wxstr(f.getErrorMessage())).wc_str());
+	FileReadHandle otbmFile(nstr(filename.GetFullPath()));
+	if (!otbmFile.isOk()) {
+		error(("Couldn't open file for reading\nThe error reported was: " + wxstr(otbmFile.getErrorMessage())).wc_str());
 		return false;
 	}
 
+	const size_t otbmSize = otbmFile.size();
+	if (otbmSize < 4) {
+		error("Could not read OTBM file header.");
+		return false;
+	}
+
+	std::vector<uint8_t> otbmBuffer(otbmSize);
+	if (!otbmFile.getRAW(otbmBuffer.data(), otbmBuffer.size())) {
+		error(("Couldn't read file\nThe error reported was: " + wxstr(otbmFile.getErrorMessage())).wc_str());
+		return false;
+	}
+
+	const bool wildcardIdentifier = otbmBuffer[0] == 0 && otbmBuffer[1] == 0 && otbmBuffer[2] == 0 && otbmBuffer[3] == 0;
+	if (!wildcardIdentifier && memcmp(otbmBuffer.data(), "OTBM", 4) != 0) {
+		error("File magic number not recognized.");
+		return false;
+	}
+
+	MemoryNodeFileReadHandle f(otbmBuffer.data() + 4, otbmSize - 4);
 	if (!loadMap(map, f)) {
 		return false;
 	}

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -791,12 +791,13 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 					}
 					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
 
-					if (map.getTile(pos)) {
+					TileLocation* tileLocation = map.createTileL(pos);
+					if (tileLocation->get()) {
 						warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
 						continue;
 					}
 
-					tile = map.allocator(map.createTileL(pos));
+					tile = map.allocator(tileLocation);
 					House* house = nullptr;
 					if (tile_type == OTBM_HOUSETILE) {
 						uint32_t house_id;
@@ -887,7 +888,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 						house->addTile(tile);
 					}
 
-					map.setTile(pos.x, pos.y, pos.z, tile);
+					map.setTile(tileLocation, tile);
 				} else {
 					warning("Unknown type of tile node");
 				}

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -868,6 +868,7 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 
 					// printf("So far so good\n");
 
+					bool needsFullTileUpdate = false;
 					uint8_t attribute;
 					while (tileNode->getU8(attribute)) {
 						switch (attribute) {
@@ -885,7 +886,11 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 								if (item == nullptr) {
 									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
 								} else {
-									tile->addItem(item, *itemType);
+									if (((itemType->isGroundTile() || itemType->ground_equivalent != 0) && tile->ground) ||
+											(itemType->alwaysOnBottom && !tile->items.empty())) {
+										needsFullTileUpdate = true;
+									}
+									tile->addLoadedItem(item, *itemType);
 								}
 								break;
 							}
@@ -913,7 +918,11 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
 								}
 								// reform(&map, tile, item);
-								tile->addItem(item, *itemType);
+								if (((itemType->isGroundTile() || itemType->ground_equivalent != 0) && tile->ground) ||
+										(itemType->alwaysOnBottom && !tile->items.empty())) {
+									needsFullTileUpdate = true;
+								}
+								tile->addLoadedItem(item, *itemType);
 							}
 						} else if (node_type == OTBM_TILE_ZONE) {
 							uint16_t zone_count;
@@ -934,7 +943,11 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 						}
 					}
 
-					tile->update();
+					if (needsFullTileUpdate) {
+						tile->update();
+					} else {
+						tile->finalizeLoadedState();
+					}
 					if (house) {
 						house->addTile(tile);
 					}

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -195,7 +195,7 @@ namespace {
 		int localZ = -1;
 	};
 
-	void updateTileSaveProgress(const Map &map, TileAreaSaveState &state) {
+	FORCEINLINE void updateTileSaveProgress(const Map &map, TileAreaSaveState &state) {
 		++state.tilesSaved;
 		const uint64_t tileCount = map.getTileCount();
 		if (tileCount != 0 && state.tilesSaved % 8192 == 0) {
@@ -203,11 +203,11 @@ namespace {
 		}
 	}
 
-	bool needsNewTileArea(const Position &position, const TileAreaSaveState &state) {
+	FORCEINLINE bool needsNewTileArea(const Position &position, const TileAreaSaveState &state) {
 		return position.x < state.localX || position.x >= state.localX + 256 || position.y < state.localY || position.y >= state.localY + 256 || position.z != state.localZ;
 	}
 
-	void beginTileArea(NodeFileWriteHandle &file, const Position &position, TileAreaSaveState &state) {
+	FORCEINLINE void beginTileArea(NodeFileWriteHandle &file, const Position &position, TileAreaSaveState &state) {
 		if (!state.firstArea) {
 			file.endNode();
 		}
@@ -219,7 +219,7 @@ namespace {
 		file.addU8(state.localZ = position.z);
 	}
 
-	void saveTileGround(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
+	FORCEINLINE void saveTileGround(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
 		if (!tile.ground) {
 			return;
 		}
@@ -250,7 +250,7 @@ namespace {
 		ground->serializeItemCompact_OTBM(mapHandle, file);
 	}
 
-	void saveTileItems(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
+	FORCEINLINE void saveTileItems(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
 		for (Item* item : tile.items) {
 			const ItemType &itemType = item->getItemType();
 			if (itemType.isMetaItem() || item->getID() == 0) {
@@ -260,7 +260,7 @@ namespace {
 		}
 	}
 
-	void saveTileZones(NodeFileWriteHandle &file, const Tile &tile) {
+	FORCEINLINE void saveTileZones(NodeFileWriteHandle &file, const Tile &tile) {
 		if (tile.zones.empty()) {
 			return;
 		}
@@ -273,7 +273,7 @@ namespace {
 		file.endNode();
 	}
 
-	void saveTileLocation(const IOMapOTBM &mapHandle, Map &map, NodeFileWriteHandle &file, TileAreaSaveState &state, TileLocation* tileLocation) {
+	FORCEINLINE void saveTileLocation(const IOMapOTBM &mapHandle, Map &map, NodeFileWriteHandle &file, TileAreaSaveState &state, TileLocation* tileLocation) {
 		updateTileSaveProgress(map, state);
 
 		Tile* saveTile = tileLocation->get();

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -71,7 +71,7 @@ Item* Item::Create_OTBM(const IOMap &maphandle, BinaryNode* stream) {
 			stream->getU8(count);
 		}
 	}
-	return Item::Create(id, count);
+	return Item::Create(id, type, count);
 }
 
 bool Item::readItemAttribute_OTBM(const IOMap &maphandle, OTBM_ItemAttribute attr, BinaryNode* stream) {

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -202,11 +202,11 @@ bool Item::unserializeItemNode_OTBM(const IOMap &maphandle, BinaryNode* node) {
 }
 
 void Item::serializeItemAttributes_OTBM(const IOMap &maphandle, NodeFileWriteHandle &stream) const {
+	const ItemType &type = g_items.getItemType(id);
 	if (maphandle.version.otbm >= MAP_OTBM_2) {
-		const ItemType &type = g_items.getItemType(id);
 		if (type.stackable || type.isSplash() || type.isFluidContainer()) {
 			stream.addU8(OTBM_ATTR_COUNT);
-			stream.addU8(getSubtype());
+			stream.addU8(getSubtype(type));
 		}
 	}
 
@@ -216,9 +216,9 @@ void Item::serializeItemAttributes_OTBM(const IOMap &maphandle, NodeFileWriteHan
 			serializeAttributeMap(maphandle, stream);
 		}
 	} else {
-		if (isCharged()) {
+		if (type.isClientCharged() || type.isExtraCharged()) {
 			stream.addU8(OTBM_ATTR_CHARGES);
-			stream.addU16(getSubtype());
+			stream.addU16(getSubtype(type));
 		}
 
 		const auto actionId = getActionID();
@@ -233,16 +233,16 @@ void Item::serializeItemAttributes_OTBM(const IOMap &maphandle, NodeFileWriteHan
 			stream.addU16(uniqueId);
 		}
 
-		const std::string &text = getText();
-		if (!text.empty()) {
+		const std::string* text = getStringAttribute("text");
+		if (text && !text->empty()) {
 			stream.addU8(OTBM_ATTR_TEXT);
-			stream.addString(text);
+			stream.addString(*text);
 		}
 
-		const std::string &description = getDescription();
-		if (!description.empty()) {
+		const std::string* description = getStringAttribute("desc");
+		if (description && !description->empty()) {
 			stream.addU8(OTBM_ATTR_DESC);
-			stream.addString(description);
+			stream.addString(*description);
 		}
 	}
 }
@@ -265,7 +265,7 @@ bool Item::serializeItemNode_OTBM(const IOMap &maphandle, NodeFileWriteHandle &f
 	if (maphandle.version.otbm == MAP_OTBM_1) {
 		const ItemType &type = g_items.getItemType(id);
 		if (type.stackable || type.isSplash() || type.isFluidContainer()) {
-			file.addU8(getSubtype());
+			file.addU8(getSubtype(type));
 		}
 	}
 	serializeItemAttributes_OTBM(maphandle, file);

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -80,6 +80,111 @@ Tile* getCachedTile(Map &map, const Position &position, FloorLookupCache &cache)
 
 	return cache.floor->locs[(position.x & 3) * 4 + (position.y & 3)].get();
 }
+
+bool readFileContent(const wxString &filepath, std::string &content) {
+	if (!wxFileExists(filepath)) {
+		return false;
+	}
+
+	wxFile file(filepath, wxFile::read);
+	if (!file.IsOpened()) {
+		return false;
+	}
+
+	const wxFileOffset fileSize = file.Length();
+	if (fileSize < 0) {
+		return false;
+	}
+
+	content.resize(static_cast<size_t>(fileSize));
+	if (content.empty()) {
+		return true;
+	}
+
+	const auto bytesRead = file.Read(content.data(), content.size());
+	return static_cast<size_t>(bytesRead) == content.size();
+}
+
+bool readNormalizedLineEndingChar(const std::string &content, size_t &offset, char &out) {
+	if (offset >= content.size()) {
+		return false;
+	}
+
+	out = content[offset++];
+	if (out == '\r') {
+		if (offset < content.size() && content[offset] == '\n') {
+			++offset;
+		}
+		out = '\n';
+	}
+	return true;
+}
+
+bool contentMatchesIgnoringLineEndings(const std::string &left, const std::string &right) {
+	size_t leftOffset = 0;
+	size_t rightOffset = 0;
+	char leftChar = '\0';
+	char rightChar = '\0';
+
+	while (true) {
+		const bool hasLeft = readNormalizedLineEndingChar(left, leftOffset, leftChar);
+		const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar);
+		if (hasLeft != hasRight) {
+			return false;
+		}
+		if (!hasLeft) {
+			return true;
+		}
+		if (leftChar != rightChar) {
+			return false;
+		}
+	}
+}
+
+bool fileMatchesXmlContent(const wxString &filepath, const std::string &content) {
+	std::string existingContent;
+	if (!readFileContent(filepath, existingContent)) {
+		return false;
+	}
+
+	if (existingContent == content) {
+		return true;
+	}
+
+	return contentMatchesIgnoringLineEndings(existingContent, content);
+}
+
+bool writeContentToFile(const wxString &filepath, const std::string &content) {
+	wxFile file(filepath, wxFile::write);
+	if (!file.IsOpened()) {
+		return false;
+	}
+
+	if (!content.empty()) {
+		const auto bytesWritten = file.Write(content.data(), content.size());
+		if (static_cast<size_t>(bytesWritten) != content.size()) {
+			return false;
+		}
+	}
+	return file.Close();
+}
+
+bool saveXmlFileIfChanged(const pugi::xml_document &doc, const wxString &filepath) {
+	std::ostringstream stream;
+	doc.save(stream, "\t", pugi::format_default, pugi::encoding_utf8);
+	const std::string content = stream.str();
+
+	if (fileMatchesXmlContent(filepath, content)) {
+		return true;
+	}
+
+	const wxString backupPath = filepath + "~";
+	if (!wxFileExists(filepath) && fileMatchesXmlContent(backupPath, content)) {
+		return wxRenameFile(backupPath, filepath, false);
+	}
+
+	return writeContentToFile(filepath, content);
+}
 }
 
 // ============================================================================
@@ -1819,7 +1924,7 @@ bool IOMapOTBM::saveSpawns(Map &map, const FileName &dir) {
 	// Create the XML file
 	pugi::xml_document doc;
 	if (saveSpawns(map, doc)) {
-		return doc.save_file(filepath.wc_str(), "\t", pugi::format_default, pugi::encoding_utf8);
+		return saveXmlFileIfChanged(doc, filepath);
 	}
 	return false;
 }
@@ -1896,7 +2001,7 @@ bool IOMapOTBM::saveHouses(Map &map, const FileName &dir) {
 	// Create the XML file
 	pugi::xml_document doc;
 	if (saveHouses(map, doc)) {
-		return doc.save_file(filepath.wc_str(), "\t", pugi::format_default, pugi::encoding_utf8);
+		return saveXmlFileIfChanged(doc, filepath);
 	}
 	return false;
 }
@@ -1942,7 +2047,7 @@ bool IOMapOTBM::saveZones(Map &map, const FileName &dir) {
 	// Create the XML file
 	pugi::xml_document doc;
 	if (saveZones(map, doc)) {
-		return doc.save_file(filepath.wc_str(), "\t", pugi::format_default, pugi::encoding_utf8);
+		return saveXmlFileIfChanged(doc, filepath);
 	}
 	return false;
 }
@@ -1975,7 +2080,7 @@ bool IOMapOTBM::saveSpawnsNpc(Map &map, const FileName &dir) {
 	// Create the XML file
 	pugi::xml_document doc;
 	if (saveSpawnsNpc(map, doc)) {
-		return doc.save_file(filepath.wc_str(), "\t", pugi::format_default, pugi::encoding_utf8);
+		return saveXmlFileIfChanged(doc, filepath);
 	}
 	return false;
 }

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -185,6 +185,23 @@ namespace {
 		return data[4] == NODE_START;
 	}
 
+#if OTGZ_SUPPORT > 0
+	bool readArchiveDataFully(struct archive* archive, uint8_t* buffer, size_t targetSize, size_t &outReadBytes) {
+		outReadBytes = 0;
+		while (outReadBytes < targetSize) {
+			const auto readNow = archive_read_data(archive, buffer + outReadBytes, targetSize - outReadBytes);
+			if (readNow < 0) {
+				return false;
+			}
+			if (readNow == 0) {
+				break;
+			}
+			outReadBytes += static_cast<size_t>(readNow);
+		}
+		return true;
+	}
+#endif
+
 	bool saveXmlFileIfChanged(const pugi::xml_document &doc, const wxString &filepath) {
 		std::ostringstream stream;
 		doc.save(stream, "\t", pugi::format_default, pugi::encoding_utf8);
@@ -686,18 +703,17 @@ bool IOMapOTBM::getVersionInfo(const FileName &filename, MapVersion &out_ver) {
 				uint8_t buffer[8096];
 				memset(buffer, 0, 8096);
 
-				// Read from the archive
-				const auto readBytes = archive_read_data(a.get(), buffer, 8096);
-				if (readBytes < 0) {
+				size_t readBytes = 0;
+				if (!readArchiveDataFully(a.get(), buffer, sizeof(buffer), readBytes)) {
 					return false;
 				}
 
-				if (!hasValidOtbmPrefix(buffer, static_cast<size_t>(readBytes))) {
+				if (!hasValidOtbmPrefix(buffer, readBytes)) {
 					return false;
 				}
 
 				// Create a read handle on it
-				std::shared_ptr<NodeFileReadHandle> f(new MemoryNodeFileReadHandle(buffer + 4, static_cast<size_t>(readBytes) - 4));
+				std::shared_ptr<NodeFileReadHandle> f(new MemoryNodeFileReadHandle(buffer + 4, readBytes - 4));
 
 				// Read the version info
 				return getVersionInfo(f.get(), out_ver);
@@ -709,7 +725,22 @@ bool IOMapOTBM::getVersionInfo(const FileName &filename, MapVersion &out_ver) {
 	}
 #endif
 
-	// Just open a disk-based read handle
+	FileReadHandle otbmProbe(nstr(filename.GetFullPath()));
+	if (!otbmProbe.isOk()) {
+		return false;
+	}
+
+	uint8_t otbmPrefix[5] {};
+	if (otbmProbe.size() < sizeof(otbmPrefix)) {
+		return false;
+	}
+	if (!otbmProbe.getRAW(otbmPrefix, sizeof(otbmPrefix))) {
+		return false;
+	}
+	if (!hasValidOtbmPrefix(otbmPrefix, sizeof(otbmPrefix))) {
+		return false;
+	}
+
 	DiskNodeFileReadHandle f(nstr(filename.GetFullPath()), StringVector(1, "OTBM"));
 	if (!f.isOk()) {
 		return false;
@@ -775,13 +806,16 @@ bool IOMapOTBM::loadMap(Map &map, const FileName &filename) {
 				size_t otbm_size = archive_entry_size(entry);
 				std::shared_ptr<uint8_t> otbm_buffer(new uint8_t[otbm_size], [](uint8_t* p) { delete[] p; });
 
-				// Read from the archive
-				const auto readBytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
-				if (readBytes < 0 || static_cast<size_t>(readBytes) < otbm_size) {
+				size_t readBytes = 0;
+				if (!readArchiveDataFully(a.get(), otbm_buffer.get(), otbm_size, readBytes)) {
 					error("Could not read file.");
 					return false;
 				}
-				if (!hasValidOtbmPrefix(otbm_buffer.get(), static_cast<size_t>(readBytes))) {
+				if (readBytes < otbm_size) {
+					error("Could not read file.");
+					return false;
+				}
+				if (!hasValidOtbmPrefix(otbm_buffer.get(), readBytes)) {
 					error("Could not read OTBM file header.");
 					return false;
 				}

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -58,13 +58,21 @@ void reform(Map* map, Tile* tile, Item* item) {
 // ============================================================================
 // Item
 
-Item* Item::Create_OTBM(const IOMap &maphandle, BinaryNode* stream) {
+Item* Item::Create_OTBM(const IOMap &maphandle, BinaryNode* stream, const ItemType** itemType) {
+	if (itemType) {
+		*itemType = nullptr;
+	}
+
 	uint16_t id;
 	if (!stream->getU16(id)) {
 		return nullptr;
 	}
 
 	const ItemType &type = g_items.getItemType(id);
+	if (itemType) {
+		*itemType = &type;
+	}
+
 	uint8_t count = 0;
 	if (maphandle.version.otbm == MAP_OTBM_1) {
 		if (type.stackable || type.isSplash() || type.isFluidContainer()) {
@@ -845,11 +853,13 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 								break;
 							}
 							case OTBM_ATTR_ITEM: {
-								Item* item = Item::Create_OTBM(*this, tileNode);
+								const ItemType* itemType = nullptr;
+								Item* item = Item::Create_OTBM(*this, tileNode, &itemType);
 								if (item == nullptr) {
 									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
+								} else {
+									tile->addItem(item, *itemType);
 								}
-								tile->addItem(item);
 								break;
 							}
 							default: {
@@ -869,13 +879,14 @@ bool IOMapOTBM::loadMap(Map &map, NodeFileReadHandle &f) {
 							continue;
 						}
 						if (node_type == OTBM_ITEM) {
-							item = Item::Create_OTBM(*this, childNode);
+							const ItemType* itemType = nullptr;
+							item = Item::Create_OTBM(*this, childNode, &itemType);
 							if (item) {
 								if (!item->unserializeItemNode_OTBM(*this, childNode)) {
 									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
 								}
 								// reform(&map, tile, item);
-								tile->addItem(item);
+								tile->addItem(item, *itemType);
 							}
 						} else if (node_type == OTBM_TILE_ZONE) {
 							uint16_t zone_count;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -130,7 +130,8 @@ namespace {
 
 		while (true) {
 			const bool hasLeft = readNormalizedLineEndingChar(left, leftOffset, leftChar);
-			if (const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar); hasLeft != hasRight) {
+			const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar);
+			if (hasLeft != hasRight) {
 				return false;
 			}
 			if (!hasLeft) {

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1820,7 +1820,9 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 					Item* ground = save_tile->ground;
 					const ItemType &groundType = ground->getItemType();
 					const uint16_t groundId = ground->getID();
-					if (groundType.isMetaItem()) {
+					if (groundId == 0) {
+						// Skip invalid placeholder grounds without dropping the tile's items or zones.
+					} else if (groundType.isMetaItem()) {
 						// Do nothing, we don't save metaitems...
 					} else if (groundType.has_equivalent) {
 						bool found = false;
@@ -1834,21 +1836,12 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 						}
 
 						if (!found) {
-							if (groundId == 0) {
-								return;
-							}
 							ground->serializeItemNode_OTBM(self, f);
 						}
 					} else if (ground->isComplex()) {
-						if (groundId == 0) {
-							return;
-						}
 						ground->serializeItemNode_OTBM(self, f);
 					} else {
 						f.addByte(OTBM_ATTR_ITEM);
-						if (groundId == 0) {
-							return;
-						}
 						ground->serializeItemCompact_OTBM(self, f);
 					}
 				}

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -33,6 +33,7 @@
 #include "town.h"
 
 #include <algorithm>
+#include <array>
 
 typedef uint8_t attribute_t;
 typedef uint32_t flags_t;
@@ -130,8 +131,7 @@ namespace {
 
 		while (true) {
 			const bool hasLeft = readNormalizedLineEndingChar(left, leftOffset, leftChar);
-			const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar);
-			if (hasLeft != hasRight) {
+			if (const bool hasRight = readNormalizedLineEndingChar(right, rightOffset, rightChar); hasLeft != hasRight) {
 				return false;
 			}
 			if (!hasLeft) {
@@ -246,9 +246,12 @@ namespace {
 		state.firstArea = false;
 
 		file.addNode(OTBM_TILE_AREA);
-		file.addU16(state.localX = position.x & 0xFF00);
-		file.addU16(state.localY = position.y & 0xFF00);
-		file.addU8(state.localZ = position.z);
+		state.localX = position.x & 0xFF00;
+		state.localY = position.y & 0xFF00;
+		state.localZ = position.z;
+		file.addU16(state.localX);
+		file.addU16(state.localY);
+		file.addU8(state.localZ);
 	}
 
 	FORCEINLINE void saveTileGround(const IOMapOTBM &mapHandle, NodeFileWriteHandle &file, const Tile &tile) {
@@ -730,14 +733,14 @@ bool IOMapOTBM::getVersionInfo(const FileName &filename, MapVersion &out_ver) {
 		return false;
 	}
 
-	uint8_t otbmPrefix[5] {};
-	if (otbmProbe.size() < sizeof(otbmPrefix)) {
+	std::array<uint8_t, 5> otbmPrefix {};
+	if (otbmProbe.size() < otbmPrefix.size()) {
 		return false;
 	}
-	if (!otbmProbe.getRAW(otbmPrefix, sizeof(otbmPrefix))) {
+	if (!otbmProbe.getRAW(otbmPrefix.data(), otbmPrefix.size())) {
 		return false;
 	}
-	if (!hasValidOtbmPrefix(otbmPrefix, sizeof(otbmPrefix))) {
+	if (!hasValidOtbmPrefix(otbmPrefix.data(), otbmPrefix.size())) {
 		return false;
 	}
 

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1612,7 +1612,7 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 				Tile* save_tile = (*map_iterator)->get();
 
 				// Is it an empty tile that we can skip? (Leftovers...)
-				if (!save_tile || save_tile->size() == 0) {
+				if (!save_tile || save_tile->empty()) {
 					++map_iterator;
 					continue;
 				}

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1058,8 +1058,9 @@ bool IOMapOTBM::loadSpawnsMonster(Map &map, pugi::xml_document &doc) {
 
 		SpawnMonster* spawnMonster = newd SpawnMonster(radius);
 		if (!tile) {
-			tile = map.allocator(map.createTileL(spawnPosition));
-			map.setTile(spawnPosition, tile);
+			TileLocation* tileLocation = map.createTileL(spawnPosition);
+			tile = map.allocator(tileLocation);
+			map.setTile(tileLocation, tile);
 		}
 
 		tile->spawnMonster = spawnMonster;
@@ -1330,8 +1331,9 @@ bool IOMapOTBM::loadSpawnsNpc(Map &map, pugi::xml_document &doc) {
 
 		SpawnNpc* spawnNpc = newd SpawnNpc(radius);
 		if (!spawnTile) {
-			spawnTile = map.allocator(map.createTileL(spawnPosition));
-			map.setTile(spawnPosition, spawnTile);
+			TileLocation* tileLocation = map.createTileL(spawnPosition);
+			spawnTile = map.allocator(tileLocation);
+			map.setTile(tileLocation, spawnTile);
 		}
 
 		spawnTile->spawnNpc = spawnNpc;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -1715,12 +1715,14 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 
 				if (save_tile->ground) {
 					Item* ground = save_tile->ground;
-					if (ground->isMetaItem()) {
+					const ItemType &groundType = ground->getItemType();
+					const uint16_t groundId = ground->getID();
+					if (groundType.isMetaItem()) {
 						// Do nothing, we don't save metaitems...
-					} else if (ground->hasBorderEquivalent()) {
+					} else if (groundType.has_equivalent) {
 						bool found = false;
 						for (Item* item : save_tile->items) {
-							if (item->getGroundEquivalent() == ground->getID()) {
+							if (item->getItemType().ground_equivalent == groundId) {
 								// Do nothing
 								// Found equivalent
 								found = true;
@@ -1729,19 +1731,19 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 						}
 
 						if (!found) {
-							if (ground->getID() == 0) {
+							if (groundId == 0) {
 								return;
 							}
 							ground->serializeItemNode_OTBM(self, f);
 						}
 					} else if (ground->isComplex()) {
-						if (ground->getID() == 0) {
+						if (groundId == 0) {
 							return;
 						}
 						ground->serializeItemNode_OTBM(self, f);
 					} else {
 						f.addByte(OTBM_ATTR_ITEM);
-						if (ground->getID() == 0) {
+						if (groundId == 0) {
 							return;
 						}
 						ground->serializeItemCompact_OTBM(self, f);
@@ -1749,8 +1751,10 @@ bool IOMapOTBM::saveMap(Map &map, NodeFileWriteHandle &f) {
 				}
 
 				for (Item* item : save_tile->items) {
-					if (!item->isMetaItem()) {
-						if (item->getID() == 0) {
+					const ItemType &itemType = item->getItemType();
+					if (!itemType.isMetaItem()) {
+						const uint16_t itemId = item->getID();
+						if (itemId == 0) {
 							continue;
 						}
 						item->serializeItemNode_OTBM(self, f);

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -45,10 +45,6 @@ void Item::operator delete(void* ptr) noexcept {
 	rme::deallocatePooledObject(ptr);
 }
 
-void Item::operator delete(void* ptr, size_t) noexcept {
-	rme::deallocatePooledObject(ptr);
-}
-
 #ifdef DEBUG_MEM
 void* Item::operator new(size_t size, const char*, int) {
 	return rme::allocatePooledObject(size);

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -24,6 +24,7 @@
 #include "complexitem.h"
 #include "iomap.h"
 #include "item.h"
+#include "object_pool.h"
 
 #include "ground_brush.h"
 #include "carpet_brush.h"
@@ -36,6 +37,28 @@ bool itemTypeHasSubtype(const ItemType &type) {
 		type.isClientCharged() || type.isExtraCharged();
 }
 }
+
+void* Item::operator new(size_t size) {
+	return rme::allocatePooledObject(size);
+}
+
+void Item::operator delete(void* ptr) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+
+void Item::operator delete(void* ptr, size_t) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+
+#ifdef DEBUG_MEM
+void* Item::operator new(size_t size, const char*, int) {
+	return rme::allocatePooledObject(size);
+}
+
+void Item::operator delete(void* ptr, const char*, int) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+#endif
 
 Item* Item::Create(uint16_t id, uint16_t subtype /*= 0xFFFF*/) {
 	if (id == 0) {

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -32,10 +32,9 @@
 #include "wall_brush.h"
 
 namespace {
-bool itemTypeHasSubtype(const ItemType &type) {
-	return type.isFluidContainer() || type.stackable || type.charges != 0 || type.isSplash() ||
-		type.isClientCharged() || type.isExtraCharged();
-}
+	bool itemTypeHasSubtype(const ItemType &type) {
+		return type.isFluidContainer() || type.stackable || type.charges != 0 || type.isSplash() || type.isClientCharged() || type.isExtraCharged();
+	}
 }
 
 void* Item::operator new(size_t size) {

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -43,6 +43,14 @@ Item* Item::Create(uint16_t id, uint16_t subtype /*= 0xFFFF*/) {
 	}
 
 	const ItemType &type = g_items.getItemType(id);
+	return Create(id, type, subtype);
+}
+
+Item* Item::Create(uint16_t id, const ItemType &type, uint16_t subtype /*= 0xFFFF*/) {
+	if (id == 0) {
+		return nullptr;
+	}
+
 	if (type.id == 0) {
 		return newd Item(id, subtype, false);
 	}

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -30,6 +30,13 @@
 #include "table_brush.h"
 #include "wall_brush.h"
 
+namespace {
+bool itemTypeHasSubtype(const ItemType &type) {
+	return type.isFluidContainer() || type.stackable || type.charges != 0 || type.isSplash() ||
+		type.isClientCharged() || type.isExtraCharged();
+}
+}
+
 Item* Item::Create(uint16_t id, uint16_t subtype /*= 0xFFFF*/) {
 	if (id == 0) {
 		return nullptr;
@@ -37,7 +44,7 @@ Item* Item::Create(uint16_t id, uint16_t subtype /*= 0xFFFF*/) {
 
 	const ItemType &type = g_items.getItemType(id);
 	if (type.id == 0) {
-		return newd Item(id, subtype);
+		return newd Item(id, subtype, false);
 	}
 
 	if (!type.sprite) {
@@ -53,25 +60,30 @@ Item* Item::Create(uint16_t id, uint16_t subtype /*= 0xFFFF*/) {
 	} else if (type.isDoor()) {
 		return new Door(id);
 	} else if (subtype == 0xFFFF) {
+		const bool hasSubtype = itemTypeHasSubtype(type);
 		if (type.isFluidContainer()) {
-			return new Item(id, LIQUID_NONE);
+			return new Item(id, LIQUID_NONE, hasSubtype);
 		} else if (type.isSplash()) {
-			return new Item(id, LIQUID_WATER);
+			return new Item(id, LIQUID_WATER, hasSubtype);
 		} else if (type.charges > 0) {
-			return new Item(id, type.charges);
+			return new Item(id, type.charges, hasSubtype);
 		} else {
-			return new Item(id, 1);
+			return new Item(id, 1, hasSubtype);
 		}
 	}
-	return new Item(id, subtype);
+	return new Item(id, subtype, itemTypeHasSubtype(type));
 }
 
 Item::Item(unsigned short _type, unsigned short _count) :
+	Item(_type, _count, itemTypeHasSubtype(g_items.getItemType(_type))) {
+}
+
+Item::Item(unsigned short _type, unsigned short _count, bool typeHasSubtype) :
 	id(_type),
 	subtype(1),
 	selected(false),
 	frame(0) {
-	if (hasSubtype()) {
+	if (typeHasSubtype) {
 		subtype = _count;
 	}
 }
@@ -163,7 +175,7 @@ void Item::setSubtype(uint16_t _subtype) {
 
 bool Item::hasSubtype() const {
 	const ItemType &type = g_items.getItemType(id);
-	return (type.isFluidContainer() || type.stackable || type.charges != 0 || type.isSplash() || isCharged());
+	return itemTypeHasSubtype(type);
 }
 
 uint16_t Item::getSubtype() const {

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -182,12 +182,19 @@ void Item::setSubtype(uint16_t _subtype) {
 }
 
 bool Item::hasSubtype() const {
-	const ItemType &type = g_items.getItemType(id);
+	return hasSubtype(g_items.getItemType(id));
+}
+
+bool Item::hasSubtype(const ItemType &type) const noexcept {
 	return itemTypeHasSubtype(type);
 }
 
 uint16_t Item::getSubtype() const {
-	return hasSubtype() ? subtype : 0;
+	return getSubtype(g_items.getItemType(id));
+}
+
+uint16_t Item::getSubtype(const ItemType &type) const noexcept {
+	return hasSubtype(type) ? subtype : 0;
 }
 
 bool Item::hasProperty(enum ITEMPROPERTY prop) const {

--- a/source/item.cpp
+++ b/source/item.cpp
@@ -78,26 +78,26 @@ Item* Item::Create(uint16_t id, const ItemType &type, uint16_t subtype /*= 0xFFF
 	}
 
 	if (type.isDepot()) {
-		return new Depot(id);
+		return new Depot(id); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 	} else if (type.isContainer()) {
-		return new Container(id);
+		return new Container(id); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 	} else if (type.isTeleport()) {
-		return new Teleport(id);
+		return new Teleport(id); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 	} else if (type.isDoor()) {
-		return new Door(id);
+		return new Door(id); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 	} else if (subtype == 0xFFFF) {
 		const bool hasSubtype = itemTypeHasSubtype(type);
 		if (type.isFluidContainer()) {
-			return new Item(id, LIQUID_NONE, hasSubtype);
+			return new Item(id, LIQUID_NONE, hasSubtype); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 		} else if (type.isSplash()) {
-			return new Item(id, LIQUID_WATER, hasSubtype);
+			return new Item(id, LIQUID_WATER, hasSubtype); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 		} else if (type.charges > 0) {
-			return new Item(id, type.charges, hasSubtype);
+			return new Item(id, type.charges, hasSubtype); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 		} else {
-			return new Item(id, 1, hasSubtype);
+			return new Item(id, 1, hasSubtype); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 		}
 	}
-	return new Item(id, subtype, itemTypeHasSubtype(type));
+	return new Item(id, subtype, itemTypeHasSubtype(type)); // NOSONAR - item factories return raw pointers owned by tiles and maps.
 }
 
 Item::Item(unsigned short _type, unsigned short _count) :

--- a/source/item.h
+++ b/source/item.h
@@ -352,8 +352,10 @@ public:
 	// Subtype (count, fluid, charges)
 	int getCount() const;
 	uint16_t getSubtype() const;
+	uint16_t getSubtype(const ItemType &type) const noexcept;
 	void setSubtype(uint16_t subtype);
 	bool hasSubtype() const;
+	bool hasSubtype(const ItemType &type) const noexcept;
 
 	void setUniqueID(uint16_t n);
 	uint16_t getUniqueID() const;

--- a/source/item.h
+++ b/source/item.h
@@ -81,7 +81,7 @@ public:
 	static Item* Create(uint16_t id, uint16_t subtype = 0xFFFF);
 	static Item* Create(uint16_t id, const ItemType &type, uint16_t subtype = 0xFFFF);
 	static Item* Create(pugi::xml_node);
-	static Item* Create_OTBM(const IOMap &maphandle, BinaryNode* stream);
+	static Item* Create_OTBM(const IOMap &maphandle, BinaryNode* stream, const ItemType** itemType = nullptr);
 	// static Item* Create_OTMM(const IOMap& maphandle, BinaryNode* stream);
 
 protected:

--- a/source/item.h
+++ b/source/item.h
@@ -86,6 +86,7 @@ public:
 protected:
 	// Constructor for items
 	Item(unsigned short _type, unsigned short _count);
+	Item(unsigned short _type, unsigned short _count, bool hasSubtype);
 
 public:
 	virtual ~Item();

--- a/source/item.h
+++ b/source/item.h
@@ -79,7 +79,6 @@ class Item : public ItemAttributes {
 public:
 	static void* operator new(size_t size);
 	static void operator delete(void* ptr) noexcept;
-	static void operator delete(void* ptr, size_t size) noexcept;
 #ifdef DEBUG_MEM
 	static void* operator new(size_t size, const char* file, int line);
 	static void operator delete(void* ptr, const char* file, int line) noexcept;

--- a/source/item.h
+++ b/source/item.h
@@ -77,6 +77,14 @@ struct SpriteLight;
 
 class Item : public ItemAttributes {
 public:
+	static void* operator new(size_t size);
+	static void operator delete(void* ptr) noexcept;
+	static void operator delete(void* ptr, size_t size) noexcept;
+#ifdef DEBUG_MEM
+	static void* operator new(size_t size, const char* file, int line);
+	static void operator delete(void* ptr, const char* file, int line) noexcept;
+#endif
+
 	// Factory member to create item of right type based on type
 	static Item* Create(uint16_t id, uint16_t subtype = 0xFFFF);
 	static Item* Create(uint16_t id, const ItemType &type, uint16_t subtype = 0xFFFF);

--- a/source/item.h
+++ b/source/item.h
@@ -79,6 +79,7 @@ class Item : public ItemAttributes {
 public:
 	// Factory member to create item of right type based on type
 	static Item* Create(uint16_t id, uint16_t subtype = 0xFFFF);
+	static Item* Create(uint16_t id, const ItemType &type, uint16_t subtype = 0xFFFF);
 	static Item* Create(pugi::xml_node);
 	static Item* Create_OTBM(const IOMap &maphandle, BinaryNode* stream);
 	// static Item* Create_OTMM(const IOMap& maphandle, BinaryNode* stream);

--- a/source/items.cpp
+++ b/source/items.cpp
@@ -798,9 +798,9 @@ ItemType &ItemDatabase::getItemType(uint16_t id) {
 		return dummy;
 	}
 
-	auto type = items[id];
-	if (type) {
-		return *type;
+	const auto type = items.ptr(id);
+	if (type && *type) {
+		return **type;
 	}
 
 	return dummy;

--- a/source/map_display.cpp
+++ b/source/map_display.cpp
@@ -3015,12 +3015,9 @@ bool MapCanvas::floodFill(Map* map, const Position &center, int x, int y, Ground
 
 AnimationTimer::AnimationTimer(MapCanvas* canvas) :
 	wxTimer(),
-	map_canvas(canvas),
-	started(false),
-	mark_scene_dirty(false),
-	interval(0) {
-		////
-	};
+	map_canvas(canvas) {
+	////
+}
 
 void AnimationTimer::Notify() {
 	map_canvas->QueueRefresh(mark_scene_dirty);

--- a/source/map_display.cpp
+++ b/source/map_display.cpp
@@ -155,7 +155,13 @@ MapCanvas::~MapCanvas() {
 }
 
 void MapCanvas::Refresh() {
-	drawer->markDirty();
+	QueueRefresh(true);
+}
+
+void MapCanvas::QueueRefresh(bool mark_scene_dirty) {
+	if (mark_scene_dirty) {
+		drawer->markDirty();
+	}
 	if (refresh_watch.Time() > g_settings.getInteger(Config::HARD_REFRESH_RATE)) {
 		refresh_watch.Start();
 		wxGLCanvas::Update();
@@ -235,8 +241,14 @@ void MapCanvas::OnPaint(wxPaintEvent &event) {
 
 		options.dragging = boundbox_selection;
 
-		if (options.show_preview || drawer->GetPositionIndicatorTime() != 0 || options.show_performance_stats) {
-			animation_timer->Start();
+		const bool animate_position_indicator = drawer->GetPositionIndicatorTime() != 0;
+		const bool animate_preview = options.show_preview && zoom <= 2.0f;
+		if (animate_position_indicator) {
+			animation_timer->StartRefresh(16, true);
+		} else if (animate_preview) {
+			animation_timer->StartRefresh(250, true);
+		} else if (options.show_performance_stats) {
+			animation_timer->StartRefresh(500, false);
 		} else {
 			animation_timer->Stop();
 		}
@@ -3004,24 +3016,30 @@ bool MapCanvas::floodFill(Map* map, const Position &center, int x, int y, Ground
 AnimationTimer::AnimationTimer(MapCanvas* canvas) :
 	wxTimer(),
 	map_canvas(canvas),
-	started(false) {
+	started(false),
+	mark_scene_dirty(false),
+	interval(0) {
 		////
 	};
 
 void AnimationTimer::Notify() {
-	map_canvas->Refresh();
+	map_canvas->QueueRefresh(mark_scene_dirty);
 }
 
-void AnimationTimer::Start() {
-	if (!started) {
+void AnimationTimer::StartRefresh(int new_interval, bool new_mark_scene_dirty) {
+	if (!started || interval != new_interval || mark_scene_dirty != new_mark_scene_dirty) {
 		started = true;
-		wxTimer::Start(16);
+		interval = new_interval;
+		mark_scene_dirty = new_mark_scene_dirty;
+		wxTimer::Start(interval);
 	}
 };
 
 void AnimationTimer::Stop() {
 	if (started) {
 		started = false;
+		mark_scene_dirty = false;
+		interval = 0;
 		wxTimer::Stop();
 	}
 };

--- a/source/map_display.h
+++ b/source/map_display.h
@@ -225,9 +225,9 @@ public:
 
 private:
 	MapCanvas* map_canvas;
-	bool started;
-	bool mark_scene_dirty;
-	int interval;
+	bool started = false;
+	bool mark_scene_dirty = false;
+	int interval = 0;
 };
 
 #endif

--- a/source/map_display.h
+++ b/source/map_display.h
@@ -136,6 +136,8 @@ protected:
 	bool floodFill(Map* map, const Position &center, int x, int y, GroundBrush* brush, PositionVector* positions);
 
 private:
+	void QueueRefresh(bool mark_scene_dirty);
+
 	enum {
 		BLOCK_SIZE = 64
 	};
@@ -196,6 +198,7 @@ private:
 	AnimationTimer* animation_timer;
 
 	friend class MapDrawer;
+	friend class AnimationTimer;
 
 	DECLARE_EVENT_TABLE()
 };
@@ -217,12 +220,14 @@ public:
 	AnimationTimer(MapCanvas* canvas);
 
 	void Notify();
-	void Start();
+	void StartRefresh(int interval, bool mark_scene_dirty);
 	void Stop();
 
 private:
 	MapCanvas* map_canvas;
 	bool started;
+	bool mark_scene_dirty;
+	int interval;
 };
 
 #endif

--- a/source/map_drawer.cpp
+++ b/source/map_drawer.cpp
@@ -33,6 +33,7 @@
 #include <fstream>
 #include <format>
 #include <array>
+#include <algorithm>
 
 #include "editor.h"
 #include "gui.h"
@@ -1904,8 +1905,10 @@ void MapDrawer::DrawTooltips() {
 		return;
 	}
 
+	const float tooltip_scale = std::clamp(1.0f / zoom, 0.55f, 1.0f);
+
 	renderer->flush();
-	renderer->setOrtho(0, static_cast<float>(screensize_x), static_cast<float>(screensize_y), 0);
+	renderer->setOrtho(0, static_cast<float>(screensize_x) / tooltip_scale, static_cast<float>(screensize_y) / tooltip_scale, 0);
 
 	for (const auto &tp : tooltips) {
 		auto [width, height] = MeasureTooltipText(tp);
@@ -1914,8 +1917,8 @@ void MapDrawer::DrawTooltips() {
 		int screen_y;
 		getDrawPosition(Position(tp.map_x, tp.map_y, tp.map_z), screen_x, screen_y);
 
-		float x = static_cast<float>(screen_x + rme::TileSize / 2) / zoom;
-		float y = static_cast<float>(screen_y + rme::TileSize / 2) / zoom;
+		float x = (static_cast<float>(screen_x + rme::TileSize / 2) / zoom) / tooltip_scale;
+		float y = (static_cast<float>(screen_y + rme::TileSize / 2) / zoom) / tooltip_scale;
 		float center = width / 2.0f;
 		float space = 7.0f;
 		float startx = x - center;

--- a/source/map_region.cpp
+++ b/source/map_region.cpp
@@ -68,10 +68,6 @@ void Floor::operator delete(void* ptr) noexcept {
 	rme::deallocatePooledObject(ptr);
 }
 
-void Floor::operator delete(void* ptr, size_t) noexcept {
-	rme::deallocatePooledObject(ptr);
-}
-
 #ifdef DEBUG_MEM
 void* Floor::operator new(size_t size, const char*, int) {
 	return rme::allocatePooledObject(size);

--- a/source/map_region.cpp
+++ b/source/map_region.cpp
@@ -21,6 +21,7 @@
 #include "basemap.h"
 #include "position.h"
 #include "tile.h"
+#include "object_pool.h"
 
 //**************** Tile Location **********************
 
@@ -58,6 +59,28 @@ HouseExitList* TileLocation::createHouseExits() {
 }
 
 //**************** Floor **********************
+
+void* Floor::operator new(size_t size) {
+	return rme::allocatePooledObject(size);
+}
+
+void Floor::operator delete(void* ptr) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+
+void Floor::operator delete(void* ptr, size_t) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+
+#ifdef DEBUG_MEM
+void* Floor::operator new(size_t size, const char*, int) {
+	return rme::allocatePooledObject(size);
+}
+
+void Floor::operator delete(void* ptr, const char*, int) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+#endif
 
 Floor::Floor(int sx, int sy, int z) {
 	sx = sx & ~3;

--- a/source/map_region.h
+++ b/source/map_region.h
@@ -105,6 +105,7 @@ public:
 	friend class Floor;
 	friend class QTreeNode;
 	friend class Waypoints;
+	friend class BaseMap;
 };
 
 class Floor {

--- a/source/map_region.h
+++ b/source/map_region.h
@@ -110,6 +110,14 @@ public:
 
 class Floor {
 public:
+	static void* operator new(size_t size);
+	static void operator delete(void* ptr) noexcept;
+	static void operator delete(void* ptr, size_t size) noexcept;
+#ifdef DEBUG_MEM
+	static void* operator new(size_t size, const char* file, int line);
+	static void operator delete(void* ptr, const char* file, int line) noexcept;
+#endif
+
 	Floor(int x, int y, int z);
 	TileLocation locs[rme::MapLayers];
 };

--- a/source/map_region.h
+++ b/source/map_region.h
@@ -112,7 +112,6 @@ class Floor {
 public:
 	static void* operator new(size_t size);
 	static void operator delete(void* ptr) noexcept;
-	static void operator delete(void* ptr, size_t size) noexcept;
 #ifdef DEBUG_MEM
 	static void* operator new(size_t size, const char* file, int line);
 	static void operator delete(void* ptr, const char* file, int line) noexcept;

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -245,7 +245,10 @@ namespace {
 				return;
 			}
 
-			assert(ownerThread_ == currentThread);
+			if (ownerThread_ != currentThread) {
+				// A different owner falls back to the regular heap instead of crashing debug builds.
+				return;
+			}
 		}
 
 		void resetStats() noexcept {
@@ -390,6 +393,7 @@ namespace {
 			);
 			const std::size_t slabSize = blockCount * blockSize;
 
+			slabs_.reserve(slabs_.size() + 1);
 			auto* slab = static_cast<unsigned char*>(::operator new(slabSize));
 			slabs_.push_back(slab);
 

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -25,10 +25,22 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <mutex>
 #include <new>
 #include <thread>
 #include <vector>
+
+#ifdef _WIN32
+	#ifndef NOMINMAX
+		#define NOMINMAX
+	#endif
+	#include <windows.h>
+#endif
+
+#ifndef RME_OBJECT_POOL_STATS
+	#define RME_OBJECT_POOL_STATS 1
+#endif
 
 namespace {
 constexpr std::size_t kAlignment = alignof(std::max_align_t);
@@ -52,6 +64,101 @@ static_assert(kClassSizes[kClassCount - 1] == kMaxClassSize, "max class size mus
 
 constexpr std::size_t kSlabBytes = 256 * 1024;
 constexpr std::size_t kMinBlocksPerSlab = 64;
+
+#if RME_OBJECT_POOL_STATS
+constexpr std::memory_order kStatsMemoryOrder = std::memory_order_relaxed;
+
+void emitStatsLine(const char* line) noexcept {
+#ifdef _WIN32
+	OutputDebugStringA(line);
+	OutputDebugStringA("\n");
+#endif
+	std::fputs(line, stderr);
+	std::fputc('\n', stderr);
+}
+
+void updateMax(std::atomic<uint64_t> &target, uint64_t value) noexcept {
+	uint64_t current = target.load(kStatsMemoryOrder);
+	while (current < value && !target.compare_exchange_weak(current, value, kStatsMemoryOrder, kStatsMemoryOrder)) {
+	}
+}
+
+struct PoolStats {
+	std::atomic<uint64_t> allocCalls { 0 };
+	std::atomic<uint64_t> pooledAllocCalls { 0 };
+	std::atomic<uint64_t> fallbackSizeAllocCalls { 0 };
+	std::atomic<uint64_t> fallbackThreadAllocCalls { 0 };
+	std::atomic<uint64_t> fallbackFreeCalls { 0 };
+	std::atomic<uint64_t> remoteFreeCalls { 0 };
+	std::atomic<uint64_t> remoteDrainCalls { 0 };
+	std::atomic<uint64_t> slabRefillCalls { 0 };
+	std::atomic<uint64_t> maxFallbackPayloadSize { 0 };
+	std::array<std::atomic<uint64_t>, kClassCount> allocByClass {};
+	std::array<std::atomic<uint64_t>, kClassCount> refillByClass {};
+
+	PoolStats() noexcept {
+		reset();
+	}
+
+	void reset() noexcept {
+		allocCalls.store(0, kStatsMemoryOrder);
+		pooledAllocCalls.store(0, kStatsMemoryOrder);
+		fallbackSizeAllocCalls.store(0, kStatsMemoryOrder);
+		fallbackThreadAllocCalls.store(0, kStatsMemoryOrder);
+		fallbackFreeCalls.store(0, kStatsMemoryOrder);
+		remoteFreeCalls.store(0, kStatsMemoryOrder);
+		remoteDrainCalls.store(0, kStatsMemoryOrder);
+		slabRefillCalls.store(0, kStatsMemoryOrder);
+		maxFallbackPayloadSize.store(0, kStatsMemoryOrder);
+
+		for (auto &counter : allocByClass) {
+			counter.store(0, kStatsMemoryOrder);
+		}
+
+		for (auto &counter : refillByClass) {
+			counter.store(0, kStatsMemoryOrder);
+		}
+	}
+
+	void dump() const noexcept {
+		char line[512];
+		std::snprintf(
+			line,
+			sizeof(line),
+			"[object_pool] alloc=%llu pooled=%llu fallback_size=%llu fallback_thread=%llu fallback_free=%llu remote_free=%llu remote_drain=%llu slab_refill=%llu max_fallback_payload=%llu",
+			static_cast<unsigned long long>(allocCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(pooledAllocCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(fallbackSizeAllocCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(fallbackThreadAllocCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(fallbackFreeCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(remoteFreeCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(remoteDrainCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(slabRefillCalls.load(kStatsMemoryOrder)),
+			static_cast<unsigned long long>(maxFallbackPayloadSize.load(kStatsMemoryOrder))
+		);
+		emitStatsLine(line);
+
+		for (std::size_t i = 0; i < kClassCount; ++i) {
+			const auto allocCount = allocByClass[i].load(kStatsMemoryOrder);
+			const auto refillCount = refillByClass[i].load(kStatsMemoryOrder);
+			if (allocCount == 0 && refillCount == 0) {
+				continue;
+			}
+
+			std::snprintf(
+				line,
+				sizeof(line),
+				"[object_pool] class=%zu block_size=%zu alloc=%llu refill=%llu",
+				i,
+				kClassSizes[i],
+				static_cast<unsigned long long>(allocCount),
+				static_cast<unsigned long long>(refillCount)
+			);
+			emitStatsLine(line);
+		}
+	}
+};
+#endif
 
 struct alignas(std::max_align_t) AllocationHeader {
 	uint32_t magic;
@@ -138,15 +245,43 @@ public:
 		assert(ownerThread_ == currentThread);
 	}
 
+	void resetStats() noexcept {
+#if RME_OBJECT_POOL_STATS
+		stats_.reset();
+#endif
+	}
+
+	void dumpStats() noexcept {
+#if RME_OBJECT_POOL_STATS
+		stats_.dump();
+#endif
+	}
+
 	void* allocate(std::size_t payloadSize) {
+#if RME_OBJECT_POOL_STATS
+		stats_.allocCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
+
 		const uint16_t cls = classForPayloadSize(payloadSize);
 		if (cls == kFallbackClass) {
+#if RME_OBJECT_POOL_STATS
+			stats_.fallbackSizeAllocCalls.fetch_add(1, kStatsMemoryOrder);
+			updateMax(stats_.maxFallbackPayloadSize, static_cast<uint64_t>(payloadSize));
+#endif
 			return allocateFallback(payloadSize);
 		}
 
 		if (!becomeOwnerOrIsOwner()) {
+#if RME_OBJECT_POOL_STATS
+			stats_.fallbackThreadAllocCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
 			return allocateFallback(payloadSize);
 		}
+
+#if RME_OBJECT_POOL_STATS
+		stats_.pooledAllocCalls.fetch_add(1, kStatsMemoryOrder);
+		stats_.allocByClass[cls].fetch_add(1, kStatsMemoryOrder);
+#endif
 
 		FreeNode* node = localFreeLists_[cls];
 		if (!node) {
@@ -181,6 +316,9 @@ public:
 
 		const uint16_t cls = header->classIndex;
 		if (cls == kFallbackClass) {
+#if RME_OBJECT_POOL_STATS
+			stats_.fallbackFreeCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
 			deallocateFallback(header);
 			return;
 		}
@@ -197,6 +335,9 @@ public:
 			return;
 		}
 
+#if RME_OBJECT_POOL_STATS
+		stats_.remoteFreeCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
 		std::lock_guard<std::mutex> lock(remoteMutex_);
 		node->next = remoteFreeLists_[cls];
 		remoteFreeLists_[cls] = node;
@@ -224,11 +365,21 @@ private:
 		assert(localFreeLists_[cls] == nullptr);
 
 		std::lock_guard<std::mutex> lock(remoteMutex_);
+#if RME_OBJECT_POOL_STATS
+		if (remoteFreeLists_[cls]) {
+			stats_.remoteDrainCalls.fetch_add(1, kStatsMemoryOrder);
+		}
+#endif
 		localFreeLists_[cls] = remoteFreeLists_[cls];
 		remoteFreeLists_[cls] = nullptr;
 	}
 
 	void refill(uint16_t cls) {
+#if RME_OBJECT_POOL_STATS
+		stats_.slabRefillCalls.fetch_add(1, kStatsMemoryOrder);
+		stats_.refillByClass[cls].fetch_add(1, kStatsMemoryOrder);
+#endif
+
 		const std::size_t blockSize = kClassSizes[cls];
 		const std::size_t blockCount = std::max<std::size_t>(
 			kMinBlocksPerSlab,
@@ -254,6 +405,9 @@ private:
 	std::array<FreeNode*, kClassCount> remoteFreeLists_ {};
 	std::mutex remoteMutex_;
 	std::vector<void*> slabs_;
+#if RME_OBJECT_POOL_STATS
+	PoolStats stats_;
+#endif
 };
 
 SmallObjectPool &pooledObjectResource() {
@@ -274,4 +428,12 @@ void rme::deallocatePooledObject(void* ptr) noexcept {
 
 void rme::bindPooledObjectOwnerThread() noexcept {
 	pooledObjectResource().bindOwnerThread();
+}
+
+void rme::resetPooledObjectStats() noexcept {
+	pooledObjectResource().resetStats();
+}
+
+void rme::dumpPooledObjectStats() noexcept {
+	pooledObjectResource().dumpStats();
 }

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -19,39 +19,242 @@
 
 #include "object_pool.h"
 
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cassert>
 #include <cstddef>
-#include <memory_resource>
+#include <cstdint>
+#include <mutex>
+#include <new>
+#include <thread>
+#include <vector>
 
 namespace {
-struct alignas(std::max_align_t) PooledAllocationHeader {
-	size_t size;
+constexpr std::size_t kAlignment = alignof(std::max_align_t);
+static_assert((kAlignment & (kAlignment - 1)) == 0, "pool alignment must be a power of two");
+
+constexpr uint32_t kMagic = 0x524D4550; // "RMEP"
+constexpr uint16_t kFallbackClass = 0xFFFF;
+
+// Total block sizes including AllocationHeader. These cover Item subclasses,
+// Tile, and Floor while preserving a safe heap fallback for larger objects.
+constexpr std::array<std::size_t, 16> kClassSizes = {
+	32, 48, 64, 80,
+	96, 112, 128, 160,
+	192, 224, 256, 320,
+	384, 512, 768, 1024
 };
 
-std::pmr::synchronized_pool_resource &pooledObjectResource() {
-	static auto* resource = new std::pmr::synchronized_pool_resource(
-		std::pmr::pool_options {
-			4096,
-			2048
-		},
-		std::pmr::new_delete_resource()
+constexpr std::size_t kClassCount = kClassSizes.size();
+constexpr std::size_t kMaxClassSize = 1024;
+static_assert(kClassSizes[kClassCount - 1] == kMaxClassSize, "max class size must match the largest pool class");
+
+constexpr std::size_t kSlabBytes = 256 * 1024;
+constexpr std::size_t kMinBlocksPerSlab = 64;
+
+struct alignas(std::max_align_t) AllocationHeader {
+	uint32_t magic;
+	uint16_t classIndex;
+	uint16_t reserved;
+};
+
+static_assert(sizeof(AllocationHeader) <= 32, "unexpected pool allocation header size");
+
+struct FreeNode {
+	FreeNode* next;
+};
+
+constexpr std::size_t alignUp(std::size_t value, std::size_t alignment) noexcept {
+	return (value + alignment - 1) & ~(alignment - 1);
+}
+
+constexpr std::size_t kLookupCount = kMaxClassSize / kAlignment + 1;
+
+constexpr std::array<uint16_t, kLookupCount> makeClassLookup() {
+	std::array<uint16_t, kLookupCount> lookup {};
+
+	for (std::size_t unit = 0; unit < kLookupCount; ++unit) {
+		const std::size_t bytes = unit * kAlignment;
+		uint16_t selected = kFallbackClass;
+
+		for (uint16_t i = 0; i < kClassCount; ++i) {
+			if (bytes <= kClassSizes[i]) {
+				selected = i;
+				break;
+			}
+		}
+
+		lookup[unit] = selected;
+	}
+
+	return lookup;
+}
+
+constexpr auto kClassLookup = makeClassLookup();
+
+uint16_t classForPayloadSize(std::size_t payloadSize) noexcept {
+	const std::size_t totalSize = alignUp(
+		sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
+		kAlignment
 	);
-	return *resource;
+
+	if (totalSize > kMaxClassSize) {
+		return kFallbackClass;
+	}
+
+	return kClassLookup[totalSize / kAlignment];
+}
+
+void* allocateFallback(std::size_t payloadSize) {
+	const std::size_t totalSize = alignUp(
+		sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
+		kAlignment
+	);
+
+	auto* header = static_cast<AllocationHeader*>(::operator new(totalSize));
+	header->magic = kMagic;
+	header->classIndex = kFallbackClass;
+	header->reserved = 0;
+	return header + 1;
+}
+
+void deallocateFallback(AllocationHeader* header) noexcept {
+	::operator delete(header);
+}
+
+class SmallObjectPool {
+public:
+	void* allocate(std::size_t payloadSize) {
+		const uint16_t cls = classForPayloadSize(payloadSize);
+		if (cls == kFallbackClass) {
+			return allocateFallback(payloadSize);
+		}
+
+		if (!becomeOwnerOrIsOwner()) {
+			return allocateFallback(payloadSize);
+		}
+
+		FreeNode* node = localFreeLists_[cls];
+		if (!node) {
+			drainRemoteIntoEmptyLocal(cls);
+			node = localFreeLists_[cls];
+
+			if (!node) {
+				refill(cls);
+				node = localFreeLists_[cls];
+			}
+		}
+
+		localFreeLists_[cls] = node->next;
+
+		auto* header = reinterpret_cast<AllocationHeader*>(node);
+		header->magic = kMagic;
+		header->classIndex = cls;
+		header->reserved = 0;
+		return header + 1;
+	}
+
+	void deallocate(void* ptr) noexcept {
+		if (!ptr) {
+			return;
+		}
+
+		auto* header = static_cast<AllocationHeader*>(ptr) - 1;
+		if (header->magic != kMagic) {
+			assert(false && "invalid pooled object pointer");
+			return;
+		}
+
+		const uint16_t cls = header->classIndex;
+		if (cls == kFallbackClass) {
+			deallocateFallback(header);
+			return;
+		}
+
+		if (cls >= kClassCount) {
+			assert(false && "invalid pooled object size class");
+			return;
+		}
+
+		auto* node = reinterpret_cast<FreeNode*>(header);
+		if (isCurrentThreadOwner()) {
+			node->next = localFreeLists_[cls];
+			localFreeLists_[cls] = node;
+			return;
+		}
+
+		std::lock_guard<std::mutex> lock(remoteMutex_);
+		node->next = remoteFreeLists_[cls];
+		remoteFreeLists_[cls] = node;
+	}
+
+private:
+	bool becomeOwnerOrIsOwner() {
+		if (!ownerSet_.load(std::memory_order_acquire)) {
+			std::lock_guard<std::mutex> lock(ownerMutex_);
+			if (!ownerSet_.load(std::memory_order_relaxed)) {
+				ownerThread_ = std::this_thread::get_id();
+				ownerSet_.store(true, std::memory_order_release);
+				return true;
+			}
+		}
+
+		return ownerThread_ == std::this_thread::get_id();
+	}
+
+	bool isCurrentThreadOwner() const noexcept {
+		return ownerSet_.load(std::memory_order_acquire) && ownerThread_ == std::this_thread::get_id();
+	}
+
+	void drainRemoteIntoEmptyLocal(uint16_t cls) {
+		assert(localFreeLists_[cls] == nullptr);
+
+		std::lock_guard<std::mutex> lock(remoteMutex_);
+		localFreeLists_[cls] = remoteFreeLists_[cls];
+		remoteFreeLists_[cls] = nullptr;
+	}
+
+	void refill(uint16_t cls) {
+		const std::size_t blockSize = kClassSizes[cls];
+		const std::size_t blockCount = std::max<std::size_t>(
+			kMinBlocksPerSlab,
+			kSlabBytes / blockSize
+		);
+		const std::size_t slabSize = blockCount * blockSize;
+
+		auto* slab = static_cast<unsigned char*>(::operator new(slabSize));
+		slabs_.push_back(slab);
+
+		for (std::size_t i = 0; i < blockCount; ++i) {
+			auto* node = reinterpret_cast<FreeNode*>(slab + i * blockSize);
+			node->next = localFreeLists_[cls];
+			localFreeLists_[cls] = node;
+		}
+	}
+
+	std::atomic<bool> ownerSet_ { false };
+	std::mutex ownerMutex_;
+	std::thread::id ownerThread_;
+
+	std::array<FreeNode*, kClassCount> localFreeLists_ {};
+	std::array<FreeNode*, kClassCount> remoteFreeLists_ {};
+	std::mutex remoteMutex_;
+	std::vector<void*> slabs_;
+};
+
+SmallObjectPool &pooledObjectResource() {
+	// Intentionally kept alive for the process lifetime. Map objects can be
+	// destroyed from detached threads, so static destruction order is unsafe.
+	static auto* pool = new SmallObjectPool();
+	return *pool;
 }
 }
 
 void* rme::allocatePooledObject(std::size_t size) {
-	const std::size_t allocationSize = sizeof(PooledAllocationHeader) + std::max<std::size_t>(size, 1);
-	void* raw = pooledObjectResource().allocate(allocationSize, alignof(PooledAllocationHeader));
-	auto* header = static_cast<PooledAllocationHeader*>(raw);
-	header->size = allocationSize;
-	return header + 1;
+	return pooledObjectResource().allocate(size);
 }
 
 void rme::deallocatePooledObject(void* ptr) noexcept {
-	if (!ptr) {
-		return;
-	}
-
-	auto* header = static_cast<PooledAllocationHeader*>(ptr) - 1;
-	pooledObjectResource().deallocate(header, header->size, alignof(PooledAllocationHeader));
+	pooledObjectResource().deallocate(ptr);
 }

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -62,7 +62,7 @@ constexpr std::size_t kClassCount = kClassSizes.size();
 constexpr std::size_t kMaxClassSize = 1024;
 static_assert(kClassSizes[kClassCount - 1] == kMaxClassSize, "max class size must match the largest pool class");
 
-constexpr std::size_t kSlabBytes = 256 * 1024;
+constexpr std::size_t kSlabBytes = 2 * 1024 * 1024;
 constexpr std::size_t kMinBlocksPerSlab = 64;
 
 #if RME_OBJECT_POOL_STATS

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -65,7 +65,7 @@ constexpr std::size_t kClassCount = kClassSizes.size();
 constexpr std::size_t kMaxClassSize = 1024;
 static_assert(kClassSizes[kClassCount - 1] == kMaxClassSize, "max class size must match the largest pool class");
 
-constexpr std::size_t kSlabBytes = 2 * 1024 * 1024;
+constexpr std::size_t kSlabBytes = 4 * 1024 * 1024;
 constexpr std::size_t kMinBlocksPerSlab = 64;
 
 #if RME_OBJECT_POOL_STATS

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -25,21 +25,24 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
 #include <mutex>
 #include <new>
 #include <thread>
 #include <vector>
 
-#ifdef _WIN32
-	#ifndef NOMINMAX
-		#define NOMINMAX
-	#endif
-	#include <windows.h>
+#ifndef RME_OBJECT_POOL_STATS
+	#define RME_OBJECT_POOL_STATS 0
 #endif
 
-#ifndef RME_OBJECT_POOL_STATS
-	#define RME_OBJECT_POOL_STATS 1
+#if RME_OBJECT_POOL_STATS
+	#include <cstdio>
+
+	#ifdef _WIN32
+		#ifndef NOMINMAX
+			#define NOMINMAX
+		#endif
+		#include <windows.h>
+	#endif
 #endif
 
 namespace {

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -125,6 +125,19 @@ void deallocateFallback(AllocationHeader* header) noexcept {
 
 class SmallObjectPool {
 public:
+	void bindOwnerThread() noexcept {
+		std::lock_guard<std::mutex> lock(ownerMutex_);
+
+		const auto currentThread = std::this_thread::get_id();
+		if (!ownerSet_.load(std::memory_order_relaxed)) {
+			ownerThread_ = currentThread;
+			ownerSet_.store(true, std::memory_order_release);
+			return;
+		}
+
+		assert(ownerThread_ == currentThread);
+	}
+
 	void* allocate(std::size_t payloadSize) {
 		const uint16_t cls = classForPayloadSize(payloadSize);
 		if (cls == kFallbackClass) {
@@ -257,4 +270,8 @@ void* rme::allocatePooledObject(std::size_t size) {
 
 void rme::deallocatePooledObject(void* ptr) noexcept {
 	pooledObjectResource().deallocate(ptr);
+}
+
+void rme::bindPooledObjectOwnerThread() noexcept {
+	pooledObjectResource().bindOwnerThread();
 }

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -47,7 +48,7 @@
 
 namespace {
 	constexpr std::size_t kAlignment = alignof(std::max_align_t);
-	static_assert((kAlignment & (kAlignment - 1)) == 0, "pool alignment must be a power of two");
+	static_assert(std::has_single_bit(kAlignment), "pool alignment must be a power of two");
 
 	constexpr uint32_t kMagic = 0x524D4550; // "RMEP"
 	constexpr uint16_t kFallbackClass = 0xFFFF;
@@ -216,7 +217,7 @@ namespace {
 		return kClassLookup[totalSize / kAlignment];
 	}
 
-	void* allocateFallback(std::size_t payloadSize) {
+	void* allocateFallback(std::size_t payloadSize) { // NOSONAR - operator new requires a void pointer payload.
 		const std::size_t totalSize = alignUp(
 			sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
 			kAlignment
@@ -236,12 +237,12 @@ namespace {
 	class SmallObjectPool {
 	public:
 		void bindOwnerThread() noexcept {
-			std::lock_guard<std::mutex> lock(ownerMutex_);
+			std::scoped_lock lock(ownerMutex_);
 
 			const auto currentThread = std::this_thread::get_id();
-			if (!ownerSet_.load(std::memory_order_relaxed)) {
+			if (!ownerSet_.load()) {
 				ownerThread_ = currentThread;
-				ownerSet_.store(true, std::memory_order_release);
+				ownerSet_.store(true);
 				return;
 			}
 
@@ -251,19 +252,17 @@ namespace {
 			}
 		}
 
+#if RME_OBJECT_POOL_STATS
 		void resetStats() noexcept {
-#if RME_OBJECT_POOL_STATS
 			stats_.reset();
-#endif
 		}
 
-		void dumpStats() noexcept {
-#if RME_OBJECT_POOL_STATS
+		void dumpStats() const noexcept {
 			stats_.dump();
-#endif
 		}
+#endif
 
-		void* allocate(std::size_t payloadSize) {
+		void* allocate(std::size_t payloadSize) { // NOSONAR - this backs class operator new overloads.
 #if RME_OBJECT_POOL_STATS
 			stats_.allocCalls.fetch_add(1, kStatsMemoryOrder);
 #endif
@@ -302,14 +301,14 @@ namespace {
 
 			localFreeLists_[cls] = node->next;
 
-			auto* header = reinterpret_cast<AllocationHeader*>(node);
+			auto* header = reinterpret_cast<AllocationHeader*>(node); // NOSONAR - freelist storage is reused as an allocation header.
 			header->magic = kMagic;
 			header->classIndex = cls;
 			header->reserved = 0;
 			return header + 1;
 		}
 
-		void deallocate(void* ptr) noexcept {
+		void deallocate(void* ptr) noexcept { // NOSONAR - this backs class operator delete overloads.
 			if (!ptr) {
 				return;
 			}
@@ -334,7 +333,7 @@ namespace {
 				return;
 			}
 
-			auto* node = reinterpret_cast<FreeNode*>(header);
+			auto* node = reinterpret_cast<FreeNode*>(header); // NOSONAR - returned blocks become freelist nodes.
 			if (isCurrentThreadOwner()) {
 				node->next = localFreeLists_[cls];
 				localFreeLists_[cls] = node;
@@ -344,18 +343,18 @@ namespace {
 #if RME_OBJECT_POOL_STATS
 			stats_.remoteFreeCalls.fetch_add(1, kStatsMemoryOrder);
 #endif
-			std::lock_guard<std::mutex> lock(remoteMutex_);
+			std::scoped_lock lock(remoteMutex_);
 			node->next = remoteFreeLists_[cls];
 			remoteFreeLists_[cls] = node;
 		}
 
 	private:
 		bool becomeOwnerOrIsOwner() {
-			if (!ownerSet_.load(std::memory_order_acquire)) {
-				std::lock_guard<std::mutex> lock(ownerMutex_);
-				if (!ownerSet_.load(std::memory_order_relaxed)) {
+			if (!ownerSet_.load()) {
+				std::scoped_lock lock(ownerMutex_);
+				if (!ownerSet_.load()) {
 					ownerThread_ = std::this_thread::get_id();
-					ownerSet_.store(true, std::memory_order_release);
+					ownerSet_.store(true);
 					return true;
 				}
 			}
@@ -364,13 +363,13 @@ namespace {
 		}
 
 		bool isCurrentThreadOwner() const noexcept {
-			return ownerSet_.load(std::memory_order_acquire) && ownerThread_ == std::this_thread::get_id();
+			return ownerSet_.load() && ownerThread_ == std::this_thread::get_id();
 		}
 
 		void drainRemoteIntoEmptyLocal(uint16_t cls) {
 			assert(localFreeLists_[cls] == nullptr);
 
-			std::lock_guard<std::mutex> lock(remoteMutex_);
+			std::scoped_lock lock(remoteMutex_);
 #if RME_OBJECT_POOL_STATS
 			if (remoteFreeLists_[cls]) {
 				stats_.remoteDrainCalls.fetch_add(1, kStatsMemoryOrder);
@@ -398,7 +397,7 @@ namespace {
 			slabs_.push_back(slab);
 
 			for (std::size_t i = 0; i < blockCount; ++i) {
-				auto* node = reinterpret_cast<FreeNode*>(slab + i * blockSize);
+				auto* node = reinterpret_cast<FreeNode*>(slab + i * blockSize); // NOSONAR - slab bytes are partitioned into freelist nodes.
 				node->next = localFreeLists_[cls];
 				localFreeLists_[cls] = node;
 			}
@@ -411,7 +410,7 @@ namespace {
 		std::array<FreeNode*, kClassCount> localFreeLists_ {};
 		std::array<FreeNode*, kClassCount> remoteFreeLists_ {};
 		std::mutex remoteMutex_;
-		std::vector<void*> slabs_;
+		std::vector<void*> slabs_; // NOSONAR - raw slab ownership is intentionally process-lifetime pooled storage.
 #if RME_OBJECT_POOL_STATS
 		PoolStats stats_;
 #endif
@@ -420,16 +419,16 @@ namespace {
 	SmallObjectPool &pooledObjectResource() {
 		// Intentionally kept alive for the process lifetime. Map objects can be
 		// destroyed from detached threads, so static destruction order is unsafe.
-		static auto* pool = new SmallObjectPool();
+		static auto* pool = new SmallObjectPool(); // NOSONAR
 		return *pool;
 	}
 }
 
-void* rme::allocatePooledObject(std::size_t size) {
+void* rme::allocatePooledObject(std::size_t size) { // NOSONAR - public API mirrors operator new.
 	return pooledObjectResource().allocate(size);
 }
 
-void rme::deallocatePooledObject(void* ptr) noexcept {
+void rme::deallocatePooledObject(void* ptr) noexcept { // NOSONAR - public API mirrors operator delete.
 	pooledObjectResource().deallocate(ptr);
 }
 
@@ -438,9 +437,13 @@ void rme::bindPooledObjectOwnerThread() noexcept {
 }
 
 void rme::resetPooledObjectStats() noexcept {
+#if RME_OBJECT_POOL_STATS
 	pooledObjectResource().resetStats();
+#endif
 }
 
 void rme::dumpPooledObjectStats() noexcept {
+#if RME_OBJECT_POOL_STATS
 	pooledObjectResource().dumpStats();
+#endif
 }

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -1,0 +1,57 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+// Remere's Map Editor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Remere's Map Editor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//////////////////////////////////////////////////////////////////////
+
+#include "main.h"
+
+#include "object_pool.h"
+
+#include <cstddef>
+#include <memory_resource>
+
+namespace {
+struct alignas(std::max_align_t) PooledAllocationHeader {
+	size_t size;
+};
+
+std::pmr::synchronized_pool_resource &pooledObjectResource() {
+	static auto* resource = new std::pmr::synchronized_pool_resource(
+		std::pmr::pool_options {
+			4096,
+			2048
+		},
+		std::pmr::new_delete_resource()
+	);
+	return *resource;
+}
+}
+
+void* rme::allocatePooledObject(std::size_t size) {
+	const std::size_t allocationSize = sizeof(PooledAllocationHeader) + std::max<std::size_t>(size, 1);
+	void* raw = pooledObjectResource().allocate(allocationSize, alignof(PooledAllocationHeader));
+	auto* header = static_cast<PooledAllocationHeader*>(raw);
+	header->size = allocationSize;
+	return header + 1;
+}
+
+void rme::deallocatePooledObject(void* ptr) noexcept {
+	if (!ptr) {
+		return;
+	}
+
+	auto* header = static_cast<PooledAllocationHeader*>(ptr) - 1;
+	pooledObjectResource().deallocate(header, header->size, alignof(PooledAllocationHeader));
+}

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -240,9 +240,9 @@ namespace {
 			std::scoped_lock lock(ownerMutex_);
 
 			const auto currentThread = std::this_thread::get_id();
-			if (!ownerSet_.load()) {
+			if (!ownerSet_.load(std::memory_order_relaxed)) { // NOSONAR - relaxed is enough while ownerMutex_ is held.
 				ownerThread_ = currentThread;
-				ownerSet_.store(true);
+				ownerSet_.store(true, std::memory_order_release); // NOSONAR - paired with acquire loads on the allocation fast path.
 				return;
 			}
 
@@ -350,11 +350,11 @@ namespace {
 
 	private:
 		bool becomeOwnerOrIsOwner() {
-			if (!ownerSet_.load()) {
+			if (!ownerSet_.load(std::memory_order_acquire)) { // NOSONAR - acquire/release keeps the allocator fast path cheaper than seq_cst.
 				std::scoped_lock lock(ownerMutex_);
-				if (!ownerSet_.load()) {
+				if (!ownerSet_.load(std::memory_order_relaxed)) { // NOSONAR - ownerMutex_ protects ownerThread_ initialization here.
 					ownerThread_ = std::this_thread::get_id();
-					ownerSet_.store(true);
+					ownerSet_.store(true, std::memory_order_release); // NOSONAR - paired with acquire loads on the allocation fast path.
 					return true;
 				}
 			}
@@ -363,7 +363,7 @@ namespace {
 		}
 
 		bool isCurrentThreadOwner() const noexcept {
-			return ownerSet_.load() && ownerThread_ == std::this_thread::get_id();
+			return ownerSet_.load(std::memory_order_acquire) && ownerThread_ == std::this_thread::get_id(); // NOSONAR
 		}
 
 		void drainRemoteIntoEmptyLocal(uint16_t cls) {

--- a/source/object_pool.cpp
+++ b/source/object_pool.cpp
@@ -46,379 +46,379 @@
 #endif
 
 namespace {
-constexpr std::size_t kAlignment = alignof(std::max_align_t);
-static_assert((kAlignment & (kAlignment - 1)) == 0, "pool alignment must be a power of two");
+	constexpr std::size_t kAlignment = alignof(std::max_align_t);
+	static_assert((kAlignment & (kAlignment - 1)) == 0, "pool alignment must be a power of two");
 
-constexpr uint32_t kMagic = 0x524D4550; // "RMEP"
-constexpr uint16_t kFallbackClass = 0xFFFF;
+	constexpr uint32_t kMagic = 0x524D4550; // "RMEP"
+	constexpr uint16_t kFallbackClass = 0xFFFF;
 
-// Total block sizes including AllocationHeader. These cover Item subclasses,
-// Tile, and Floor while preserving a safe heap fallback for larger objects.
-constexpr std::array<std::size_t, 16> kClassSizes = {
-	32, 48, 64, 80,
-	96, 112, 128, 160,
-	192, 224, 256, 320,
-	384, 512, 768, 1024
-};
+	// Total block sizes including AllocationHeader. These cover Item subclasses,
+	// Tile, and Floor while preserving a safe heap fallback for larger objects.
+	constexpr std::array<std::size_t, 16> kClassSizes = {
+		32, 48, 64, 80,
+		96, 112, 128, 160,
+		192, 224, 256, 320,
+		384, 512, 768, 1024
+	};
 
-constexpr std::size_t kClassCount = kClassSizes.size();
-constexpr std::size_t kMaxClassSize = 1024;
-static_assert(kClassSizes[kClassCount - 1] == kMaxClassSize, "max class size must match the largest pool class");
+	constexpr std::size_t kClassCount = kClassSizes.size();
+	constexpr std::size_t kMaxClassSize = 1024;
+	static_assert(kClassSizes[kClassCount - 1] == kMaxClassSize, "max class size must match the largest pool class");
 
-constexpr std::size_t kSlabBytes = 4 * 1024 * 1024;
-constexpr std::size_t kMinBlocksPerSlab = 64;
+	constexpr std::size_t kSlabBytes = 4 * 1024 * 1024;
+	constexpr std::size_t kMinBlocksPerSlab = 64;
 
 #if RME_OBJECT_POOL_STATS
-constexpr std::memory_order kStatsMemoryOrder = std::memory_order_relaxed;
+	constexpr std::memory_order kStatsMemoryOrder = std::memory_order_relaxed;
 
-void emitStatsLine(const char* line) noexcept {
-#ifdef _WIN32
-	OutputDebugStringA(line);
-	OutputDebugStringA("\n");
-#endif
-	std::fputs(line, stderr);
-	std::fputc('\n', stderr);
-}
-
-void updateMax(std::atomic<uint64_t> &target, uint64_t value) noexcept {
-	uint64_t current = target.load(kStatsMemoryOrder);
-	while (current < value && !target.compare_exchange_weak(current, value, kStatsMemoryOrder, kStatsMemoryOrder)) {
-	}
-}
-
-struct PoolStats {
-	std::atomic<uint64_t> allocCalls { 0 };
-	std::atomic<uint64_t> pooledAllocCalls { 0 };
-	std::atomic<uint64_t> fallbackSizeAllocCalls { 0 };
-	std::atomic<uint64_t> fallbackThreadAllocCalls { 0 };
-	std::atomic<uint64_t> fallbackFreeCalls { 0 };
-	std::atomic<uint64_t> remoteFreeCalls { 0 };
-	std::atomic<uint64_t> remoteDrainCalls { 0 };
-	std::atomic<uint64_t> slabRefillCalls { 0 };
-	std::atomic<uint64_t> maxFallbackPayloadSize { 0 };
-	std::array<std::atomic<uint64_t>, kClassCount> allocByClass {};
-	std::array<std::atomic<uint64_t>, kClassCount> refillByClass {};
-
-	PoolStats() noexcept {
-		reset();
+	void emitStatsLine(const char* line) noexcept {
+	#ifdef _WIN32
+		OutputDebugStringA(line);
+		OutputDebugStringA("\n");
+	#endif
+		std::fputs(line, stderr);
+		std::fputc('\n', stderr);
 	}
 
-	void reset() noexcept {
-		allocCalls.store(0, kStatsMemoryOrder);
-		pooledAllocCalls.store(0, kStatsMemoryOrder);
-		fallbackSizeAllocCalls.store(0, kStatsMemoryOrder);
-		fallbackThreadAllocCalls.store(0, kStatsMemoryOrder);
-		fallbackFreeCalls.store(0, kStatsMemoryOrder);
-		remoteFreeCalls.store(0, kStatsMemoryOrder);
-		remoteDrainCalls.store(0, kStatsMemoryOrder);
-		slabRefillCalls.store(0, kStatsMemoryOrder);
-		maxFallbackPayloadSize.store(0, kStatsMemoryOrder);
-
-		for (auto &counter : allocByClass) {
-			counter.store(0, kStatsMemoryOrder);
-		}
-
-		for (auto &counter : refillByClass) {
-			counter.store(0, kStatsMemoryOrder);
+	void updateMax(std::atomic<uint64_t> &target, uint64_t value) noexcept {
+		uint64_t current = target.load(kStatsMemoryOrder);
+		while (current < value && !target.compare_exchange_weak(current, value, kStatsMemoryOrder, kStatsMemoryOrder)) {
 		}
 	}
 
-	void dump() const noexcept {
-		char line[512];
-		std::snprintf(
-			line,
-			sizeof(line),
-			"[object_pool] alloc=%llu pooled=%llu fallback_size=%llu fallback_thread=%llu fallback_free=%llu remote_free=%llu remote_drain=%llu slab_refill=%llu max_fallback_payload=%llu",
-			static_cast<unsigned long long>(allocCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(pooledAllocCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(fallbackSizeAllocCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(fallbackThreadAllocCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(fallbackFreeCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(remoteFreeCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(remoteDrainCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(slabRefillCalls.load(kStatsMemoryOrder)),
-			static_cast<unsigned long long>(maxFallbackPayloadSize.load(kStatsMemoryOrder))
-		);
-		emitStatsLine(line);
+	struct PoolStats {
+		std::atomic<uint64_t> allocCalls { 0 };
+		std::atomic<uint64_t> pooledAllocCalls { 0 };
+		std::atomic<uint64_t> fallbackSizeAllocCalls { 0 };
+		std::atomic<uint64_t> fallbackThreadAllocCalls { 0 };
+		std::atomic<uint64_t> fallbackFreeCalls { 0 };
+		std::atomic<uint64_t> remoteFreeCalls { 0 };
+		std::atomic<uint64_t> remoteDrainCalls { 0 };
+		std::atomic<uint64_t> slabRefillCalls { 0 };
+		std::atomic<uint64_t> maxFallbackPayloadSize { 0 };
+		std::array<std::atomic<uint64_t>, kClassCount> allocByClass {};
+		std::array<std::atomic<uint64_t>, kClassCount> refillByClass {};
 
-		for (std::size_t i = 0; i < kClassCount; ++i) {
-			const auto allocCount = allocByClass[i].load(kStatsMemoryOrder);
-			const auto refillCount = refillByClass[i].load(kStatsMemoryOrder);
-			if (allocCount == 0 && refillCount == 0) {
-				continue;
+		PoolStats() noexcept {
+			reset();
+		}
+
+		void reset() noexcept {
+			allocCalls.store(0, kStatsMemoryOrder);
+			pooledAllocCalls.store(0, kStatsMemoryOrder);
+			fallbackSizeAllocCalls.store(0, kStatsMemoryOrder);
+			fallbackThreadAllocCalls.store(0, kStatsMemoryOrder);
+			fallbackFreeCalls.store(0, kStatsMemoryOrder);
+			remoteFreeCalls.store(0, kStatsMemoryOrder);
+			remoteDrainCalls.store(0, kStatsMemoryOrder);
+			slabRefillCalls.store(0, kStatsMemoryOrder);
+			maxFallbackPayloadSize.store(0, kStatsMemoryOrder);
+
+			for (auto &counter : allocByClass) {
+				counter.store(0, kStatsMemoryOrder);
 			}
 
+			for (auto &counter : refillByClass) {
+				counter.store(0, kStatsMemoryOrder);
+			}
+		}
+
+		void dump() const noexcept {
+			char line[512];
 			std::snprintf(
 				line,
 				sizeof(line),
-				"[object_pool] class=%zu block_size=%zu alloc=%llu refill=%llu",
-				i,
-				kClassSizes[i],
-				static_cast<unsigned long long>(allocCount),
-				static_cast<unsigned long long>(refillCount)
+				"[object_pool] alloc=%llu pooled=%llu fallback_size=%llu fallback_thread=%llu fallback_free=%llu remote_free=%llu remote_drain=%llu slab_refill=%llu max_fallback_payload=%llu",
+				static_cast<unsigned long long>(allocCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(pooledAllocCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(fallbackSizeAllocCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(fallbackThreadAllocCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(fallbackFreeCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(remoteFreeCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(remoteDrainCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(slabRefillCalls.load(kStatsMemoryOrder)),
+				static_cast<unsigned long long>(maxFallbackPayloadSize.load(kStatsMemoryOrder))
 			);
 			emitStatsLine(line);
-		}
-	}
-};
-#endif
 
-struct alignas(std::max_align_t) AllocationHeader {
-	uint32_t magic;
-	uint16_t classIndex;
-	uint16_t reserved;
-};
+			for (std::size_t i = 0; i < kClassCount; ++i) {
+				const auto allocCount = allocByClass[i].load(kStatsMemoryOrder);
+				const auto refillCount = refillByClass[i].load(kStatsMemoryOrder);
+				if (allocCount == 0 && refillCount == 0) {
+					continue;
+				}
 
-static_assert(sizeof(AllocationHeader) <= 32, "unexpected pool allocation header size");
-
-struct FreeNode {
-	FreeNode* next;
-};
-
-constexpr std::size_t alignUp(std::size_t value, std::size_t alignment) noexcept {
-	return (value + alignment - 1) & ~(alignment - 1);
-}
-
-constexpr std::size_t kLookupCount = kMaxClassSize / kAlignment + 1;
-
-constexpr std::array<uint16_t, kLookupCount> makeClassLookup() {
-	std::array<uint16_t, kLookupCount> lookup {};
-
-	for (std::size_t unit = 0; unit < kLookupCount; ++unit) {
-		const std::size_t bytes = unit * kAlignment;
-		uint16_t selected = kFallbackClass;
-
-		for (uint16_t i = 0; i < kClassCount; ++i) {
-			if (bytes <= kClassSizes[i]) {
-				selected = i;
-				break;
+				std::snprintf(
+					line,
+					sizeof(line),
+					"[object_pool] class=%zu block_size=%zu alloc=%llu refill=%llu",
+					i,
+					kClassSizes[i],
+					static_cast<unsigned long long>(allocCount),
+					static_cast<unsigned long long>(refillCount)
+				);
+				emitStatsLine(line);
 			}
 		}
+	};
+#endif
 
-		lookup[unit] = selected;
+	struct alignas(std::max_align_t) AllocationHeader {
+		uint32_t magic;
+		uint16_t classIndex;
+		uint16_t reserved;
+	};
+
+	static_assert(sizeof(AllocationHeader) <= 32, "unexpected pool allocation header size");
+
+	struct FreeNode {
+		FreeNode* next;
+	};
+
+	constexpr std::size_t alignUp(std::size_t value, std::size_t alignment) noexcept {
+		return (value + alignment - 1) & ~(alignment - 1);
 	}
 
-	return lookup;
-}
+	constexpr std::size_t kLookupCount = kMaxClassSize / kAlignment + 1;
 
-constexpr auto kClassLookup = makeClassLookup();
+	constexpr std::array<uint16_t, kLookupCount> makeClassLookup() {
+		std::array<uint16_t, kLookupCount> lookup {};
 
-uint16_t classForPayloadSize(std::size_t payloadSize) noexcept {
-	const std::size_t totalSize = alignUp(
-		sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
-		kAlignment
-	);
+		for (std::size_t unit = 0; unit < kLookupCount; ++unit) {
+			const std::size_t bytes = unit * kAlignment;
+			uint16_t selected = kFallbackClass;
 
-	if (totalSize > kMaxClassSize) {
-		return kFallbackClass;
-	}
-
-	return kClassLookup[totalSize / kAlignment];
-}
-
-void* allocateFallback(std::size_t payloadSize) {
-	const std::size_t totalSize = alignUp(
-		sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
-		kAlignment
-	);
-
-	auto* header = static_cast<AllocationHeader*>(::operator new(totalSize));
-	header->magic = kMagic;
-	header->classIndex = kFallbackClass;
-	header->reserved = 0;
-	return header + 1;
-}
-
-void deallocateFallback(AllocationHeader* header) noexcept {
-	::operator delete(header);
-}
-
-class SmallObjectPool {
-public:
-	void bindOwnerThread() noexcept {
-		std::lock_guard<std::mutex> lock(ownerMutex_);
-
-		const auto currentThread = std::this_thread::get_id();
-		if (!ownerSet_.load(std::memory_order_relaxed)) {
-			ownerThread_ = currentThread;
-			ownerSet_.store(true, std::memory_order_release);
-			return;
-		}
-
-		assert(ownerThread_ == currentThread);
-	}
-
-	void resetStats() noexcept {
-#if RME_OBJECT_POOL_STATS
-		stats_.reset();
-#endif
-	}
-
-	void dumpStats() noexcept {
-#if RME_OBJECT_POOL_STATS
-		stats_.dump();
-#endif
-	}
-
-	void* allocate(std::size_t payloadSize) {
-#if RME_OBJECT_POOL_STATS
-		stats_.allocCalls.fetch_add(1, kStatsMemoryOrder);
-#endif
-
-		const uint16_t cls = classForPayloadSize(payloadSize);
-		if (cls == kFallbackClass) {
-#if RME_OBJECT_POOL_STATS
-			stats_.fallbackSizeAllocCalls.fetch_add(1, kStatsMemoryOrder);
-			updateMax(stats_.maxFallbackPayloadSize, static_cast<uint64_t>(payloadSize));
-#endif
-			return allocateFallback(payloadSize);
-		}
-
-		if (!becomeOwnerOrIsOwner()) {
-#if RME_OBJECT_POOL_STATS
-			stats_.fallbackThreadAllocCalls.fetch_add(1, kStatsMemoryOrder);
-#endif
-			return allocateFallback(payloadSize);
-		}
-
-#if RME_OBJECT_POOL_STATS
-		stats_.pooledAllocCalls.fetch_add(1, kStatsMemoryOrder);
-		stats_.allocByClass[cls].fetch_add(1, kStatsMemoryOrder);
-#endif
-
-		FreeNode* node = localFreeLists_[cls];
-		if (!node) {
-			drainRemoteIntoEmptyLocal(cls);
-			node = localFreeLists_[cls];
-
-			if (!node) {
-				refill(cls);
-				node = localFreeLists_[cls];
+			for (uint16_t i = 0; i < kClassCount; ++i) {
+				if (bytes <= kClassSizes[i]) {
+					selected = i;
+					break;
+				}
 			}
+
+			lookup[unit] = selected;
 		}
 
-		localFreeLists_[cls] = node->next;
+		return lookup;
+	}
 
-		auto* header = reinterpret_cast<AllocationHeader*>(node);
+	constexpr auto kClassLookup = makeClassLookup();
+
+	uint16_t classForPayloadSize(std::size_t payloadSize) noexcept {
+		const std::size_t totalSize = alignUp(
+			sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
+			kAlignment
+		);
+
+		if (totalSize > kMaxClassSize) {
+			return kFallbackClass;
+		}
+
+		return kClassLookup[totalSize / kAlignment];
+	}
+
+	void* allocateFallback(std::size_t payloadSize) {
+		const std::size_t totalSize = alignUp(
+			sizeof(AllocationHeader) + std::max<std::size_t>(payloadSize, 1),
+			kAlignment
+		);
+
+		auto* header = static_cast<AllocationHeader*>(::operator new(totalSize));
 		header->magic = kMagic;
-		header->classIndex = cls;
+		header->classIndex = kFallbackClass;
 		header->reserved = 0;
 		return header + 1;
 	}
 
-	void deallocate(void* ptr) noexcept {
-		if (!ptr) {
-			return;
-		}
-
-		auto* header = static_cast<AllocationHeader*>(ptr) - 1;
-		if (header->magic != kMagic) {
-			assert(false && "invalid pooled object pointer");
-			return;
-		}
-
-		const uint16_t cls = header->classIndex;
-		if (cls == kFallbackClass) {
-#if RME_OBJECT_POOL_STATS
-			stats_.fallbackFreeCalls.fetch_add(1, kStatsMemoryOrder);
-#endif
-			deallocateFallback(header);
-			return;
-		}
-
-		if (cls >= kClassCount) {
-			assert(false && "invalid pooled object size class");
-			return;
-		}
-
-		auto* node = reinterpret_cast<FreeNode*>(header);
-		if (isCurrentThreadOwner()) {
-			node->next = localFreeLists_[cls];
-			localFreeLists_[cls] = node;
-			return;
-		}
-
-#if RME_OBJECT_POOL_STATS
-		stats_.remoteFreeCalls.fetch_add(1, kStatsMemoryOrder);
-#endif
-		std::lock_guard<std::mutex> lock(remoteMutex_);
-		node->next = remoteFreeLists_[cls];
-		remoteFreeLists_[cls] = node;
+	void deallocateFallback(AllocationHeader* header) noexcept {
+		::operator delete(header);
 	}
 
-private:
-	bool becomeOwnerOrIsOwner() {
-		if (!ownerSet_.load(std::memory_order_acquire)) {
+	class SmallObjectPool {
+	public:
+		void bindOwnerThread() noexcept {
 			std::lock_guard<std::mutex> lock(ownerMutex_);
+
+			const auto currentThread = std::this_thread::get_id();
 			if (!ownerSet_.load(std::memory_order_relaxed)) {
-				ownerThread_ = std::this_thread::get_id();
+				ownerThread_ = currentThread;
 				ownerSet_.store(true, std::memory_order_release);
-				return true;
+				return;
+			}
+
+			assert(ownerThread_ == currentThread);
+		}
+
+		void resetStats() noexcept {
+#if RME_OBJECT_POOL_STATS
+			stats_.reset();
+#endif
+		}
+
+		void dumpStats() noexcept {
+#if RME_OBJECT_POOL_STATS
+			stats_.dump();
+#endif
+		}
+
+		void* allocate(std::size_t payloadSize) {
+#if RME_OBJECT_POOL_STATS
+			stats_.allocCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
+
+			const uint16_t cls = classForPayloadSize(payloadSize);
+			if (cls == kFallbackClass) {
+#if RME_OBJECT_POOL_STATS
+				stats_.fallbackSizeAllocCalls.fetch_add(1, kStatsMemoryOrder);
+				updateMax(stats_.maxFallbackPayloadSize, static_cast<uint64_t>(payloadSize));
+#endif
+				return allocateFallback(payloadSize);
+			}
+
+			if (!becomeOwnerOrIsOwner()) {
+#if RME_OBJECT_POOL_STATS
+				stats_.fallbackThreadAllocCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
+				return allocateFallback(payloadSize);
+			}
+
+#if RME_OBJECT_POOL_STATS
+			stats_.pooledAllocCalls.fetch_add(1, kStatsMemoryOrder);
+			stats_.allocByClass[cls].fetch_add(1, kStatsMemoryOrder);
+#endif
+
+			FreeNode* node = localFreeLists_[cls];
+			if (!node) {
+				drainRemoteIntoEmptyLocal(cls);
+				node = localFreeLists_[cls];
+
+				if (!node) {
+					refill(cls);
+					node = localFreeLists_[cls];
+				}
+			}
+
+			localFreeLists_[cls] = node->next;
+
+			auto* header = reinterpret_cast<AllocationHeader*>(node);
+			header->magic = kMagic;
+			header->classIndex = cls;
+			header->reserved = 0;
+			return header + 1;
+		}
+
+		void deallocate(void* ptr) noexcept {
+			if (!ptr) {
+				return;
+			}
+
+			auto* header = static_cast<AllocationHeader*>(ptr) - 1;
+			if (header->magic != kMagic) {
+				assert(false && "invalid pooled object pointer");
+				return;
+			}
+
+			const uint16_t cls = header->classIndex;
+			if (cls == kFallbackClass) {
+#if RME_OBJECT_POOL_STATS
+				stats_.fallbackFreeCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
+				deallocateFallback(header);
+				return;
+			}
+
+			if (cls >= kClassCount) {
+				assert(false && "invalid pooled object size class");
+				return;
+			}
+
+			auto* node = reinterpret_cast<FreeNode*>(header);
+			if (isCurrentThreadOwner()) {
+				node->next = localFreeLists_[cls];
+				localFreeLists_[cls] = node;
+				return;
+			}
+
+#if RME_OBJECT_POOL_STATS
+			stats_.remoteFreeCalls.fetch_add(1, kStatsMemoryOrder);
+#endif
+			std::lock_guard<std::mutex> lock(remoteMutex_);
+			node->next = remoteFreeLists_[cls];
+			remoteFreeLists_[cls] = node;
+		}
+
+	private:
+		bool becomeOwnerOrIsOwner() {
+			if (!ownerSet_.load(std::memory_order_acquire)) {
+				std::lock_guard<std::mutex> lock(ownerMutex_);
+				if (!ownerSet_.load(std::memory_order_relaxed)) {
+					ownerThread_ = std::this_thread::get_id();
+					ownerSet_.store(true, std::memory_order_release);
+					return true;
+				}
+			}
+
+			return ownerThread_ == std::this_thread::get_id();
+		}
+
+		bool isCurrentThreadOwner() const noexcept {
+			return ownerSet_.load(std::memory_order_acquire) && ownerThread_ == std::this_thread::get_id();
+		}
+
+		void drainRemoteIntoEmptyLocal(uint16_t cls) {
+			assert(localFreeLists_[cls] == nullptr);
+
+			std::lock_guard<std::mutex> lock(remoteMutex_);
+#if RME_OBJECT_POOL_STATS
+			if (remoteFreeLists_[cls]) {
+				stats_.remoteDrainCalls.fetch_add(1, kStatsMemoryOrder);
+			}
+#endif
+			localFreeLists_[cls] = remoteFreeLists_[cls];
+			remoteFreeLists_[cls] = nullptr;
+		}
+
+		void refill(uint16_t cls) {
+#if RME_OBJECT_POOL_STATS
+			stats_.slabRefillCalls.fetch_add(1, kStatsMemoryOrder);
+			stats_.refillByClass[cls].fetch_add(1, kStatsMemoryOrder);
+#endif
+
+			const std::size_t blockSize = kClassSizes[cls];
+			const std::size_t blockCount = std::max<std::size_t>(
+				kMinBlocksPerSlab,
+				kSlabBytes / blockSize
+			);
+			const std::size_t slabSize = blockCount * blockSize;
+
+			auto* slab = static_cast<unsigned char*>(::operator new(slabSize));
+			slabs_.push_back(slab);
+
+			for (std::size_t i = 0; i < blockCount; ++i) {
+				auto* node = reinterpret_cast<FreeNode*>(slab + i * blockSize);
+				node->next = localFreeLists_[cls];
+				localFreeLists_[cls] = node;
 			}
 		}
 
-		return ownerThread_ == std::this_thread::get_id();
-	}
+		std::atomic<bool> ownerSet_ { false };
+		std::mutex ownerMutex_;
+		std::thread::id ownerThread_;
 
-	bool isCurrentThreadOwner() const noexcept {
-		return ownerSet_.load(std::memory_order_acquire) && ownerThread_ == std::this_thread::get_id();
-	}
-
-	void drainRemoteIntoEmptyLocal(uint16_t cls) {
-		assert(localFreeLists_[cls] == nullptr);
-
-		std::lock_guard<std::mutex> lock(remoteMutex_);
+		std::array<FreeNode*, kClassCount> localFreeLists_ {};
+		std::array<FreeNode*, kClassCount> remoteFreeLists_ {};
+		std::mutex remoteMutex_;
+		std::vector<void*> slabs_;
 #if RME_OBJECT_POOL_STATS
-		if (remoteFreeLists_[cls]) {
-			stats_.remoteDrainCalls.fetch_add(1, kStatsMemoryOrder);
-		}
+		PoolStats stats_;
 #endif
-		localFreeLists_[cls] = remoteFreeLists_[cls];
-		remoteFreeLists_[cls] = nullptr;
+	};
+
+	SmallObjectPool &pooledObjectResource() {
+		// Intentionally kept alive for the process lifetime. Map objects can be
+		// destroyed from detached threads, so static destruction order is unsafe.
+		static auto* pool = new SmallObjectPool();
+		return *pool;
 	}
-
-	void refill(uint16_t cls) {
-#if RME_OBJECT_POOL_STATS
-		stats_.slabRefillCalls.fetch_add(1, kStatsMemoryOrder);
-		stats_.refillByClass[cls].fetch_add(1, kStatsMemoryOrder);
-#endif
-
-		const std::size_t blockSize = kClassSizes[cls];
-		const std::size_t blockCount = std::max<std::size_t>(
-			kMinBlocksPerSlab,
-			kSlabBytes / blockSize
-		);
-		const std::size_t slabSize = blockCount * blockSize;
-
-		auto* slab = static_cast<unsigned char*>(::operator new(slabSize));
-		slabs_.push_back(slab);
-
-		for (std::size_t i = 0; i < blockCount; ++i) {
-			auto* node = reinterpret_cast<FreeNode*>(slab + i * blockSize);
-			node->next = localFreeLists_[cls];
-			localFreeLists_[cls] = node;
-		}
-	}
-
-	std::atomic<bool> ownerSet_ { false };
-	std::mutex ownerMutex_;
-	std::thread::id ownerThread_;
-
-	std::array<FreeNode*, kClassCount> localFreeLists_ {};
-	std::array<FreeNode*, kClassCount> remoteFreeLists_ {};
-	std::mutex remoteMutex_;
-	std::vector<void*> slabs_;
-#if RME_OBJECT_POOL_STATS
-	PoolStats stats_;
-#endif
-};
-
-SmallObjectPool &pooledObjectResource() {
-	// Intentionally kept alive for the process lifetime. Map objects can be
-	// destroyed from detached threads, so static destruction order is unsafe.
-	static auto* pool = new SmallObjectPool();
-	return *pool;
-}
 }
 
 void* rme::allocatePooledObject(std::size_t size) {

--- a/source/object_pool.h
+++ b/source/object_pool.h
@@ -1,0 +1,28 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+// Remere's Map Editor is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Remere's Map Editor is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//////////////////////////////////////////////////////////////////////
+
+#ifndef RME_OBJECT_POOL_H_
+#define RME_OBJECT_POOL_H_
+
+#include <cstddef>
+
+namespace rme {
+void* allocatePooledObject(std::size_t size);
+void deallocatePooledObject(void* ptr) noexcept;
+}
+
+#endif

--- a/source/object_pool.h
+++ b/source/object_pool.h
@@ -21,8 +21,8 @@
 #include <cstddef>
 
 namespace rme {
-	void* allocatePooledObject(std::size_t size);
-	void deallocatePooledObject(void* ptr) noexcept;
+	void* allocatePooledObject(std::size_t size); // NOSONAR - pooled operator new API.
+	void deallocatePooledObject(void* ptr) noexcept; // NOSONAR - pooled operator delete API.
 	void bindPooledObjectOwnerThread() noexcept;
 	void resetPooledObjectStats() noexcept;
 	void dumpPooledObjectStats() noexcept;

--- a/source/object_pool.h
+++ b/source/object_pool.h
@@ -21,11 +21,11 @@
 #include <cstddef>
 
 namespace rme {
-void* allocatePooledObject(std::size_t size);
-void deallocatePooledObject(void* ptr) noexcept;
-void bindPooledObjectOwnerThread() noexcept;
-void resetPooledObjectStats() noexcept;
-void dumpPooledObjectStats() noexcept;
+	void* allocatePooledObject(std::size_t size);
+	void deallocatePooledObject(void* ptr) noexcept;
+	void bindPooledObjectOwnerThread() noexcept;
+	void resetPooledObjectStats() noexcept;
+	void dumpPooledObjectStats() noexcept;
 }
 
 #endif

--- a/source/object_pool.h
+++ b/source/object_pool.h
@@ -23,6 +23,7 @@
 namespace rme {
 void* allocatePooledObject(std::size_t size);
 void deallocatePooledObject(void* ptr) noexcept;
+void bindPooledObjectOwnerThread() noexcept;
 }
 
 #endif

--- a/source/object_pool.h
+++ b/source/object_pool.h
@@ -24,6 +24,8 @@ namespace rme {
 void* allocatePooledObject(std::size_t size);
 void deallocatePooledObject(void* ptr) noexcept;
 void bindPooledObjectOwnerThread() noexcept;
+void resetPooledObjectStats() noexcept;
+void dumpPooledObjectStats() noexcept;
 }
 
 #endif

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -41,10 +41,6 @@ void Tile::operator delete(void* ptr) noexcept {
 	rme::deallocatePooledObject(ptr);
 }
 
-void Tile::operator delete(void* ptr, size_t) noexcept {
-	rme::deallocatePooledObject(ptr);
-}
-
 #ifdef DEBUG_MEM
 void* Tile::operator new(size_t size, const char*, int) {
 	return rme::allocatePooledObject(size);

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -291,7 +291,15 @@ void Tile::addItem(Item* item) {
 	if (!item) {
 		return;
 	}
-	if (item->isGroundTile()) {
+
+	addItem(item, item->getItemType());
+}
+
+void Tile::addItem(Item* item, const ItemType &type) {
+	if (!item) {
+		return;
+	}
+	if (type.isGroundTile()) {
 		// printf("ADDING GROUND\n");
 		delete ground;
 		ground = item;
@@ -305,24 +313,27 @@ void Tile::addItem(Item* item) {
 
 	ItemVector::iterator it;
 
-	uint16_t gid = item->getGroundEquivalent();
+	uint16_t gid = type.ground_equivalent;
 	if (gid != 0) {
 		delete ground;
 		ground = Item::Create(gid);
 		// At the very bottom!
 		it = items.begin();
 	} else {
-		if (item->isAlwaysOnBottom()) {
+		if (type.alwaysOnBottom) {
+			const int topOrder = type.alwaysOnTopOrder;
 			it = items.begin();
 			while (true) {
 				if (it == items.end()) {
 					break;
-				} else if ((*it)->isAlwaysOnBottom()) {
-					if (item->getTopOrder() < (*it)->getTopOrder()) {
+				} else {
+					const ItemType &existingType = (*it)->getItemType();
+					if (!existingType.alwaysOnBottom) {
 						break;
 					}
-				} else { // Always on top
-					break;
+					if (topOrder < existingType.alwaysOnTopOrder) {
+						break;
+					}
 				}
 				++it;
 			}

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -31,6 +31,29 @@
 #include "graphics.h"
 #include "npc.h"
 #include "spawn_npc.h"
+#include "object_pool.h"
+
+void* Tile::operator new(size_t size) {
+	return rme::allocatePooledObject(size);
+}
+
+void Tile::operator delete(void* ptr) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+
+void Tile::operator delete(void* ptr, size_t) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+
+#ifdef DEBUG_MEM
+void* Tile::operator new(size_t size, const char*, int) {
+	return rme::allocatePooledObject(size);
+}
+
+void Tile::operator delete(void* ptr, const char*, int) noexcept {
+	rme::deallocatePooledObject(ptr);
+}
+#endif
 
 Tile::Tile(int x, int y, int z) :
 	location(nullptr),

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -314,6 +314,18 @@ void Tile::addItem(Item* item) {
 	addItem(item, item->getItemType());
 }
 
+namespace {
+	ItemVector::iterator findBottomInsertPosition(ItemVector &items, int topOrder) {
+		for (auto it = items.begin(); it != items.end(); ++it) {
+			const ItemType &existingType = (*it)->getItemType();
+			if (!existingType.alwaysOnBottom || topOrder < existingType.alwaysOnTopOrder) {
+				return it;
+			}
+		}
+		return items.end();
+	}
+}
+
 void Tile::addItem(Item* item, const ItemType &type) {
 	if (!item) {
 		return;
@@ -340,22 +352,7 @@ void Tile::addItem(Item* item, const ItemType &type) {
 		it = items.begin();
 	} else {
 		if (type.alwaysOnBottom) {
-			const int topOrder = type.alwaysOnTopOrder;
-			it = items.begin();
-			while (true) {
-				if (it == items.end()) {
-					break;
-				} else {
-					const ItemType &existingType = (*it)->getItemType();
-					if (!existingType.alwaysOnBottom) {
-						break;
-					}
-					if (topOrder < existingType.alwaysOnTopOrder) {
-						break;
-					}
-				}
-				++it;
-			}
+			it = findBottomInsertPosition(items, type.alwaysOnTopOrder);
 		} else {
 			items.emplace_back(item);
 
@@ -619,10 +616,8 @@ void Tile::updateStateForItem(const Item* item, const ItemType &type) {
 }
 
 void Tile::finalizeLoadedState() {
-	if ((statflags & TILESTATE_BLOCKING) == 0) {
-		if (!ground && items.empty()) {
-			statflags |= TILESTATE_BLOCKING;
-		}
+	if ((statflags & TILESTATE_BLOCKING) == 0 && !ground && items.empty()) {
+		statflags |= TILESTATE_BLOCKING;
 	}
 }
 

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -297,6 +297,11 @@ void Tile::addItem(Item* item) {
 		return;
 	}
 
+	if (items.empty()) {
+		constexpr size_t initialTileItemCapacity = 4;
+		items.reserve(initialTileItemCapacity);
+	}
+
 	ItemVector::iterator it;
 
 	uint16_t gid = item->getGroundEquivalent();
@@ -321,7 +326,12 @@ void Tile::addItem(Item* item) {
 				++it;
 			}
 		} else {
-			it = items.end();
+			items.emplace_back(item);
+
+			if (item->isSelected()) {
+				statflags |= TILESTATE_SELECTED;
+			}
+			return;
 		}
 	}
 

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -354,6 +354,25 @@ void Tile::addItem(Item* item, const ItemType &type) {
 	}
 }
 
+void Tile::addLoadedItem(Item* item, const ItemType &type) {
+	if (!item) {
+		return;
+	}
+
+	const bool createsGroundEquivalent = !type.isGroundTile() && type.ground_equivalent != 0;
+	addItem(item, type);
+
+	if (type.isGroundTile()) {
+		updateStateForItem(item, type);
+		return;
+	}
+
+	if (createsGroundEquivalent && ground) {
+		updateStateForItem(ground, ground->getItemType());
+	}
+	updateStateForItem(item, type);
+}
+
 bool Tile::removeItem(const Item* item) {
 	for (auto it = items.begin(); it != items.end(); ++it) {
 		if (*it == item) {
@@ -551,6 +570,41 @@ uint8_t Tile::getMiniMapColor() const {
 	}
 
 	return 0;
+}
+
+void Tile::updateStateForItem(const Item* item, const ItemType &type) {
+	if (item->isSelected()) {
+		statflags |= TILESTATE_SELECTED;
+	}
+	if (item->getUniqueID() != 0) {
+		statflags |= TILESTATE_UNIQUE;
+	}
+	if (type.sprite) {
+		const uint8_t color = type.sprite->getMiniMapColor();
+		if (color != 0) {
+			minimapColor = color;
+		}
+	}
+	if (type.unpassable) {
+		statflags |= TILESTATE_BLOCKING;
+	}
+	if (type.isOptionalBorder) {
+		statflags |= TILESTATE_OP_BORDER;
+	}
+	if (type.isTable) {
+		statflags |= TILESTATE_HAS_TABLE;
+	}
+	if (type.isCarpet) {
+		statflags |= TILESTATE_HAS_CARPET;
+	}
+}
+
+void Tile::finalizeLoadedState() {
+	if ((statflags & TILESTATE_BLOCKING) == 0) {
+		if (!ground && items.empty()) {
+			statflags |= TILESTATE_BLOCKING;
+		}
+	}
 }
 
 void Tile::update() {

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -315,7 +315,7 @@ void Tile::addItem(Item* item) {
 }
 
 namespace {
-	ItemVector::iterator findBottomInsertPosition(ItemVector &items, int topOrder) {
+	FORCEINLINE ItemVector::iterator findBottomInsertPosition(ItemVector &items, int topOrder) {
 		for (auto it = items.begin(); it != items.end(); ++it) {
 			const ItemType &existingType = (*it)->getItemType();
 			if (!existingType.alwaysOnBottom || topOrder < existingType.alwaysOnTopOrder) {

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -28,6 +28,7 @@
 #include "wall_brush.h"
 #include "carpet_brush.h"
 #include "table_brush.h"
+#include "graphics.h"
 #include "npc.h"
 #include "spawn_npc.h"
 
@@ -563,32 +564,39 @@ void Tile::update() {
 	}
 
 	if (ground) {
+		const ItemType &groundType = ground->getItemType();
 		if (ground->isSelected()) {
 			statflags |= TILESTATE_SELECTED;
 		}
-		if (ground->isBlocking()) {
+		if (groundType.unpassable) {
 			statflags |= TILESTATE_BLOCKING;
 		}
 		if (ground->getUniqueID() != 0) {
 			statflags |= TILESTATE_UNIQUE;
 		}
-		if (ground->getMiniMapColor() != 0) {
-			minimapColor = ground->getMiniMapColor();
+		if (groundType.sprite) {
+			const uint8_t color = groundType.sprite->getMiniMapColor();
+			if (color != 0) {
+				minimapColor = color;
+			}
 		}
 	}
 
 	for (const Item* item : items) {
+		const ItemType &type = item->getItemType();
+
 		if (item->isSelected()) {
 			statflags |= TILESTATE_SELECTED;
 		}
 		if (item->getUniqueID() != 0) {
 			statflags |= TILESTATE_UNIQUE;
 		}
-		if (item->getMiniMapColor() != 0) {
-			minimapColor = item->getMiniMapColor();
+		if (type.sprite) {
+			const uint8_t color = type.sprite->getMiniMapColor();
+			if (color != 0) {
+				minimapColor = color;
+			}
 		}
-
-		const ItemType &type = g_items.getItemType(item->getID());
 
 		if (type.unpassable) {
 			statflags |= TILESTATE_BLOCKING;

--- a/source/tile.cpp
+++ b/source/tile.cpp
@@ -316,13 +316,10 @@ void Tile::addItem(Item* item) {
 
 namespace {
 	FORCEINLINE ItemVector::iterator findBottomInsertPosition(ItemVector &items, int topOrder) {
-		for (auto it = items.begin(); it != items.end(); ++it) {
-			const ItemType &existingType = (*it)->getItemType();
-			if (!existingType.alwaysOnBottom || topOrder < existingType.alwaysOnTopOrder) {
-				return it;
-			}
-		}
-		return items.end();
+		return std::find_if(items.begin(), items.end(), [topOrder](const Item* existingItem) {
+			const ItemType &existingType = existingItem->getItemType();
+			return !existingType.alwaysOnBottom || topOrder < existingType.alwaysOnTopOrder;
+		});
 	}
 }
 

--- a/source/tile.h
+++ b/source/tile.h
@@ -62,7 +62,6 @@ public: // Members
 public:
 	static void* operator new(size_t size);
 	static void operator delete(void* ptr) noexcept;
-	static void operator delete(void* ptr, size_t size) noexcept;
 #ifdef DEBUG_MEM
 	static void* operator new(size_t size, const char* file, int line);
 	static void operator delete(void* ptr, const char* file, int line) noexcept;

--- a/source/tile.h
+++ b/source/tile.h
@@ -60,6 +60,14 @@ public: // Members
 	std::set<unsigned int> zones;
 
 public:
+	static void* operator new(size_t size);
+	static void operator delete(void* ptr) noexcept;
+	static void operator delete(void* ptr, size_t size) noexcept;
+#ifdef DEBUG_MEM
+	static void* operator new(size_t size, const char* file, int line);
+	static void operator delete(void* ptr, const char* file, int line) noexcept;
+#endif
+
 	// ALWAYS use this constructor if the Tile is EVER going to be placed on a map
 	Tile(TileLocation &location);
 	// Use this when the tile is only used internally by the editor (like in certain brushes)

--- a/source/tile.h
+++ b/source/tile.h
@@ -117,7 +117,9 @@ public: // Functions
 	uint32_t memsize() const;
 	// Get number of items on the tile
 	bool empty() const {
-		return size() == 0;
+		return !ground && items.empty() && monsters.empty() && !spawnMonster && !npc && !spawnNpc && (!location || (
+			!location->getHouseExits() && !location->getSpawnMonsterCount() && !location->getSpawnNpcCount() && !location->getWaypointCount()
+		));
 	}
 	int size() const;
 

--- a/source/tile.h
+++ b/source/tile.h
@@ -159,6 +159,7 @@ public: // Functions
 	Item* getItemAt(int index) const;
 	void addItem(Item* item);
 	void addItem(Item* item, const ItemType &type);
+	void addLoadedItem(Item* item, const ItemType &type);
 	bool removeItem(const Item* item);
 	void clearGround();
 	void replaceGround(Item* newGround);
@@ -191,6 +192,7 @@ public: // Functions
 
 	// Refresh internal flags (such as selected etc.)
 	void update();
+	void finalizeLoadedState();
 
 	uint8_t getMiniMapColor() const;
 
@@ -310,6 +312,8 @@ protected:
 
 private:
 	uint8_t minimapColor;
+
+	void updateStateForItem(const Item* item, const ItemType &type);
 
 	Tile(const Tile &tile); // No copy
 	Tile &operator=(const Tile &i); // Can't copy

--- a/source/tile.h
+++ b/source/tile.h
@@ -125,9 +125,7 @@ public: // Functions
 	uint32_t memsize() const;
 	// Get number of items on the tile
 	bool empty() const {
-		return !ground && items.empty() && monsters.empty() && !spawnMonster && !npc && !spawnNpc && (!location || (
-			!location->getHouseExits() && !location->getSpawnMonsterCount() && !location->getSpawnNpcCount() && !location->getWaypointCount()
-		));
+		return !ground && items.empty() && monsters.empty() && !spawnMonster && !npc && !spawnNpc && (!location || (!location->getHouseExits() && !location->getSpawnMonsterCount() && !location->getSpawnNpcCount() && !location->getWaypointCount()));
 	}
 	int size() const;
 

--- a/source/tile.h
+++ b/source/tile.h
@@ -158,6 +158,7 @@ public: // Functions
 	Item* getTopItem() const; // Returns the topmost item, or nullptr if the tile is empty
 	Item* getItemAt(int index) const;
 	void addItem(Item* item);
+	void addItem(Item* item, const ItemType &type);
 	bool removeItem(const Item* item);
 	void clearGround();
 	void replaceGround(Item* newGround);

--- a/vcproj/Project/RME.vcxproj
+++ b/vcproj/Project/RME.vcxproj
@@ -364,6 +364,8 @@
     <ClInclude Include="..\..\source\map_allocator.h" />
     <ClInclude Include="..\..\source\map_region.h" />
     <ClCompile Include="..\..\source\map_region.cpp" />
+    <ClInclude Include="..\..\source\object_pool.h" />
+    <ClCompile Include="..\..\source\object_pool.cpp" />
     <ClInclude Include="..\..\source\mt_rand.h" />
     <ClCompile Include="..\..\source\mt_rand.cpp" />
     <ClInclude Include="..\..\source\net_connection.h" />


### PR DESCRIPTION
This pull request focuses on OTBM load/save profiling and performance improvements for Remere's Map Editor. It follows the same approach used in the Canary startup work: profile first, reduce the visible hot paths, then preserve behavior while avoiding extra work in map parsing, tile lookup, binary serialization, and high-volume object allocation.

## Measured Impact

The captures are Visual Studio sampling profiles, so percentages represent share of sampled CPU in each run, not direct wall-clock speedup. Some captures include both loading and saving in the same session, so the table separates measured profile share from allocator diagnostics. The allocator diagnostics are exact counters emitted by the new pool instrumentation.

### Object Pool Tuning

The highest-confidence improvement is the pooled object allocator path. In the measured large-map load, every tracked object allocation stayed inside the pool and heap fallback stayed at zero.

```text
Object pool slab refills, lower is better
Before slab tuning   17,830 | ██████████████████████████████
After slab tuning     2,230 | ████                          -87.5%

rme::allocatePooledObject sampled CPU share, lower is better
Before tuning        20.01% | ████████████████████
Latest capture       14.62% | ███████████████             -26.9%
```

| Area | Before | After | Result |
| --- | ---: | ---: | --- |
| Total pooled allocation calls | 42,559,971 | 42,559,971 | Same workload measured |
| Heap fallback allocations | 0 | 0 | Hot load path stays pooled |
| Slab refill events | 17,830 | 2,230 | ~87.5% fewer slab growth events |
| 48-byte class refills | 4,276 | 535 | ~87.5% fewer refills |
| 64-byte class refills | 5 | 1 | 80.0% fewer refills |
| 128-byte class refills | 8,776 | 1,097 | ~87.5% fewer refills |
| 1024-byte class refills | 4,773 | 597 | ~87.5% fewer refills |
| `rme::allocatePooledObject` sampled CPU | 20.01% | 14.62% latest mixed capture | ~26.9% lower sampled share |

### Latest Mixed Load/Save Profile

The latest local profile still shows map load as the dominant cost, with save traversal and allocation now visible enough to guide the next round of work.

| Area | Latest sampled CPU share | Notes |
| --- | ---: | --- |
| `GUI::LoadMap` | 67.02% | Full load action in the mixed capture |
| `IOMapOTBM::loadMap` | 60.23% total, 56.34% inner load body | Main remaining load hotspot |
| `GUI::SaveMap` / `Editor::saveMap` | 28.16% | Save action in the same capture |
| `IOMapOTBM::saveMap` | 27.63% | Main save hotspot |
| `BaseMap::forEachTileLocation` during save | 23.01% | Save traversal is now visible after load improvements |
| `Tile::Tile` | 11.53% | Tile construction remains a load cost |
| `Tile::addLoadedItem` | 8.15% | Item insertion/update path remains relevant |
| `Item::Create` | 6.99% | Item factory cost remains relevant |
| `QTreeNode::createFloor` | 6.71% | Floor creation remains relevant |
| `BinaryNode::advance` / `BinaryNode::load` | 5.37% / 3.81% | Binary parsing remains relevant |

### Map View Idle/Preview Rendering

A separate stationary map-view profile was captured in a dense city area at normal zoom. The original idle path was not truly idle: `AnimationTimer` refreshed every 16 ms, and `MapCanvas::Refresh()` always marked the cached scene dirty. That meant a static viewport still forced `MapDrawer::DrawMap`, `DrawTile`, `GLRenderer::flushCommands`, and AMD OpenGL driver work even when the user was not moving the mouse, scrolling, or editing.

```text
Stationary map-view sampled CPU, lower is better
Before idle render fix          139,767 | full map redraws on the timer
After overlay-only refresh          126 | cached map scene reused
Preview active before throttle   12,223 | Show Preview still redrew the scene
```

| Area | Before | After | Result |
| --- | ---: | ---: | --- |
| Static view with performance stats/overlays | 139,767 sampled CPU units | 126 sampled CPU units | Overlay refresh no longer invalidates the cached map scene |
| `MapCanvas::OnPaint` in the static capture | 46,229 sampled units / 32.20% | 19 sampled units / 15.08% | Paint still happens, but no longer drives full scene redraw |
| `MapDrawer::DrawMap` / `DrawTile` in the static capture | 15,888 / 15,336 sampled units | Not a visible hotspot | Static map FBO is reused |
| `GLRenderer::flushCommands` in the static capture | 24,321 sampled units / 16.94% | 4 sampled units / 3.17% | Far fewer OpenGL command flushes while idle |
| Performance stats timer | 16 ms scene-dirty timer | 500 ms overlay-only timer | Stats can update without redrawing the map scene |
| Show Preview animation timer | 16 ms scene-dirty timer | 250 ms scene-dirty timer | Preview animation remains visible without forcing around 60 full map redraws per second |
| Tooltip rendering at low zoom | Fixed screen-size labels covered zoomed-out views | Tooltip overlay scales with zoom, clamped to 55% minimum | Zoomed-out labels stay readable without covering the viewport |

The follow-up profile with Show Preview enabled still showed `Item::animate`, `DrawMap`, and `DrawTile`, confirming that preview animation is a legitimate scene-dirty case. The fix therefore throttles preview redraws instead of treating them as overlay-only. The short-lived position indicator keeps the 16 ms timer because it is expected to animate smoothly while active.

## What Changed

- Added fast cached floor/tile lookup while loading OTBM map data and spawn files, reducing repeated tree traversal and duplicate lookup work.
- Added direct `TileLocation` assignment through `BaseMap::setTile(TileLocation*, Tile*, bool)` for parser paths that already resolved the destination location.
- Added `BaseMap::forEachTileLocation` to traverse existing tile locations directly during save without rebuilding lookup state.
- Added a small-object slab allocator for hot `Item`, `Tile`, and `Floor` allocations while preserving raw `new`/`delete` semantics used throughout the editor.
- Added explicit pool owner-thread binding and diagnostics to confirm the load path remains pooled and does not fall back to the heap.
- Increased slab sizing after diagnostics showed refill pressure, reducing slab refills from 17,830 to 2,230 on the measured large-map load.
- Improved binary node writing by batching raw bytes and avoiding redundant cache renewal checks while preserving escape handling for OTBM marker bytes.
- Avoided rewriting XML sidecar files when serialized content is unchanged except for line endings, reducing noisy saves in `monster`, `npc`, and `house` XML files.
- Fixed invalid ground serialization so placeholder ground id `0` no longer drops the rest of the tile contents during save.
- Split map canvas refresh into scene-dirty and overlay-only paths so performance stats and overlays can repaint without invalidating the cached map FBO.
- Changed map animation timer modes: the position indicator keeps a 16 ms scene-dirty timer, Show Preview uses a 250 ms scene-dirty timer, and performance stats use a 500 ms overlay-only timer.
- Scaled tooltip rendering with map zoom, clamped to 55% minimum, so zoomed-out views do not get covered by fixed-size labels.
- Kept review/Sonar cleanups away from hotpath regressions by using targeted `NOSONAR` annotations or `FORCEINLINE` where a static-analysis-friendly refactor would otherwise add cost.
- Added `AGENTS.md` guidance so future work keeps the same Git/build/PCH discipline used in the Canary repository.

## Notes

- The latest profile was a mixed interaction profile, not a strict load-only or save-only benchmark. The numbers are useful for hotspot direction, but the allocator counters are the strongest before/after measurement in this PR.
- The stationary map-view profiles are also sampling profiles. They are useful for confirming that idle repaint no longer forces full map rendering, while Show Preview remains intentionally scene-dirty but throttled.
- The remaining high-return areas are likely tile construction, loaded item insertion/state updates, floor creation, and binary parsing. Further Sonar or review fixes should avoid adding calls, extra allocations, or stronger atomics to these paths just to satisfy static analysis.
- No OTBM format or map semantics are intended to change; the performance work focuses on avoiding repeated work and reducing allocation/cache overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added contributor/agent guidance document.

* **Performance Improvements**
  - Introduced a pooled-object allocator to reduce allocation overhead.
  - Faster, more memory-efficient map load/save and tile allocation.
  - Throttled rendering refresh and refined animation scheduling for smoother UI.

* **Refactor**
  - Item/tile creation and loading now use type-driven paths and pooled allocation.
  - File I/O and serialization paths streamlined for robustness.

* **Bug Fixes**
  - Tooltip rendering correctly accounts for zoom.

* **Chores**
  - Documentation expanded with contributor guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentibiabr/remeres-map-editor/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->