### PR TITLE
fix: dont crash on cutting with ghost paste

### DIFF
--- a/source/copybuffer.cpp
+++ b/source/copybuffer.cpp
@@ -47,6 +47,13 @@ Position CopyBuffer::getPosition() const {
 }
 
 void CopyBuffer::clear() {
+	if (!tiles) {
+		return;
+	}
+
+	if (g_gui.secondary_map == tiles) {
+		g_gui.secondary_map = nullptr;
+	}
 	delete tiles;
 	tiles = nullptr;
 }


### PR DESCRIPTION
Fixes https://github.com/opentibiabr/remeres-map-editor/issues/123 

This pr fixes crash at the tradeoff of introducing new visual (mostly harmless) bug: When cutting with ghost paste (explained below) hovering on cursor, the ghost paste actually stays, but is invisible. Left clicking will paste that invisible content.
Steps to reproduce this visual bug are same as for crash:
> Make an area selection that has some items (preferably about one in-game screen or bigger)
> Cut with ctrl + x.
> Undo cutting with ctrl + z.
> Paste clipboard with ctrl + v (this will cancel the selection). <-- this is the 'ghost paste' i'm referring to
> Undo selection cancel with ctrl + z.
> Cut with ctrl + x. <-- you still have 'ghost paste' on cursor, but its invisible now