### PR TITLE
fix: prevent grid truncation on ultrawide displays

### DIFF
--- a/source/gl_renderer.cpp
+++ b/source/gl_renderer.cpp
@@ -823,13 +823,23 @@ void GLRenderer::flushCommands() {
 
 		while (i < verts.size()) {
 			size_t remaining = verts.size() - i;
-			size_t batchFree = STREAM_VBO_CAPACITY - batch.size();
-			// Number of vertices that still fit (rounded to a multiple of vertStep)
-			size_t canTake = (batchFree / vertStep) * vertStep;
+			size_t batchFreeVerts = STREAM_VBO_CAPACITY - batch.size();
+			size_t batchFreeIdx = STREAM_EBO_CAPACITY - indexBatch.size();
+			size_t canTakeStepsVerts = batchFreeVerts / vertStep;
+			size_t canTakeStepsIdx = batchFreeIdx / idxPerStep;
+			size_t canTake = std::min(canTakeStepsVerts, canTakeStepsIdx) * vertStep;
 
 			if (canTake == 0) {
 				flushBatch();
-				canTake = (STREAM_VBO_CAPACITY / vertStep) * vertStep;
+				batchFreeVerts = STREAM_VBO_CAPACITY - batch.size();
+				batchFreeIdx = STREAM_EBO_CAPACITY - indexBatch.size();
+				canTakeStepsVerts = batchFreeVerts / vertStep;
+				canTakeStepsIdx = batchFreeIdx / idxPerStep;
+				canTake = std::min(canTakeStepsVerts, canTakeStepsIdx) * vertStep;
+			}
+
+			if (canTake == 0) {
+				break;
 			}
 
 			size_t take = std::min(remaining, canTake);


### PR DESCRIPTION
## Summary

Fix intermittent grid truncation on ultrawide monitors when the viewport is idle. The renderer could exceed the index (EBO) capacity while slicing large frames, causing batches (including the grid) to be dropped. The flush logic now accounts for both vertex and index capacity when chunking commands, preventing partial overlays.

## Files changed
- source/gl_renderer.cpp

## HOW TO TEST
1. On an ultrawide monitor, enable `View -> Grid`.
2. Keep the viewport idle (no pan/zoom) and confirm the grid covers the full viewport.
3. Hover around to trigger overlays and confirm the grid remains complete.
4. Pan/zoom and stop again; confirm the grid does not truncate.