### PR TITLE
fix: make macOS build with modern sol2 and wxGL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
               - ".reviewdog.yml"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-build-linux.yml"
+              - ".github/workflows/reusable-build-macos.yml"
               - ".github/workflows/reusable-build-windows.yml"
               - ".github/workflows/reusable-checks.yml"
               - ".github/workflows/autofix-ci.yml"
@@ -124,6 +125,16 @@ jobs:
       contents: read
       packages: read
     uses: ./.github/workflows/reusable-build-linux.yml
+    secrets: inherit
+
+  build-macos:
+    name: Build - macOS
+    needs: [changes, checks]
+    if: needs.changes.outputs.compile == 'true' && needs.checks.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/reusable-build-macos.yml
     secrets: inherit
 
   build-windows:

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -55,7 +55,7 @@ jobs:
           ccache --version
 
       - name: CCache
-        uses: hendrikmuhs/ccache-action@v1.2.23
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
         with:
           max-size: "1G"
           key: ccache-macos-${{ matrix.buildtype }}
@@ -63,7 +63,7 @@ jobs:
             ccache-macos
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2  # v11
         with:
           vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
           vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
@@ -91,7 +91,7 @@ jobs:
             -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
 
       - name: Run CMake
-        uses: lukka/run-cmake@v10
+        uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956  # v10
         with:
           configurePreset: ${{ matrix.buildtype }}
           buildPreset: ${{ matrix.buildtype }}

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -48,6 +48,7 @@ jobs:
             ccache \
             libtool \
             mono \
+            nuget \
             ninja \
             pkg-config
           ninja --version

--- a/.github/workflows/reusable-build-macos.yml
+++ b/.github/workflows/reusable-build-macos.yml
@@ -1,0 +1,122 @@
+name: Reusable macOS Build
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    name: Compile (${{ matrix.buildtype }})
+    strategy:
+      fail-fast: false
+      matrix:
+        buildtype: [macos-release]
+    runs-on: macos-15
+    env:
+      VCPKG_BINARY_CACHE_ACCESS: ${{ secrets.VCPKG_PACKAGES_TOKEN != '' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && 'readwrite' || 'read' }}
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,${{ secrets.VCPKG_PACKAGES_TOKEN != '' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && 'readwrite' || 'read' }};nugettimeout,600"
+      VCPKG_NUGET_API_KEY: ${{ secrets.VCPKG_PACKAGES_TOKEN != '' && ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && secrets.VCPKG_PACKAGES_TOKEN || github.token }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v9
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Get vcpkg baseline
+        shell: bash
+        run: |
+          set -euo pipefail
+          vcpkg_commit_id="$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ')"
+          echo "VCPKG_GIT_COMMIT_ID=${vcpkg_commit_id}" >> "${GITHUB_ENV}"
+
+      - name: Install macOS dependencies
+        run: |
+          brew update
+          brew install \
+            autoconf \
+            autoconf-archive \
+            automake \
+            ccache \
+            libtool \
+            mono \
+            ninja \
+            pkg-config
+          ninja --version
+          ccache --version
+
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          max-size: "1G"
+          key: ccache-macos-${{ matrix.buildtype }}
+          restore-keys: |
+            ccache-macos
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
+
+      - name: Setup NuGet for vcpkg
+        env:
+          NUGET_AUTH_TOKEN: ${{ env.VCPKG_NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+          unset VCPKG_FORCE_SYSTEM_BINARIES
+          nuget_path="$(vcpkg fetch nuget 2>&1 | grep -E '^/' | tail -n 1)"
+          if [[ -z "${nuget_path}" || ! -f "${nuget_path}" ]]; then
+            echo "Failed to locate NuGet fetched by vcpkg."
+            vcpkg fetch nuget 2>&1 || true
+            exit 1
+          fi
+          mono "${nuget_path}" sources remove -name "GitHubPackages" >/dev/null 2>&1 || true
+          mono "${nuget_path}" sources add \
+            -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            -storepasswordincleartext \
+            -name "GitHubPackages" \
+            -username "${{ github.repository_owner }}" \
+            -password "${NUGET_AUTH_TOKEN}"
+          mono "${nuget_path}" setapikey "${NUGET_AUTH_TOKEN}" \
+            -source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+      - name: Run CMake
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: ${{ matrix.buildtype }}
+          buildPreset: ${{ matrix.buildtype }}
+          configurePresetAdditionalArgs: "['-DTOGGLE_BIN_FOLDER=ON', '-DOPTIONS_ENABLE_IPO=OFF']"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-${{ matrix.buildtype }}
+          path: build/${{ matrix.buildtype }}/bin/
+
+      - name: Verify vcpkg binary cache push
+        if: success() && env.VCPKG_BINARY_CACHE_ACCESS == 'readwrite'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -d '' logs < <(find . -name "vcpkg-manifest-install.log" -print0)
+          if [[ ${#logs[@]} -eq 0 ]]; then
+            echo "No vcpkg manifest logs found." >&2
+            exit 1
+          fi
+          if grep -Eq "to [1-9][0-9]* binary cache\(s\)" -- "${logs[@]}"; then
+            exit 0
+          fi
+          if grep -q "to 0 binary cache(s)" -- "${logs[@]}"; then
+            echo "Binary cache push reported 0 caches and no successful push was found." >&2
+            exit 1
+          fi
+          echo "No binary cache push summary found; assuming no package was built for upload."

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -25,6 +25,23 @@ find_package(
              base
              CONFIG
   REQUIRED)
+# wxWidgets/vcpkg may bake in XQuartz libGL; that breaks Cocoa textures (black tiles).
+if(APPLE)
+  find_library(RME_OPENGL_FRAMEWORK OpenGL REQUIRED)
+  if(TARGET OpenGL::GL)
+    set_property(TARGET OpenGL::GL PROPERTY IMPORTED_LOCATION
+                 "${RME_OPENGL_FRAMEWORK}")
+  endif()
+  if(TARGET wx::wxgl)
+    get_target_property(_rme_gl_libs wx::wxgl INTERFACE_LINK_LIBRARIES)
+    if(_rme_gl_libs)
+      list(FILTER _rme_gl_libs EXCLUDE REGEX "X11.*/libGL")
+      set_property(TARGET wx::wxgl PROPERTY INTERFACE_LINK_LIBRARIES
+                   "${_rme_gl_libs}")
+    endif()
+  endif()
+  set(OPENGL_LIBRARIES "${RME_OPENGL_FRAMEWORK}")
+endif()
 if(DEFINED VCPKG_TARGET_TRIPLET)
   unset(ZLIB_LIBRARY CACHE)
   unset(ZLIB_LIBRARY_DEBUG CACHE)

--- a/source/application.cpp
+++ b/source/application.cpp
@@ -565,8 +565,7 @@ void MainFrame::ShowMissingMonsters() {
 
 	if (!missingMonsters.IsEmpty()) {
 		wxString missingMonstersStr = "Missing Monsters:\n" + wxJoin(missingMonsters, '\n');
-		wxMessageDialog dialog(this, missingMonstersStr, "Missing Monsters", wxOK | wxICON_INFORMATION);
-		dialog.ShowModal();
+		g_gui.ShowTextBox(this, "Missing Monsters", missingMonstersStr);
 	}
 }
 
@@ -575,8 +574,7 @@ void MainFrame::ShowMissingNpcs() {
 
 	if (!missingNpcs.IsEmpty()) {
 		wxString missingNpcsStr = "Missing NPCs:\n" + wxJoin(missingNpcs, '\n');
-		wxMessageDialog dialog(this, missingNpcsStr, "Missing NPCs", wxOK | wxICON_INFORMATION);
-		dialog.ShowModal();
+		g_gui.ShowTextBox(this, "Missing NPCs", missingNpcsStr);
 	}
 }
 

--- a/source/client_assets.cpp
+++ b/source/client_assets.cpp
@@ -62,32 +62,36 @@ bool ClientAssets::loadAppearanceProtobuf(wxString &error, wxArrayString &warnin
 	using namespace canary::protobuf::appearances;
 	using json = nlohmann::json;
 
-	auto clientDirectory = ClientAssets::getPath().ToStdString() + "/";
-	if (!wxDirExists(wxString(clientDirectory))) {
-		logErrorAndSetMessage(fmt::format("Client directory is not a valid path: {}", clientDirectory), error);
-		return false;
+	const std::filesystem::path selectedDirectory(ClientAssets::getPath().ToStdString());
+	if (!std::filesystem::is_directory(selectedDirectory)) {
+		return logErrorAndSetMessage(fmt::format("Client directory is not a valid path: {}", selectedDirectory.string()), error);
 	}
 
-	auto assetsDirectory = clientDirectory + "/assets/";
-	if (!wxDirExists(wxString(assetsDirectory))) {
-		logErrorAndSetMessage(fmt::format("Assets directory not found in path: {}", assetsDirectory), error);
-		return false;
+	std::filesystem::path packagePath = selectedDirectory / "package.json";
+	if (!std::filesystem::exists(packagePath)) {
+		packagePath = selectedDirectory.parent_path().parent_path() / "package.json";
 	}
 
-	if (!g_spriteAppearances.loadCatalogContent(assetsDirectory, false)) {
-		logErrorAndSetMessage(fmt::format("Failed to load catalog content from directory: {}", assetsDirectory), error);
-		return false;
+	std::filesystem::path assetsDirectory = selectedDirectory / "assets";
+	if (!std::filesystem::is_directory(assetsDirectory)) {
+		assetsDirectory = selectedDirectory / "Contents" / "Resources" / "assets";
+	}
+	if (!std::filesystem::is_directory(assetsDirectory)) {
+		return logErrorAndSetMessage(fmt::format("Assets directory not found for client path: {}", selectedDirectory.string()), error);
 	}
 
-	using json = nlohmann::json;
-	std::filesystem::path packagesPath = std::filesystem::path(clientDirectory) / std::filesystem::path("package.json");
-	if (!std::filesystem::exists(packagesPath)) {
+	const std::string assetsPath = assetsDirectory.string() + "/";
+	if (!g_spriteAppearances.loadCatalogContent(assetsPath, false)) {
+		return logErrorAndSetMessage(fmt::format("Failed to load catalog content from directory: {}", assetsPath), error);
+	}
+
+	if (!std::filesystem::exists(packagePath)) {
 		error = "The file package.json is not present in the client directory.";
-		spdlog::error("The file package.json is not present in the client directory. {}", packagesPath.string().c_str());
+		spdlog::error("The file package.json is not present for client path. {}", selectedDirectory.string());
 		return false;
 	}
 
-	std::ifstream file(packagesPath, std::ios::in);
+	std::ifstream file(packagePath, std::ios::in);
 	if (!file.is_open()) {
 		error = "Failed to open packages.json";
 		spdlog::error("Failed to open packages.json");
@@ -102,7 +106,7 @@ bool ClientAssets::loadAppearanceProtobuf(wxString &error, wxArrayString &warnin
 
 	const std::string appearanceFileName = g_spriteAppearances.getAppearanceFileName();
 
-	std::fstream fileStream(assetsDirectory + appearanceFileName, std::ios::in | std::ios::binary);
+	std::fstream fileStream(assetsDirectory / appearanceFileName, std::ios::in | std::ios::binary);
 	if (!fileStream.is_open()) {
 		error = "Failed to load " + appearanceFileName + " from the client folder, file cannot be oppened";
 		spdlog::error("[{}] - Failed to load {}, file cannot be oppened", __func__, appearanceFileName);

--- a/source/client_assets.cpp
+++ b/source/client_assets.cpp
@@ -63,20 +63,25 @@ bool ClientAssets::loadAppearanceProtobuf(wxString &error, wxArrayString &warnin
 	using json = nlohmann::json;
 
 	const std::filesystem::path selectedDirectory(ClientAssets::getPath().ToStdString());
-	if (!std::filesystem::is_directory(selectedDirectory)) {
+	std::error_code filesystemError;
+	if (!std::filesystem::is_directory(selectedDirectory, filesystemError)) {
+		if (filesystemError && filesystemError != std::errc::no_such_file_or_directory) {
+			return logErrorAndSetMessage(fmt::format("Could not inspect client path {}: {}", selectedDirectory.string(), filesystemError.message()), error);
+		}
 		return logErrorAndSetMessage(fmt::format("Client directory is not a valid path: {}", selectedDirectory.string()), error);
 	}
 
-	std::filesystem::path packagePath = selectedDirectory / "package.json";
-	if (!std::filesystem::exists(packagePath)) {
-		packagePath = selectedDirectory.parent_path().parent_path() / "package.json";
-	}
-
 	std::filesystem::path assetsDirectory = selectedDirectory / "assets";
-	if (!std::filesystem::is_directory(assetsDirectory)) {
+	if (!std::filesystem::is_directory(assetsDirectory, filesystemError)) {
+		if (filesystemError && filesystemError != std::errc::no_such_file_or_directory) {
+			return logErrorAndSetMessage(fmt::format("Could not inspect assets path {}: {}", assetsDirectory.string(), filesystemError.message()), error);
+		}
 		assetsDirectory = selectedDirectory / "Contents" / "Resources" / "assets";
 	}
-	if (!std::filesystem::is_directory(assetsDirectory)) {
+	if (!std::filesystem::is_directory(assetsDirectory, filesystemError)) {
+		if (filesystemError && filesystemError != std::errc::no_such_file_or_directory) {
+			return logErrorAndSetMessage(fmt::format("Could not inspect assets path {}: {}", assetsDirectory.string(), filesystemError.message()), error);
+		}
 		return logErrorAndSetMessage(fmt::format("Assets directory not found for client path: {}", selectedDirectory.string()), error);
 	}
 
@@ -85,10 +90,23 @@ bool ClientAssets::loadAppearanceProtobuf(wxString &error, wxArrayString &warnin
 		return logErrorAndSetMessage(fmt::format("Failed to load catalog content from directory: {}", assetsPath), error);
 	}
 
-	if (!std::filesystem::exists(packagePath)) {
-		error = "The file package.json is not present in the client directory.";
-		spdlog::error("The file package.json is not present for client path. {}", selectedDirectory.string());
-		return false;
+	std::filesystem::path packagePath;
+	for (const auto &candidate : {
+			 selectedDirectory / "package.json",
+			 assetsDirectory.parent_path() / "package.json",
+			 assetsDirectory.parent_path() / "app" / "package.json",
+			 assetsDirectory.parent_path().parent_path().parent_path() / "package.json",
+		 }) {
+		if (std::filesystem::exists(candidate, filesystemError)) {
+			packagePath = candidate;
+			break;
+		}
+		if (filesystemError && filesystemError != std::errc::no_such_file_or_directory) {
+			return logErrorAndSetMessage(fmt::format("Could not inspect package path {}: {}", candidate.string(), filesystemError.message()), error);
+		}
+	}
+	if (packagePath.empty()) {
+		return logErrorAndSetMessage(fmt::format("The file package.json is not present for client path: {}", selectedDirectory.string()), error);
 	}
 
 	std::ifstream file(packagePath, std::ios::in);

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -49,10 +49,6 @@
 #include "live_tab.h"
 #include "live_server.h"
 
-#ifdef __WXOSX__
-	#include <AGL/agl.h>
-#endif
-
 #include <appearances.pb.h>
 
 namespace InternalGUI {
@@ -123,17 +119,7 @@ GUI::~GUI() {
 
 wxGLContext* GUI::GetGLContext(wxGLCanvas* win) {
 	if (OGLContext == nullptr) {
-#ifdef __WXOSX__
-		/*
-		wxGLContext(AGLPixelFormat fmt, wxGLCanvas *win,
-					const wxPalette& WXUNUSED(palette),
-					const wxGLContext *other
-					);
-		*/
-		OGLContext = new wxGLContext(win, nullptr);
-#else
 		OGLContext = newd wxGLContext(win);
-#endif
 	}
 
 	return OGLContext;

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -1449,7 +1449,7 @@ void GUI::StartAsyncSqliteBootstrapImport() {
 	SetStatusText("Building SQLite materials database in background...");
 	UpdateMenubar();
 
-	sqlite_bootstrap_thread_ = std::jthread(&GUI::RunAsyncSqliteBootstrapImport, this);
+	sqlite_bootstrap_thread_ = std::thread(&GUI::RunAsyncSqliteBootstrapImport, this);
 }
 
 void GUI::SetTitle(wxString title) {

--- a/source/gui.h
+++ b/source/gui.h
@@ -513,7 +513,7 @@ protected:
 
 	wxWindowDisabler* winDisabler;
 	int disabled_counter;
-	std::jthread sqlite_bootstrap_thread_;
+	std::thread sqlite_bootstrap_thread_;
 	std::atomic<bool> sqlite_bootstrap_running_ = false;
 
 	friend class RenderingLock;

--- a/source/iomap_otbm.cpp
+++ b/source/iomap_otbm.cpp
@@ -6213,7 +6213,7 @@ bool IOMapOTBM::saveStaticData(Map &map, const FileName &dir, const std::vector<
 
 	const auto registerExportError = [&](const std::string &errorMessage) {
 		lastStaticHouseExportReport.errors.push_back(errorMessage);
-		warning("%s", wxstr(errorMessage));
+		warning("%s", errorMessage.c_str());
 	};
 
 	struct StaticHouseExportFilterScopeGuard final {

--- a/source/lua/lua_api_app.cpp
+++ b/source/lua/lua_api_app.cpp
@@ -383,8 +383,8 @@ namespace LuaAPI {
 		sol::state_view lua(ts2);
 		std::string content;
 
-		sol::object data = (second.valid() && !second.is<sol::nil_t>()) ? second : first;
-		if (!data.valid() || data.is<sol::nil_t>()) {
+		sol::object data = (second.valid() && !second.is<sol::lua_nil_t>()) ? second : first;
+		if (!data.valid() || data.is<sol::lua_nil_t>()) {
 			return false;
 		}
 
@@ -443,7 +443,7 @@ namespace LuaAPI {
 			sol::state_view lua(ts2);
 			std::ifstream file(path);
 			if (!file.is_open()) {
-				return sol::make_object(lua, sol::nil);
+				return sol::make_object(lua, sol::lua_nil);
 			}
 
 			std::stringstream buffer;
@@ -452,24 +452,24 @@ namespace LuaAPI {
 
 			std::string content = buffer.str();
 			if (content.empty()) {
-				return sol::make_object(lua, sol::nil);
+				return sol::make_object(lua, sol::lua_nil);
 			}
 
 			sol::table json = lua["json"];
 			if (!json.valid() || !json["decode"].valid()) {
-				return sol::make_object(lua, sol::nil);
+				return sol::make_object(lua, sol::lua_nil);
 			}
 
 			try {
 				sol::function decode = json["decode"];
 				sol::protected_function_result result = decode(content);
 				if (!result.valid()) {
-					return sol::make_object(lua, sol::nil);
+					return sol::make_object(lua, sol::lua_nil);
 				}
 				sol::object decoded = result;
 				return sol::make_object(lua, decoded);
 			} catch (const sol::error &) {
-				return sol::make_object(lua, sol::nil);
+				return sol::make_object(lua, sol::lua_nil);
 			}
 		};
 
@@ -496,14 +496,14 @@ namespace LuaAPI {
 			if (map) {
 				return sol::make_object(lua, map);
 			}
-			return sol::nil;
+			return sol::lua_nil;
 		}
 		if (key == "selection") {
 			Selection* sel = getSelection();
 			if (sel) {
 				return sol::make_object(lua, sel);
 			}
-			return sol::nil;
+			return sol::lua_nil;
 		}
 		if (key == "borders") {
 			return getBorders(ts);
@@ -513,14 +513,14 @@ namespace LuaAPI {
 			if (editor) {
 				return sol::make_object(lua, editor);
 			}
-			return sol::nil;
+			return sol::lua_nil;
 		}
 		if (key == "brush") {
 			Brush* b = g_gui.GetCurrentBrush();
 			if (b) {
 				return sol::make_object(lua, b);
 			}
-			return sol::nil;
+			return sol::lua_nil;
 		}
 		if (key == "brushSize") {
 			return sol::make_object(lua, g_gui.GetBrushSize());
@@ -534,7 +534,7 @@ namespace LuaAPI {
 		if (key == "spawnTime") {
 			return sol::make_object(lua, 0);
 		}
-		return sol::nil;
+		return sol::lua_nil;
 	}
 
 	static void appPropertySetter(sol::this_state ts, sol::table self, std::string key, sol::object value) {

--- a/source/lua/lua_api_http.cpp
+++ b/source/lua/lua_api_http.cpp
@@ -37,6 +37,16 @@ namespace LuaAPI {
 		static constexpr size_t kMaxBufferedBytes = 4 * 1024 * 1024; // 4 MB
 
 		StreamSession() = default;
+		~StreamSession() {
+			if (!worker_.joinable()) {
+				return;
+			}
+			if (worker_.get_id() == std::this_thread::get_id()) {
+				worker_.detach();
+			} else {
+				worker_.join();
+			}
+		}
 
 		bool appendChunk(const std::string &chunk) {
 			std::scoped_lock lock(mutex_);
@@ -121,7 +131,7 @@ namespace LuaAPI {
 			cv_.notify_all();
 		}
 
-		void setWorker(std::jthread &&t) {
+		void setWorker(std::thread &&t) {
 			worker_ = std::move(t);
 		}
 
@@ -135,7 +145,7 @@ namespace LuaAPI {
 		std::string errorMessage_;
 		std::atomic<int> statusCode_ = 0;
 		cpr::Header responseHeaders_;
-		std::jthread worker_;
+		std::thread worker_;
 	};
 
 	static std::map<int, std::shared_ptr<StreamSession>> &streamSessions() {
@@ -360,7 +370,7 @@ namespace LuaAPI {
 		}
 
 		// Start the streaming request in a separate thread
-		session->setWorker(std::jthread([session, url, body, headers](std::stop_token) {
+		session->setWorker(std::thread([session, url, body, headers]() {
 			std::function<bool(std::string_view, intptr_t)> writeCallback = [session](std::string_view data, intptr_t /*userdata*/) {
 				return session->appendChunk(std::string(data));
 			};

--- a/source/lua/lua_api_http.cpp
+++ b/source/lua/lua_api_http.cpp
@@ -301,7 +301,7 @@ namespace LuaAPI {
 			}
 			visited.erase(ptr);
 			return result;
-		} else if (obj.is<sol::nil_t>()) {
+		} else if (obj.is<sol::lua_nil_t>()) {
 			return nullptr;
 		}
 		return nullptr;

--- a/source/lua/lua_api_item.cpp
+++ b/source/lua/lua_api_item.cpp
@@ -99,7 +99,7 @@ namespace LuaAPI {
 		items["get"] = [](sol::this_state ts, int id) -> sol::object {
 			sol::state_view lua(ts);
 			if (g_items[id].id == 0) {
-				return sol::nil;
+				return sol::lua_nil;
 			}
 			ItemType &it = g_items[id];
 			sol::table info = lua.create_table();
@@ -114,7 +114,7 @@ namespace LuaAPI {
 		items["getInfo"] = [](sol::this_state ts, int id) -> sol::object {
 			sol::state_view lua(ts);
 			if (g_items[id].id == 0) {
-				return sol::nil;
+				return sol::lua_nil;
 			}
 			ItemType &it = g_items[id];
 			sol::table info = lua.create_table();

--- a/source/lua/lua_api_json.cpp
+++ b/source/lua/lua_api_json.cpp
@@ -11,7 +11,7 @@ namespace LuaAPI {
 	// Convert nlohmann::json to Lua Object
 	sol::object valueToLua(const nlohmann::json &val, sol::state_view &lua) {
 		if (val.is_null()) {
-			return sol::nil;
+			return sol::lua_nil;
 		} else if (val.is_boolean()) {
 			return sol::make_object(lua, val.get<bool>());
 		} else if (val.is_number_integer()) {
@@ -33,13 +33,13 @@ namespace LuaAPI {
 			}
 			return t;
 		}
-		return sol::nil;
+		return sol::lua_nil;
 	}
 
 	// Convert Lua Object to nlohmann::json
 	nlohmann::json luaToValue(const sol::object &obj) {
 		switch (obj.get_type()) {
-			case sol::type::nil:
+			case sol::type::lua_nil:
 				return nullptr;
 			case sol::type::boolean:
 				return obj.as<bool>();
@@ -131,7 +131,7 @@ namespace LuaAPI {
 				sol::state_view lua(s);
 				return valueToLua(val, lua);
 			} catch (const nlohmann::json::parse_error &) {
-				return sol::nil;
+				return sol::lua_nil;
 			}
 		});
 

--- a/source/lua/lua_api_map.cpp
+++ b/source/lua/lua_api_map.cpp
@@ -41,7 +41,7 @@ namespace LuaAPI {
 			sol::state_view lua(ts);
 
 			if (!map) {
-				return std::make_tuple(sol::nil, sol::nil);
+				return std::make_tuple(sol::lua_nil, sol::lua_nil);
 			}
 
 			// Find next valid tile
@@ -58,7 +58,7 @@ namespace LuaAPI {
 				}
 			}
 
-			return std::make_tuple(sol::nil, sol::nil);
+			return std::make_tuple(sol::lua_nil, sol::lua_nil);
 		}
 
 	private:

--- a/source/lua/lua_api_tile.cpp
+++ b/source/lua/lua_api_tile.cpp
@@ -245,7 +245,7 @@ namespace LuaAPI {
 				newGround = item->deepCopy();
 			}
 			// nullptr Item* treated as removal
-		} else if (groundObj.is<sol::nil_t>()) {
+		} else if (groundObj.is<sol::lua_nil_t>()) {
 			// Explicit nil: remove ground (newGround stays nullptr)
 		} else {
 			throw sol::error("Invalid argument: expected item id (int), Item*, or nil");

--- a/source/lua/lua_dialog.cpp
+++ b/source/lua/lua_dialog.cpp
@@ -2722,12 +2722,12 @@ sol::table LuaDialog::getBounds() {
 sol::object LuaDialog::getActiveTab() {
 	wxNotebook* notebook = activeNotebook ? activeNotebook : currentNotebook;
 	if (!notebook) {
-		return sol::make_object(lua, sol::nil);
+		return sol::make_object(lua, sol::lua_nil);
 	}
 
 	int selection = notebook->GetSelection();
 	if (selection == wxNOT_FOUND) {
-		return sol::make_object(lua, sol::nil);
+		return sol::make_object(lua, sol::lua_nil);
 	}
 
 	wxString text = notebook->GetPageText(selection);

--- a/source/lua/lua_engine.cpp
+++ b/source/lua/lua_engine.cpp
@@ -109,28 +109,28 @@ std::string LuaEngine::sanitizeScriptPath(const std::string &filename) {
 
 void LuaEngine::setupSandbox() {
 	if (lua["os"].valid()) {
-		lua["os"]["execute"] = sol::nil;
-		lua["os"]["exit"] = sol::nil;
-		lua["os"]["remove"] = sol::nil;
-		lua["os"]["rename"] = sol::nil;
-		lua["os"]["tmpname"] = sol::nil;
-		lua["os"]["getenv"] = sol::nil;
-		lua["os"]["setlocale"] = sol::nil;
+		lua["os"]["execute"] = sol::lua_nil;
+		lua["os"]["exit"] = sol::lua_nil;
+		lua["os"]["remove"] = sol::lua_nil;
+		lua["os"]["rename"] = sol::lua_nil;
+		lua["os"]["tmpname"] = sol::lua_nil;
+		lua["os"]["getenv"] = sol::lua_nil;
+		lua["os"]["setlocale"] = sol::lua_nil;
 	}
 
-	lua["io"] = sol::nil;
+	lua["io"] = sol::lua_nil;
 
 	if (lua["package"].valid()) {
-		lua["package"]["loadlib"] = sol::nil;
-		lua["package"]["path"] = sol::nil;
-		lua["package"]["cpath"] = sol::nil;
-		lua["package"]["searchpath"] = sol::nil;
+		lua["package"]["loadlib"] = sol::lua_nil;
+		lua["package"]["path"] = sol::lua_nil;
+		lua["package"]["cpath"] = sol::lua_nil;
+		lua["package"]["searchpath"] = sol::lua_nil;
 
 		if (lua["package"]["searchers"].valid()) {
 			sol::table searchers = lua["package"]["searchers"];
-			searchers[2] = sol::nil; // Disable Lua file searcher
-			searchers[3] = sol::nil;
-			searchers[4] = sol::nil;
+			searchers[2] = sol::lua_nil; // Disable Lua file searcher
+			searchers[3] = sol::lua_nil;
+			searchers[4] = sol::lua_nil;
 		}
 	}
 
@@ -194,7 +194,7 @@ void LuaEngine::setupSandbox() {
 			if (result.return_count() > 0) {
 				return result[0];
 			}
-			return sol::nil;
+			return sol::lua_nil;
 		};
 
 		return sol::make_object(this->lua, wrapper);

--- a/source/lua/lua_script_manager.cpp
+++ b/source/lua/lua_script_manager.cpp
@@ -478,7 +478,7 @@ void LuaOverlayManager::updateMapOverlayHover(LuaEngine &engine, int map_x, int 
 
 		try {
 			sol::object result = overlay.onhover(info);
-			if (!result.valid() || result.is<sol::nil_t>()) {
+			if (!result.valid() || result.is<sol::lua_nil_t>()) {
 				continue;
 			}
 

--- a/source/materials.cpp
+++ b/source/materials.cpp
@@ -1540,10 +1540,10 @@ bool Materials::migrateGroundsToSQLite(wxString &error, wxArrayString &warnings)
 		return false;
 	}
 
-	const FileName bordersFile(GUI::GetDataDirectory() + "materials/borders.xml");
+	const FileName bordersFile(g_gui.getFoundDataDirectory() + "materials/borders.xml");
 	// Ground brushes are not confined to grounds.xml in the current dataset, so import
 	// every ground brush reachable from the shared brushs.xml include tree.
-	const FileName brushsRoot(GUI::GetDataDirectory() + "materials/brushs.xml");
+	const FileName brushsRoot(g_gui.getFoundDataDirectory() + "materials/brushs.xml");
 
 	if (!g_brush_database.deleteBrushesByType("ground")) {
 		error = g_brush_database.getLastError();
@@ -1583,7 +1583,7 @@ bool Materials::migrateWallsToSQLite(wxString &error, wxArrayString &warnings) {
 
 	// Wall brushes are not confined to walls.xml in the current dataset, so import
 	// every wall brush reachable from the shared brushs.xml include tree.
-	const FileName brushsRoot(GUI::GetDataDirectory() + "materials/brushs.xml");
+	const FileName brushsRoot(g_gui.getFoundDataDirectory() + "materials/brushs.xml");
 	if (!g_brush_database.deleteBrushesByType("wall")) {
 		error = g_brush_database.getLastError();
 		return false;
@@ -1610,7 +1610,7 @@ bool Materials::migrateDecorativeBrushesToSQLite(wxString &error, wxArrayString 
 		return false;
 	}
 
-	const FileName brushsRoot(GUI::GetDataDirectory() + "materials/brushs.xml");
+	const FileName brushsRoot(g_gui.getFoundDataDirectory() + "materials/brushs.xml");
 	if (!g_brush_database.deleteBrushesByType("doodad")) {
 		error = g_brush_database.getLastError();
 		return false;
@@ -1643,7 +1643,7 @@ bool Materials::migrateTilesetsToSQLite(wxString &error, wxArrayString &warnings
 		return false;
 	}
 
-	const FileName tilesetsRoot(GUI::GetDataDirectory() + "materials/tilesets.xml");
+	const FileName tilesetsRoot(g_gui.getFoundDataDirectory() + "materials/tilesets.xml");
 	std::vector<TilesetStorageRecord> tilesetsToStore;
 	std::set<wxString> visited;
 	if (!ImportTilesetsRecursive(tilesetsRoot, warnings, visited, tilesetsToStore)) {

--- a/source/preferences.cpp
+++ b/source/preferences.cpp
@@ -549,7 +549,7 @@ wxNotebookPage* PreferencesWindow::CreateClientPage() {
 
 	wxBoxSizer* client_path_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	version_dir_picker = newd wxTextCtrl(client_list_window, wxID_ANY, ClientAssets::getPath());
-	version_dir_picker->SetEditable(false);
+	version_dir_picker->SetEditable(true);
 	wxButton* client_browse_button = newd wxButton(client_list_window, wxID_ANY, "Browse...");
 	client_browse_button->Bind(wxEVT_BUTTON, &PreferencesWindow::OnBrowseClientPath, this);
 	client_path_sizer->Add(version_dir_picker, wxSizerFlags(1).Expand());
@@ -615,7 +615,11 @@ void PreferencesWindow::OnClickApply(wxCommandEvent &WXUNUSED(event)) {
 }
 
 void PreferencesWindow::OnBrowseClientPath(wxCommandEvent &WXUNUSED(event)) {
+#ifdef __WXOSX__
+	wxFileDialog dialog(this, "Select Tibia application", version_dir_picker->GetValue(), "", "Applications (*.app)|*.app", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+#else
 	wxDirDialog dialog(this, "Select client directory", version_dir_picker->GetValue(), wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+#endif
 	if (dialog.ShowModal() == wxID_OK) {
 		wxString path = dialog.GetPath();
 		version_dir_picker->SetValue(path);


### PR DESCRIPTION
Use sol::lua_nil for ObjC-safe sol2 APIs, pass C strings to variadic warning(), and drop the obsolete AGL wxGLContext path on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lua scripting: Lua-visible nil is now consistent for missing/empty values across storage, JSON parsing, item/map/tile APIs, dialogs, app properties, and overlay hover.
  * Improved macOS graphics reliability (OpenGL context/linking) and safer background/thread handling for streaming and SQLite bootstrap.
  * Fixed client asset loading paths and improved SQLite migration input paths.
* **UI Improvements**
  * Replaced “Missing …” modal dialogs with inline text boxes.
  * Made “Client directory” editable; added macOS app-picker browse flow.
* **CI**
  * Added compile-scoped macOS builds via reusable workflow and a new build-macos job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->