### PR TITLE
ci(vcpkg): keep baseline updates synchronized and auto-mergeable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
               - ".github/workflows/reusable-build-windows.yml"
               - ".github/workflows/reusable-checks.yml"
               - ".github/workflows/autofix-ci.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
             docker:
               - "Dockerfile"
               - ".dockerignore"
@@ -106,6 +107,7 @@ jobs:
               - "CMakePresets.json"
               - ".github/workflows/ci.yml"
               - ".github/workflows/reusable-build-docker.yml"
+              - ".github/workflows/update_vcpkg_baseline.yml"
 
   checks:
     name: Fast Checks

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -111,7 +111,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          existing_pr="$(gh pr list --state open --base main --head "${GITHUB_REPOSITORY_OWNER}:${branch_name}" --limit 1 --json number --jq '.[0].number // empty')"
+          existing_pr="$(gh api \
+            --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f base=main \
+            -f head="${GITHUB_REPOSITORY_OWNER}:${branch_name}" \
+            -f per_page=1 \
+            --jq '.[0].number // empty')"
 
           if [[ -n "${existing_pr}" ]]; then
             echo "Found existing baseline PR #${existing_pr}, updating it"

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -165,5 +165,9 @@ jobs:
 
             trigger_ci
             new_pr="${pr_url##*/}"
-            queue_auto_merge "${new_pr}"
+            if [[ "${new_pr}" =~ ^[0-9]+$ ]]; then
+              queue_auto_merge "${new_pr}"
+            else
+              echo "::warning::Created a baseline PR, but could not parse its number for auto-merge."
+            fi
           fi

--- a/.github/workflows/update_vcpkg_baseline.yml
+++ b/.github/workflows/update_vcpkg_baseline.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           ref: main
 
       - name: Get latest vcpkg release
@@ -75,32 +76,62 @@ jobs:
             gh workflow run ci.yml --ref "${branch_name}"
           }
 
+          queue_auto_merge() {
+            local pr_number="$1"
+            local merge_subject="chore(vcpkg): update baseline to ${RELEASE_TAG}"
+            local merge_body="vcpkg baseline: ${NEW_BASELINE}"
+
+            if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid baseline pull request number: ${pr_number}"
+              return 1
+            fi
+
+            if gh pr merge "${pr_number}" --auto --squash \
+              --subject "${merge_subject}" \
+              --body "${merge_body}"; then
+              echo "Queued native GitHub auto-merge for PR #${pr_number}"
+            else
+              echo "::warning::Could not queue auto-merge for PR #${pr_number}. Repository auto-merge may be disabled or branch protection may require a review."
+            fi
+          }
+
+          sync_update_branch() {
+            git fetch --prune origin main
+
+            if git ls-remote --exit-code --heads origin "${branch_name}" >/dev/null 2>&1; then
+              git fetch origin "+refs/heads/${branch_name}:refs/remotes/origin/${branch_name}"
+              git checkout -B "${branch_name}" "origin/${branch_name}"
+              git rebase origin/main
+              git push --force-with-lease origin "${branch_name}"
+            else
+              git checkout -B "${branch_name}" origin/main
+            fi
+          }
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          existing_pr="$(gh pr list --state open --json number,headRefName | jq -r '.[] | select(.headRefName == "'"${branch_name}"'") | .number')"
+          existing_pr="$(gh pr list --state open --base main --head "${GITHUB_REPOSITORY_OWNER}:${branch_name}" --limit 1 --json number --jq '.[0].number // empty')"
 
           if [[ -n "${existing_pr}" ]]; then
             echo "Found existing baseline PR #${existing_pr}, updating it"
-            git fetch origin "${branch_name}"
-            git checkout "${branch_name}"
+            sync_update_branch
 
             current_in_branch="$(jq -r '."builtin-baseline"' vcpkg.json)"
             if [[ "${current_in_branch}" == "${NEW_BASELINE}" ]]; then
               echo "PR #${existing_pr} already has baseline ${NEW_BASELINE}"
               trigger_ci
+              queue_auto_merge "${existing_pr}"
               exit 0
             fi
 
             jq --arg baseline "${NEW_BASELINE}" '."builtin-baseline" = $baseline' vcpkg.json > vcpkg.json.tmp
             mv vcpkg.json.tmp vcpkg.json
 
-            if git diff --quiet -- vcpkg.json; then
-              echo "No baseline change to commit on ${branch_name}"
-            else
-              git add vcpkg.json
+            git add vcpkg.json
+            if ! git diff --cached --quiet; then
               git commit -m "chore: update vcpkg baseline to ${RELEASE_TAG}"
-              git push origin "${branch_name}"
+              git push --force-with-lease origin "${branch_name}"
             fi
 
             gh pr edit "${existing_pr}" --title "chore: Update vcpkg baseline to ${RELEASE_TAG}"
@@ -110,35 +141,29 @@ jobs:
 
             gh pr comment "${existing_pr}" --body "${comment_body}"
             trigger_ci
+            queue_auto_merge "${existing_pr}"
           else
             echo "No existing baseline PR found, creating new one"
 
-            if git ls-remote --heads origin "${branch_name}" | grep -q "${branch_name}"; then
-              git fetch origin "${branch_name}"
-              git checkout "${branch_name}"
-            else
-              git checkout -b "${branch_name}"
-            fi
+            sync_update_branch
 
             jq --arg baseline "${NEW_BASELINE}" '."builtin-baseline" = $baseline' vcpkg.json > vcpkg.json.tmp
             mv vcpkg.json.tmp vcpkg.json
 
-            if git diff --quiet -- vcpkg.json; then
-              echo "No baseline change to commit on ${branch_name}"
-            else
-              git add vcpkg.json
-              git commit -m "chore: update vcpkg baseline to ${RELEASE_TAG}"
-              git push --force-with-lease origin "${branch_name}"
-            fi
+            git add vcpkg.json
+            git commit -m "chore: update vcpkg baseline to ${RELEASE_TAG}"
+            git push --force-with-lease origin "${branch_name}"
 
             printf -v pr_body '## vcpkg Baseline Update\n\nThis PR updates the vcpkg baseline to the latest release.\n\n**Release:** `%s`\n**Previous:** `%s`\n**New:** `%s`\n\n**Release notes:** https://github.com/microsoft/vcpkg/releases/tag/%s\n\n---\nThis PR is automatically updated when new vcpkg releases are published.' \
               "${RELEASE_TAG}" "${PREVIOUS}" "${NEW_BASELINE}" "${RELEASE_TAG}"
 
-            gh pr create \
+            pr_url="$(gh pr create \
               --title "chore: Update vcpkg baseline to ${RELEASE_TAG}" \
               --body "${pr_body}" \
               --base main \
-              --head "${branch_name}"
+              --head "${branch_name}")"
 
             trigger_ci
+            new_pr="${pr_url##*/}"
+            queue_auto_merge "${new_pr}"
           fi

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -25,19 +25,20 @@ find_package(
              base
              CONFIG
   REQUIRED)
-# wxWidgets/vcpkg may bake in XQuartz libGL; that breaks Cocoa textures (black tiles).
+# wxWidgets/vcpkg may bake in XQuartz libGL; that breaks Cocoa textures (black
+# tiles).
 if(APPLE)
   find_library(RME_OPENGL_FRAMEWORK OpenGL REQUIRED)
   if(TARGET OpenGL::GL)
     set_property(TARGET OpenGL::GL PROPERTY IMPORTED_LOCATION
-                 "${RME_OPENGL_FRAMEWORK}")
+                                            "${RME_OPENGL_FRAMEWORK}")
   endif()
   if(TARGET wx::wxgl)
     get_target_property(_rme_gl_libs wx::wxgl INTERFACE_LINK_LIBRARIES)
     if(_rme_gl_libs)
       list(FILTER _rme_gl_libs EXCLUDE REGEX "X11.*/libGL")
       set_property(TARGET wx::wxgl PROPERTY INTERFACE_LINK_LIBRARIES
-                   "${_rme_gl_libs}")
+                                            "${_rme_gl_libs}")
     endif()
   endif()
   set(OPENGL_LIBRARIES "${RME_OPENGL_FRAMEWORK}")


### PR DESCRIPTION
This keeps generated vcpkg baseline pull requests synchronized with `main`, validates updater changes with the full build scope, and uses a concise squash-merge message.

## Fixes

- Rebase the generated baseline branch onto `main` and update it with `--force-with-lease`, preventing a stale update branch from accumulating behind the base branch.
- Find only the open baseline PR for the repository-owned update branch.
- Include the baseline updater workflow in the compile and Docker scope filters so its changes do not skip build validation.
- Pass an explicit subject and plain-text body when queueing the squash merge, preventing PR Markdown from being copied literally into the commit history.

## Improvements

- Dispatch CI and queue GitHub auto-merge after creating, updating, or confirming the generated baseline PR. Repository protection requirements continue to apply.

## Tests/Validation

- `git diff --check`
- `actionlint -shellcheck "" -pyflakes "" .github/workflows/ci.yml .github/workflows/update_vcpkg_baseline.yml`
- `bash -n` validation for the updater run block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automation for dependency baseline updates, including branch synchronization and pull request handling.
  * Added automatic merging for successful baseline update pull requests.
  * Expanded CI change detection to include baseline update workflow changes.

* **Style**
  * Reformatted Apple platform build configuration comments and values without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->